### PR TITLE
add profiling for server and worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ coverage_html_report
 examples/cross_compare/reports/
 examples/cross_compare/*.csv
 data/*
+
+profiler

--- a/mcrit/Worker.py
+++ b/mcrit/Worker.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import uuid
 import json
 import logging
@@ -37,13 +38,19 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Worker(QueueRemoteCallee):
-    def __init__(self, queue=None, config=None, storage: Optional["StorageInterface"] = None):
+    def __init__(self, queue=None, config=None, storage: Optional["StorageInterface"] = None, profiling=False):
         if config is None:
             config = McritConfig()
 
         if not queue:
             queue = QueueFactory().getQueue(config, consumer_id="Worker-" + str(uuid.uuid4()))
-        super().__init__(queue)
+
+        if profiling:
+            profiling_path = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__ )), "..", "profiler"))
+            os.makedirs(profiling_path, exist_ok=True)
+        else:
+            profiling_path = None
+        super().__init__(queue, profiling_path)
 
         self.config = config
         self._storage_config = config.STORAGE_CONFIG

--- a/mcrit/__main__.py
+++ b/mcrit/__main__.py
@@ -14,9 +14,20 @@ def runWorker():
     worker.run()
 
 
-def runServer():
+def runServer(profiling=False):
+    wrapped_app = app
+    if profiling:
+        from werkzeug.middleware.profiler import ProfilerMiddleware
+        profile_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "profiler")
+        os.makedirs(profile_dir, exist_ok=True)
+        wrapped_app = ProfilerMiddleware(
+            wrapped_app,
+            restrictions=[30],
+            profile_dir=profile_dir,
+            filename_format="{method}-{path}-{time:.0f}-{elapsed:.0f}ms.prof",
+        )
     # TODO consider allowing an argument to pass an configuration for initial setup of the instance
-    serve(app, listen="*:8000")
+    serve(wrapped_app, listen="*:8000")
 
 
 def runClient(arguments):
@@ -58,6 +69,7 @@ parser = argparse.ArgumentParser()
 subparsers = parser.add_subparsers(dest="command")
 
 parser_server = subparsers.add_parser("server")
+parser_server.add_argument("--profile", help="Profile server. Requires werkzeug package.", action="store_true")
 parser_worker = subparsers.add_parser("worker")
 # create a set of subparsers for all client commands
 parser_client = subparsers.add_parser("client")
@@ -76,7 +88,7 @@ client_queue.add_argument("--filter", type=str, help="Filter queue entries with 
 ARGS = parser.parse_args()
 
 if ARGS.command == "server":
-    runServer()
+    runServer(profiling = ARGS.profile)
 elif ARGS.command == "worker":
     runWorker()
 elif ARGS.command == "client":

--- a/mcrit/__main__.py
+++ b/mcrit/__main__.py
@@ -9,8 +9,8 @@ from mcrit.client.McritClient import McritClient
 from mcrit.Worker import Worker
 
 
-def runWorker():
-    worker = Worker()
+def runWorker(profiling=False):
+    worker = Worker(profiling=profiling)
     worker.run()
 
 
@@ -71,6 +71,7 @@ subparsers = parser.add_subparsers(dest="command")
 parser_server = subparsers.add_parser("server")
 parser_server.add_argument("--profile", help="Profile server. Requires werkzeug package.", action="store_true")
 parser_worker = subparsers.add_parser("worker")
+parser_worker.add_argument("--profile", help="Profile worker. Requires cProfile.", action="store_true")
 # create a set of subparsers for all client commands
 parser_client = subparsers.add_parser("client")
 subparser_client = parser_client.add_subparsers(dest="client_command")
@@ -90,7 +91,7 @@ ARGS = parser.parse_args()
 if ARGS.command == "server":
     runServer(profiling = ARGS.profile)
 elif ARGS.command == "worker":
-    runWorker()
+    runWorker(profiling = ARGS.profile)
 elif ARGS.command == "client":
     runClient(ARGS)
 else:


### PR DESCRIPTION
Server and worker can be profiled by running `python -m mcrit server --profile` `python -m mcrit worker --profile`.

Results are stored as `.prof` files in a profiler folder