### PR TITLE
Handle failed smda disassembly in McritClient

### DIFF
--- a/mcrit/client/McritClient.py
+++ b/mcrit/client/McritClient.py
@@ -231,6 +231,8 @@ class McritClient:
         if disassemble_locally:
             disassembler = Disassembler()
             smda_report = disassembler.disassembleBuffer(binary, base_address)
+            if smda_report.status == "error":
+                return None
             return self.requestMatchesForSmdaReport(
                 smda_report,
                 minhash_threshold=minhash_threshold,
@@ -253,6 +255,8 @@ class McritClient:
         if disassemble_locally:
             disassembler = Disassembler()
             smda_report = disassembler.disassembleUnmappedBuffer(binary)
+            if smda_report.status == "error":
+                return None
             return self.requestMatchesForSmdaReport(
                 smda_report,
                 minhash_threshold=minhash_threshold,


### PR DESCRIPTION
This prevents the McritClient from crashing if a smda report with status `error` was created locally.