### PR TITLE
Allow AUTH_TOKEN via MCRIT_AUTH_TOKEN env var, warn when the API is unprotected

### DIFF
--- a/mcrit/config/McritConfig.py
+++ b/mcrit/config/McritConfig.py
@@ -14,8 +14,9 @@ class McritConfig:
     CONFIG_FILE_PATH = str(os.path.abspath(__file__))
     PROJECT_ROOT = str(os.path.abspath(os.sep.join([CONFIG_FILE_PATH, "..", ".."])))
 
-    # Authentication token, which can be optionally used to lock down communication with the API
-    AUTH_TOKEN = ""
+    # Authentication token, which can be optionally used to lock down communication with the API.
+    # It can be supplied via the environment, so that it does not have to be stored in a config file.
+    AUTH_TOKEN = os.getenv("MCRIT_AUTH_TOKEN", "")
 
     ### global logging-config setup
     # Only do basicConfig if no handlers have been configured
@@ -32,3 +33,5 @@ class McritConfig:
     def __init__(self, log_level=logging.INFO):
         if len(logging._handlerList) == 0:
             logging.basicConfig(level=log_level, format=self.LOG_FORMAT)
+        if self.AUTH_TOKEN in (None, ""):
+            logging.getLogger(__name__).warning("No AUTH_TOKEN configured (MCRIT_AUTH_TOKEN is unset) - the API is not protected against unauthenticated access.")

--- a/mcrit/server/application_routes.py
+++ b/mcrit/server/application_routes.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import secrets
 
 import falcon
 
@@ -48,7 +49,7 @@ class AuthMiddleware:
     def _token_is_valid(self, token):
         if McritConfig.AUTH_TOKEN in [None, ""]:
             return True
-        return token == McritConfig.AUTH_TOKEN
+        return secrets.compare_digest(token, McritConfig.AUTH_TOKEN)
 
 
 def create_index():

--- a/tests/testMcritConfig.py
+++ b/tests/testMcritConfig.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+import sys
+import unittest
+
+READ_TOKEN = "from mcrit.config.McritConfig import McritConfig; print(McritConfig.AUTH_TOKEN)"
+
+
+class TestMcritConfigAuthToken(unittest.TestCase):
+    def _run(self, code, token=None):
+        # use a subprocess, as AUTH_TOKEN is a class attribute evaluated at import time
+        env = os.environ.copy()
+        env.pop("MCRIT_AUTH_TOKEN", None)
+        if token is not None:
+            env["MCRIT_AUTH_TOKEN"] = token
+        return subprocess.run([sys.executable, "-c", code], env=env, capture_output=True, check=True)
+
+    def test_auth_token_from_env(self):
+        result = self._run(READ_TOKEN, token="secret_token_from_env")
+        self.assertEqual(result.stdout.decode().strip(), "secret_token_from_env")
+
+    def test_auth_token_defaults_to_empty(self):
+        result = self._run(READ_TOKEN)
+        self.assertEqual(result.stdout.decode().strip(), "")
+
+    def test_warning_when_no_token_configured(self):
+        result = self._run("from mcrit.config.McritConfig import McritConfig; McritConfig()")
+        self.assertIn(b"No AUTH_TOKEN configured", result.stderr)
+
+    def test_no_warning_when_token_configured(self):
+        result = self._run("from mcrit.config.McritConfig import McritConfig; McritConfig()", token="some_token")
+        self.assertNotIn(b"No AUTH_TOKEN configured", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

`McritConfig.AUTH_TOKEN` currently has to be edited into the config in order to lock down the API. That makes it awkward to run mcrit in containerized/CI setups, where secrets are usually injected via the environment, and there is no signal at all when a server is running unprotected.

### Changes

* `AUTH_TOKEN` can now be supplied via the `MCRIT_AUTH_TOKEN` environment variable. The default stays `""`, i.e. authentication remains opt-in and existing deployments are unaffected.
* `McritConfig.__init__()` logs a warning when no token is configured, so an unprotected API is at least visible in the log.
* `AuthMiddleware._token_is_valid()` now uses `secrets.compare_digest()` instead of `==`, to avoid leaking token contents through comparison timing.
* Added `tests/testMcritConfig.py`, covering both the environment override and the default/warning behaviour (in a subprocess, since `AUTH_TOKEN` is a class attribute evaluated at import time).

### Note

An earlier version of this change generated a random token when `MCRIT_AUTH_TOKEN` was unset. I dropped that: since the value is evaluated per process at import time, server, worker and client would each end up with a different token, and it would silently break every existing deployment that relies on the documented "empty token = no authentication" default. Making the token configurable and loudly warning about the unprotected case seemed like the better trade-off — happy to revisit if you'd prefer a different default.
