### PR TITLE
Bugfix RPC results

### DIFF
--- a/mcrit/client/McritClient.py
+++ b/mcrit/client/McritClient.py
@@ -368,6 +368,12 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/results/{result_id}")
         return handle_response(response)
 
+    def getJobForResult(self, result_id):
+        response = requests.get(f"{self.mcrit_server}/results/{result_id}/job")
+        data = handle_response(response)
+        if data is not None:
+            return Job(data, None)
+
     def awaitResult(self, job_id, sleep_time=2):
         if job_id is None:
             return None

--- a/mcrit/libs/mongoqueue.py
+++ b/mcrit/libs/mongoqueue.py
@@ -373,6 +373,8 @@ class Job(object):
     def progress(self):
         return self._data["progress"]
 
+
+    # This is a GridFS id, not the actual result
     @property
     def result(self):
         return self._data["result"]

--- a/mcrit/queue/LocalQueue.py
+++ b/mcrit/queue/LocalQueue.py
@@ -110,11 +110,10 @@ class Job(object):
             method_str += "(" + ", ".join([str(v) for v in combined_values]) + ")"
         return method_str
 
+
+    # NOTE: This is a GridFS id, not the actual result
     @property
     def result(self):
-        if self._data["result"] is None:
-            pass
-            # self._queue._worker._executeJob(self)
         return self._data["result"]
 
     @result.setter

--- a/mcrit/queue/LocalQueue.py
+++ b/mcrit/queue/LocalQueue.py
@@ -73,6 +73,16 @@ class Job(object):
         return self._data["finished_at"] is not None
 
     @property
+    def duration(self):
+        if self.is_finished:
+            FMT = '%Y-%m-%d-%H:%M:%S'
+            finished_at = self.finished_at[:10] + "-" + self.finished_at[11:19]
+            started_at = self.started_at[:10] + "-" + self.started_at[11:19]
+            duration = datetime.strptime(finished_at, FMT)-datetime.strptime(started_at, FMT)
+            return duration
+        return None
+
+    @property
     def created_at(self):
         if isinstance(self._data["created_at"], dict):
             return str(self._data["created_at"]["$date"])

--- a/mcrit/queue/QueueRemoteCalls.py
+++ b/mcrit/queue/QueueRemoteCalls.py
@@ -207,6 +207,14 @@ class BaseRemoteCallerClass:
             result = self.queue._grid_to_dicts(res_id)
         return result
 
+    def getJobIdForResult(self, result_id):
+        job_id = None
+        meta = self.queue._grid_to_meta(result_id)
+        if meta is not None and "job" in meta:
+            job_id = meta["job"]
+            LOGGER.debug("getJobIdForResult: %s -> %s", result_id, job_id)
+        return job_id
+
     def getResult(self, res_id):
         result_dict = self.queue._grid_to_dicts(res_id)
         return result_dict

--- a/mcrit/queue/QueueRemoteCalls.py
+++ b/mcrit/queue/QueueRemoteCalls.py
@@ -103,12 +103,6 @@ class QueueRemoteCallee(object):
                 result = self._executeJobPayload(j["payload"], job)
                 LOGGER.debug("Remote Job Result: %s", result)
                 # ensure we always have a job_id for finished job payloads
-                if "info" not in result:
-                    result["info"] = {"job": {"job_id": str(job.job_id)}}
-                elif "job" not in result["info"]:
-                    result["info"]["job"] = {"job_id": str(job.job_id)}
-                else:
-                    result["info"]["job"]["job_id"] = str(job.job_id)
                 job.result = self.queue._dicts_to_grid(result, metadata={"result": True, "job": job.job_id})
                 LOGGER.info("Finished Remote Job: %s", job)
         except:
@@ -206,21 +200,16 @@ class BaseRemoteCallerClass:
         return self.queue.get_job(job_id)._data
 
     def getResultForJob(self, job_id):
-        result = {}
+        result = None
         res_id = self.queue.get_job(job_id).result
         if res_id is not None:
             LOGGER.debug("GetResultForJob: %s -> %s", job_id, res_id)
             result = self.queue._grid_to_dicts(res_id)
-            result["info"]["job"]["result_id"] = str(res_id)
         return result
 
     def getResult(self, res_id):
-        result = {}
         result_dict = self.queue._grid_to_dicts(res_id)
-        if result_dict is not None:
-            result = result_dict
-            result["info"]["job"]["result_id"] = str(res_id)
-        return result
+        return result_dict
 
     def awaitResult(self, job_id):
         job = self.queue.get_job(job_id)

