### PR TITLE
fast tokenized search for MongoDbStorage

### DIFF
--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -5,8 +5,6 @@ import traceback
 from operator import itemgetter
 from typing import Any, TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
-from mcrit.storage.SearchCursor import FullSearchCursor
-
 LOGGER = logging.getLogger(__name__)
 try:
     from pymongo import InsertOne, MongoClient, UpdateOne
@@ -20,6 +18,7 @@ from mcrit.libs.utility import generate_unique_groups
 from mcrit.storage.FunctionEntry import FunctionEntry
 from mcrit.storage.MatchingCache import MatchingCache
 from mcrit.storage.SampleEntry import SampleEntry
+from mcrit.storage.SearchCursor import FullSearchCursor
 from mcrit.storage.StorageInterface import StorageInterface
 
 if TYPE_CHECKING: # pragma: no cover


### PR DESCRIPTION
Changes:
- use regex in MongoDB instead of python's `in` operation
- make search case insensitive
- tokenize search term by splitting it at `' '` characters. Every token needs to be found.