### PR TITLE
Prevent crashes when filtering MatchingResults

### DIFF
--- a/mcrit/storage/MatchingResult.py
+++ b/mcrit/storage/MatchingResult.py
@@ -38,7 +38,7 @@ class MatchingResult(object):
         return family_name
 
     def getFilteredSampleMatch(self):
-        if not self.is_sample_filtered:
+        if not self.is_sample_filtered or not len(self.sample_matches):
             return None
         else:
             return self.sample_matches[0]


### PR DESCRIPTION
When MatchingResults are filtered and no matches remain, `getFilteredSampleMatch` will no longer crash. Instead it returns None.