--- a/mcrit/server/JobResource.py
+++ b/mcrit/server/JobResource.py
@@ -87,3 +87,17 @@ class JobResource:
         # TODO throw 404 if job_id is unknown
         # resp.status = falcon.HTTP_404
         resp.data = jsonify({"status": "successful", "data": data})
+
+    @timing
+    def on_get_result_job(self, req, resp, result_id=None):
+        LOGGER.info("JobResource.on_get_results")
+        # validate that we only allow hexstrings with 24 chars
+        if not re.match("[a-fA-F0-9]{24}", result_id):
+            resp.status = falcon.HTTP_400
+            resp.data = jsonify({"status": "failed", "data": {"message": "Valid ResultIDs are hexstrings with 24 characters."}})
+            return  
+        job_id = self.index.getJobIdForResult(result_id)
+        data = self.index.getJobData(job_id)
+        # TODO throw 404 if job_id is unknown
+        # resp.status = falcon.HTTP_404
+        resp.data = jsonify({"status": "successful", "data": data})

--- a/mcrit/server/application_routes.py
+++ b/mcrit/server/application_routes.py
@@ -103,5 +103,6 @@ def get_app():
     _app.add_route("/jobs/{job_id}", job_resource)
     _app.add_route("/jobs/{job_id}/result", job_resource, suffix="job_result")
     _app.add_route("/results/{result_id}", job_resource, suffix="results")
+    _app.add_route("/results/{result_id}/job", job_resource, suffix="result_job")
 
     return _app

--- a/mcrit/storage/MatchingResult.py
+++ b/mcrit/storage/MatchingResult.py
@@ -13,11 +13,6 @@ if TYPE_CHECKING:  # pragma: no cover
 # assume sample_entry, smda_function always available
 
 class MatchingResult(object):
-    job_id: str
-    result_id: str
-    job_duration: int
-    job_timestamp: int
-    job_parameters: int
     reference_sample_entry: "SampleEntry"
     other_sample_entry: "SampleEntry"
     match_aggregation: Dict
@@ -148,13 +143,6 @@ class MatchingResult(object):
         # build the dictionary
         matching_entry = {
             "info": {
-                "job": {
-                    "job_id": self.job_id,
-                    "result_id": self.result_id,
-                    "duration": self.job_duration,
-                    "timestamp": self.job_timestamp,
-                    "parameters": self.job_parameters,
-                },
                 "sample": self.reference_sample_entry.toDict()
             },
             "matches": {
@@ -170,12 +158,6 @@ class MatchingResult(object):
     @classmethod
     def fromDict(cls, entry_dict):
         matching_entry = cls(None)
-        matching_entry.job_id = entry_dict["info"]["job"]["job_id"]
-        matching_entry.result_id = entry_dict["info"]["job"]["result_id"]
-        matching_entry.job_duration = entry_dict["info"]["job"]["duration"]
-        matching_entry.job_timestamp = entry_dict["info"]["job"]["timestamp"]
-        matching_entry.job_parameters = entry_dict["info"]["job"]["parameters"]
-
         matching_entry.reference_sample_entry = SampleEntry.fromDict(entry_dict["info"]["sample"])
         if "other_sample_info" in entry_dict:
             matching_entry.other_sample_entry = SampleEntry.fromDict(entry_dict["other_sample_info"])
@@ -195,9 +177,10 @@ class MatchingResult(object):
         return matching_entry
 
     def __str__(self):
+        # TODO: fix
         return "Job: {} / {} - Matched: Samples: {} Functions: {}".format(
-            self.job_timestamp,
-            self.job_parameters,
+            None,
+            None,
             len(self.sample_matches),
             len(self.function_matches),
         )

--- a/mcrit/storage/MatchingResult.py
+++ b/mcrit/storage/MatchingResult.py
@@ -177,10 +177,7 @@ class MatchingResult(object):
         return matching_entry
 
     def __str__(self):
-        # TODO: fix
-        return "Job: {} / {} - Matched: Samples: {} Functions: {}".format(
-            None,
-            None,
+        return "Matched: Samples: {} Functions: {}".format(
             len(self.sample_matches),
             len(self.function_matches),
         )


### PR DESCRIPTION
Changes:
- results of RPCs are no longer modified by appending job metadata
- instead there is a new api to get the job for a result
- the dependency of `MatchingResults` on this metadata is removed
- Job object does now provide duration for convenience