### PR TITLE
Handle query functions in addMinHash/addMinHashes and resolve their TODOs

### DIFF
--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -473,11 +473,17 @@ class MemoryStorage(StorageInterface):
         return function_entry
 
     def addMinHash(self, minhash: "MinHash") -> bool:
-        if minhash.function_id is None or minhash.function_id not in self._functions:
+        if minhash.function_id is None:
             return False
-        self._functions[minhash.function_id].minhash = minhash.getMinHash()
-        self._functions[minhash.function_id].minhash_shingle_composition = minhash.getComposition()
-        self._addMinHashToBands(minhash)
+        is_query_function = minhash.function_id < 0
+        functions = self._query_functions if is_query_function else self._functions
+        if minhash.function_id not in functions:
+            return False
+        functions[minhash.function_id].minhash = minhash.getMinHash()
+        functions[minhash.function_id].minhash_shingle_composition = minhash.getComposition()
+        # query functions are not indexed into bands, they are only ever used as query input
+        if not is_query_function:
+            self._addMinHashToBands(minhash)
         return True
 
     def addMinHashes(self, minhashes: List["MinHash"]) -> None:

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -833,29 +833,39 @@ class MongoDbStorage(StorageInterface):
     def addMinHash(self, minhash: "MinHash") -> bool:
         if minhash.function_id is None:
             return False
-        function_entry = self.getFunctionById(minhash.function_id)
-        if function_entry is None:
-            return False
-        function_entry.minhash = minhash.getMinHash()
-        function_entry.minhash_shingle_composition = minhash.getComposition()
-        function_dict = function_entry.toDict()
-        self._encodeFunction(function_dict)
+        is_query_function = minhash.function_id < 0
+        collection = self._getDb().query_functions if is_query_function else self._getDb().functions
         set_command = {"$set": {"minhash": minhash.getMinHash().hex(), "minhash_shingle_composition": minhash.getComposition()}}
-        self._getDb().functions.find_one_and_update({"function_id": minhash.function_id}, set_command)
-        self._addMinHashToBands(minhash)
+        if collection.find_one_and_update({"function_id": minhash.function_id}, set_command) is None:
+            return False
+        # query functions are not indexed into bands, they are only ever used as query input
+        if not is_query_function:
+            self._addMinHashToBands(minhash)
         return True
 
     def addMinHashes(self, minhashes: List["MinHash"]) -> None:
-        # TODO can this be removed
         if not minhashes:
             return
-        function_updates = []
-        for minhash in minhashes:
-            set_command = {"$set": {"minhash": minhash.getMinHash().hex(), "minhash_shingle_composition": minhash.getComposition()}}
-            # TODO what happens if one of the function_ids is not found or minhash.function_id is not set?
-            function_updates.append(UpdateOne({"function_id": minhash.function_id}, set_command))
-        self._getDb().functions.bulk_write(function_updates, ordered=False)
-        self._addMinHashesToBands(minhashes)
+        for is_query_function in (False, True):
+            relevant_minhashes = [minhash for minhash in minhashes if minhash.function_id is not None and (minhash.function_id < 0) == is_query_function]
+            if not relevant_minhashes:
+                continue
+            collection = self._getDb().query_functions if is_query_function else self._getDb().functions
+            function_ids = [minhash.function_id for minhash in relevant_minhashes]
+            existing_ids = set(collection.distinct("function_id", {"function_id": {"$in": function_ids}}))
+            function_updates = []
+            stored_minhashes = []
+            for minhash in relevant_minhashes:
+                if minhash.function_id not in existing_ids:
+                    LOGGER.warning("addMinHashes() - no function with id %d, skipping its minhash.", minhash.function_id)
+                    continue
+                set_command = {"$set": {"minhash": minhash.getMinHash().hex(), "minhash_shingle_composition": minhash.getComposition()}}
+                function_updates.append(UpdateOne({"function_id": minhash.function_id}, set_command))
+                stored_minhashes.append(minhash)
+            if function_updates:
+                collection.bulk_write(function_updates, ordered=False)
+            if stored_minhashes and not is_query_function:
+                self._addMinHashesToBands(stored_minhashes)
 
     # original implementation, already working
     def _addMinHashToBands(self, minhash: "MinHash") -> None:


### PR DESCRIPTION
### Motivation

This addresses the two TODOs in `MongoDbStorage.addMinHashes()`:

```python
# TODO what happens if one of the function_ids is not found or minhash.function_id is not set?
```

and fixes the handling of query functions (negative `function_id`s, stored in the `query_functions` collection) in both storage backends.

### Problems

* `MongoDbStorage.addMinHash()` resolves the entry via `getFunctionById()`, which *does* route negative ids to `query_functions` — but the subsequent `find_one_and_update()` always went to `functions`, so the update silently did nothing for query functions, and the minhash was then indexed into the LSH bands, which is wrong for query input.
* `MongoDbStorage.addMinHashes()` had the same collection problem, and additionally issued band updates for `function_id`s that do not exist in the database at all (or that are `None`), leaving dangling entries in the bands.
* `MemoryStorage.addMinHash()` returned `False` for any query function, so query minhashes were never stored there.
* `addMinHash()` loaded the full `FunctionEntry`, mutated it and re-encoded it, without using the result — the actual write is the `$set` command.

### Changes

* Route minhash updates to `query_functions` / `functions` based on the sign of `function_id`, in both backends.
* Do not index query-function minhashes into the bands.
* In `addMinHashes()`, look up which `function_id`s actually exist and skip (with a warning) the ones that do not, so bands only ever reference stored functions.
* Return `False` from `MongoDbStorage.addMinHash()` when no document matched, instead of reporting success.
* Drop the now-unused entry load/encode round-trip in `addMinHash()`.

`tests/testStorage.py` passes (non-mongo subset locally, full suite in CI).
