### PR TITLE
Feature: add gunicorn based deployment

### DIFF
--- a/mcrit/config/GunicornConfig.py
+++ b/mcrit/config/GunicornConfig.py
@@ -1,0 +1,8 @@
+from mcrit.config.ConfigInterface import ConfigInterface
+
+class GunicornConfig(ConfigInterface):
+    BIND = "0.0.0.0:8000"
+    # The number of workers gunicorn will spin up
+    WORKERS = 4
+    # The number of threads in each worker
+    THREADS = 8

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ coverage
 dataclasses
 falcon>=2.0.0
 fastcluster
+gunicorn
 picblocks>=1.1.2
 pymongo
 pyparsing
@@ -14,4 +15,5 @@ scipy
 smda>=1.11.0
 tqdm
 waitress
+werkzeug
 rapidfuzz


### PR DESCRIPTION
This PR adds a gunicorn based deployment of the falcon app for linux based servers specifically. This takes into assumption that if someone were to deploy mcrit on a production environment, it would probably be a large one that would require robustness from the server.

## Case study
Our mcrit deployment is based on AWS linux servers. We needed a way to index many files quick (we're talking about 100k in a reasonable amount of time). With waitress' single-worker design, even scaling to 50 worker threads would eventually break. We noticed that over long periods of time, the server RAM usage just started to increase as if there's some memory leak. After further inspection, we got to the conclusion this is not a memory leak, but rather the server getting more requests than it can handle and queuing them up.

Using different optimizations (using a CPU oriented machine, etc...) we got to 4000 file submits / hour with drops to ~3000 after some time, and a large RAM usage that eventually kills the mcrit server (docker out-of-memory protection). Switching to gunicorn's worker model and using 8 worker processes with 10 threads in each we got to a steady 9000 submits/hour and a lower memory usage. It actually stabilized at around 22gb and didn't really creep up.

## Additional info
This PR was made with docker-mcrit in mind. Since I don't want to also update it every time this project changes I made the changes here transparent to it, it just calls "mcrit server" and it should work as before.

Also, profiling mode for the server isn't really working. I added a requirement to the requirements to fix that.