### PR TITLE
Refactor storage to use GridFS for binary samples and add orphan cleanup

### DIFF
--- a/mcrit/storage/SampleEntry.py
+++ b/mcrit/storage/SampleEntry.py
@@ -27,11 +27,15 @@ class SampleEntry(object):
     summary: None
     statistics: Dict[str, int]
     timestamp: datetime.datetime
+    gridfs_id: Optional[str] = None
+    binary_data: Optional[bytes] = None # For transient storage when retrieved from GridFS
 
     # TODO -> rename to fromSmdaReport
     def __init__(self, smda_report: "SmdaReport", sample_id=-1, family_id=0):
         self.sample_id = sample_id
         self.family_id = family_id
+        self.gridfs_id = None
+        self.binary_data = None
         if smda_report:
             self.architecture = smda_report.architecture
             self.base_addr = smda_report.base_addr
@@ -79,6 +83,8 @@ class SampleEntry(object):
             "timestamp": self.timestamp.strftime("%Y-%m-%dT%H-%M-%S"),
             "version": self.version,
         }
+        if self.gridfs_id:
+            sample_entry["gridfs_id"] = self.gridfs_id
         return sample_entry
 
     @classmethod
@@ -86,6 +92,7 @@ class SampleEntry(object):
         sample_entry = cls(None) #type: ignore
         sample_entry.family_id = entry_dict["family_id"]
         sample_entry.sample_id = entry_dict["sample_id"]
+        sample_entry.gridfs_id = entry_dict.get("gridfs_id")
         sample_entry.architecture = entry_dict["architecture"]
         sample_entry.base_addr = decode_two_complement(entry_dict["base_addr"])
         sample_entry.binary_size = entry_dict["binary_size"]


### PR DESCRIPTION
This commit addresses issue #80 by refactoring the MongoDB storage backend to utilize GridFS for storing binary sample data. Storing binary data in GridFS is more efficient for large files and is the recommended approach with MongoDB.

Key changes include:
- Modified `MongoDbStorage.py` and `SampleEntry.py` to integrate GridFS.
- When samples are added via `addSmdaReport`, their binary content (assumed to be in `smda_report.buffer`) is now stored in GridFS. A reference (GridFS file ID) is stored in the `SampleEntry`.
- Sample retrieval methods (`getSampleById`, `getSampleBySha256`) now fetch binary data from GridFS if a `gridfs_id` is present.
- Deleting a sample via `deleteSample` now also removes the corresponding binary file from GridFS.
- Implemented a new utility method `cleanup_orphan_gridfs_objects` in `MongoDbStorage.py`. This method identifies and deletes GridFS files that are no longer referenced by any `SampleEntry` in the database, helping to reclaim storage space.
- Added comprehensive integration tests in `tests/testStorage.py` to cover:
    - Storing and retrieving sample binary data via GridFS.
    - Deletion of samples and their corresponding GridFS files.
    - Correct identification and removal of orphan GridFS files by the cleanup utility under different scenarios.

This refactoring improves the scalability and efficiency of handling binary samples within mcrit.