### PR TITLE
Fix: make job deletion safer

### DIFF
--- a/mcrit/libs/mongoqueue.py
+++ b/mcrit/libs/mongoqueue.py
@@ -377,7 +377,7 @@ class MongoQueue(object):
                     if self._getFs().count_documents(
                         {"_id": file_object_id, "metadata.jobs": [], "metadata.tmp_lock": 0}
                     ) > 0:
-                        self._getFs().delete(ObjectId(file_object_id))
+                        self._getFs().delete(file_object_id)
             if with_result:
                 # delete result from GridFS  
                 self._getFs().delete(ObjectId(deletable_job["result"]))

--- a/mcrit/libs/mongoqueue.py
+++ b/mcrit/libs/mongoqueue.py
@@ -366,8 +366,18 @@ class MongoQueue(object):
             print(deletable_job)
             if "file_params" in deletable_job["payload"]:
                 file_params_dict = json.loads(deletable_job["payload"]["file_params"])
-                for k, file_object_id in file_params_dict.items():
-                    self._getFs().delete(ObjectId(file_object_id))
+                for _, file_object_id in file_params_dict.items():
+                    file_object_id = ObjectId(file_object_id)
+                    # update gridFs entry of file to not link
+                    # to this job anymore
+                    self._getFs().update_one(
+                        {"_id": file_object_id}, {"$pull": {"metadata.jobs": str(job_id)}}
+                    )
+                    # check if file is safe to delete
+                    if self._getFs().count_documents(
+                        {"_id": file_object_id, "metadata.jobs": [], "metadata.tmp_lock": 0}
+                    ) > 0:
+                        self._getFs().delete(ObjectId(file_object_id))
             if with_result:
                 # delete result from GridFS  
                 self._getFs().delete(ObjectId(deletable_job["result"]))


### PR DESCRIPTION
Fixes #73 

Helps with the case where the binary was both indexed and queried, or the same binary queried multiple times in which case we wouldn't want to remove it unless all jobs are deleted