### PR TITLE
Add try/catch block around gunicorn config set

### DIFF
--- a/mcrit/__main__.py
+++ b/mcrit/__main__.py
@@ -26,7 +26,10 @@ def runServer(profiling=False, uses_gunicorn=False):
         
         def load_config(self):
             for key, value in GunicornConfig().toDict().items():
-                self.cfg.set(key.lower(), value)
+                try:
+                    self.cfg.set(key.lower(), value)
+                except AttributeError:
+                    continue
 
         def load(self):
             return self.app


### PR DESCRIPTION
In Gunicorn's `Config` object, setting an unknown config option results in an `AttributeError`, [see](https://github.com/benoitc/gunicorn/blob/ab9c8301cb9ae573ba597154ddeea16f0326fc15/gunicorn/config.py#L74C4-L74C4).

This causes an error with the `USE_GUNICORN` config option in `GunicornConfig.py` which is not used in Gunicorn. This PR basically skips those unknown values