### PR TITLE
Improve matcher speed

### DIFF
--- a/mcrit/matchers/MatcherQuery.py
+++ b/mcrit/matchers/MatcherQuery.py
@@ -43,19 +43,11 @@ class MatcherQuery(MatcherInterface):
         return pichash_matches
 
     def _createMatchingCache(self, candidate_groups):
-        cache_data = {"func_id_to_minhash": {}, "func_id_to_sample_id": {}, "sample_id_to_func_ids": {}}
-        for function_entry in self._function_entries:
-            cache_data["func_id_to_minhash"][function_entry.function_id] = function_entry.minhash
-            cache_data["func_id_to_sample_id"][function_entry.function_id] = function_entry.sample_id
-        cache_data["sample_id_to_func_ids"][self._sample_id] = [f.function_id for f in self._function_entries]
+        function_ids_from_storage = set()
         for own_function_id, other_function_ids in candidate_groups.items():
             for function_id in other_function_ids:
                 if function_id >= 0:
-                    function_entry = self._storage.getFunctionById(function_id, with_xcfg=False)
-                    cache_data["func_id_to_minhash"][function_id] = function_entry.minhash
-                    cache_data["func_id_to_sample_id"][function_id] = function_entry.sample_id
-                    sample_cache = cache_data["sample_id_to_func_ids"].get(function_entry.sample_id, [])
-                    sample_cache.append(function_entry.function_id)
-                    cache_data["sample_id_to_func_ids"][function_entry.sample_id] = sample_cache
-        cache = MatchingCache(cache_data)
+                    function_ids_from_storage.add(function_id)
+        cache = self._storage.createMatchingCache(function_ids_from_storage)
+        cache.addFunctionEntriesToCache(self._function_entries)
         return cache

--- a/mcrit/matchers/MatcherQuery.py
+++ b/mcrit/matchers/MatcherQuery.py
@@ -36,10 +36,16 @@ class MatcherQuery(MatcherInterface):
 
     def _getPicHashMatches(self) -> Dict[int, Set[Tuple[int, int, int]]]:
         pichash_matches = {}
+        checked_pichashes = set()
         for function_entry in self._function_entries:
-            if function_entry.pichash and self._storage.isPicHash(function_entry.pichash):
-                pichash_matches[function_entry.pichash] = self._storage.getMatchesForPicHash(function_entry.pichash)
-                pichash_matches[function_entry.pichash].add((function_entry.family_id, function_entry.sample_id, function_entry.function_id))
+            if function_entry.pichash:
+                if function_entry.pichash not in checked_pichashes:
+                    checked_pichashes.add(function_entry.pichash)
+                    matches = self._storage.getMatchesForPicHash(function_entry.pichash)
+                    if len(matches) > 0:
+                        pichash_matches[function_entry.pichash] = matches
+                if function_entry.pichash in pichash_matches:
+                    pichash_matches[function_entry.pichash].add((function_entry.family_id, function_entry.sample_id, function_entry.function_id))
         return pichash_matches
 
     def _createMatchingCache(self, candidate_groups):

--- a/mcrit/storage/MatchingCache.py
+++ b/mcrit/storage/MatchingCache.py
@@ -17,3 +17,12 @@ class MatchingCache(object):
 
     def getFunctionIdsBySampleId(self, sample_id):
         return self._sample_id_to_func_ids[sample_id]
+
+    def addFunctionEntriesToCache(self, function_entries):
+        for function_entry in function_entries:
+            self._func_id_to_minhash[function_entry.function_id] = function_entry.minhash
+            self._func_id_to_sample_id[function_entry.function_id] = function_entry.sample_id
+            sample_id = function_entry.sample_id
+            if sample_id not in self._sample_id_to_func_ids:
+                self._sample_id_to_func_ids[sample_id] = []
+            self._sample_id_to_func_ids[sample_id].append(function_entry.function_id)

--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -495,12 +495,12 @@ class MemoryStorage(StorageInterface):
     def isPicHash(self, pichash: int) -> bool:
         return pichash in self._pichashes
 
-    def getMatchesForPicHash(self, pichash: int) -> Optional[Set[Tuple[int, int, int]]]:
+    def getMatchesForPicHash(self, pichash: int) -> Set[Tuple[int, int, int]]:
         if pichash not in self._pichashes:
             return set()
         return deepcopy(self._pichashes[pichash])
 
-    def getMatchesForPicBlockHash(self, picblockhash: int) -> Optional[Set[Tuple[int, int, int, int]]]:
+    def getMatchesForPicBlockHash(self, picblockhash: int) -> Set[Tuple[int, int, int, int]]:
         result = set()
         for function_id, function_entry in self._functions.items():
             for pbh in function_entry.picblockhashes:


### PR DESCRIPTION
This PR improves the speed of matching
- `MatcherQuery`'s creation of `MatchingCache`s was **drastically** improved.
-  However, this comes with a slight slow down for `MatcherVS` and `MatcherSample` if `MemoryStorage` is used. This could be mitigated in the future by enabling the old behavior for `MemoryStorage` in these cases via a flag.
- Pichash Matching in `MongoDbStorage` and for `MatcherQuery` was made more efficient.
-  A bug in `MatcherQuery`'s Pichash Matching was removed: Pichashes belonging to more than one function of the queried sample are now handled correctly.