### PR TITLE
Fix pichash encoding in MongoDB search conditions

### DIFF
--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -104,12 +104,15 @@ class MongoSearchTranspiler(BaseVisitor):
             except Exception:
                 pass
         mongo_operator = operator_to_mongo[node.operator]
+        if node.field == "pichash" and mongo_operator in ("$lt", "$lte", "$gt", "$gte"):
+            # pichashes are stored as hex strings, on which range comparisons are not meaningful
+            raise ValueError("Range operators are not supported for the field 'pichash'.")
         if mongo_operator is None:
             condition = {node.field: value}
         else:
             condition = {node.field: {mongo_operator: value}}
-        # TODO: fix
-        MongoDbStorage._encodePichash(None, condition)
+        if node.field == "pichash":
+            MongoDbStorage._encodePichash(condition)
         return condition
 
 
@@ -321,21 +324,29 @@ class MongoDbStorage(StorageInterface):
     # Conversion
     ###############################################################################
 
-    def _encodeXcfg(self, function_dict: Dict, delete_old: bool = True) -> None:
+    @staticmethod
+    def _encodeXcfg(function_dict: Dict, delete_old: bool = True) -> None:
         if "xcfg" in function_dict:
             function_dict["_xcfg"] = json.dumps(function_dict["xcfg"])
             if delete_old:
                 del function_dict["xcfg"]
 
-    def _decodeXcfg(self, function_dict: Dict, delete_old: bool = True) -> None:
+    @staticmethod
+    def _decodeXcfg(function_dict: Dict, delete_old: bool = True) -> None:
         if "_xcfg" in function_dict:
             function_dict["xcfg"] = json.loads(function_dict["_xcfg"])
             if delete_old:
                 del function_dict["_xcfg"]
 
-    def _encodePichash(self, function_dict: Dict, delete_old: bool = True) -> None:
+    @staticmethod
+    def _encodePichash(function_dict: Dict, delete_old: bool = True) -> None:
         if "pichash" in function_dict:
-            function_dict["_pichash"] = hex(function_dict["pichash"])
+            value = function_dict["pichash"]
+            # search conditions wrap the value in an operator dict, e.g. {"$ne": 0x1234}
+            if isinstance(value, dict):
+                function_dict["_pichash"] = {k: hex(v) if isinstance(v, int) else v for k, v in value.items()}
+            else:
+                function_dict["_pichash"] = hex(value)
             if delete_old:
                 del function_dict["pichash"]
         if "picblockhashes" in function_dict:
@@ -350,9 +361,14 @@ class MongoDbStorage(StorageInterface):
             if delete_old:
                 del function_dict["picblockhashes"]
 
-    def _decodePichash(self, function_dict: Dict, delete_old: bool = True) -> None:
+    @staticmethod
+    def _decodePichash(function_dict: Dict, delete_old: bool = True) -> None:
         if "_pichash" in function_dict:
-            function_dict["pichash"] = int(function_dict["_pichash"], 16)
+            value = function_dict["_pichash"]
+            if isinstance(value, dict):
+                function_dict["pichash"] = {k: int(v, 16) if isinstance(v, str) else v for k, v in value.items()}
+            else:
+                function_dict["pichash"] = int(value, 16)
             if delete_old:
                 del function_dict["_pichash"]
         if "_picblockhashes" in function_dict:
@@ -367,13 +383,15 @@ class MongoDbStorage(StorageInterface):
             if delete_old:
                 del function_dict["_picblockhashes"]
 
-    def _encodeFunction(self, function_dict: Dict, delete_old: bool = True) -> None:
-        self._encodePichash(function_dict, delete_old=delete_old)
-        self._encodeXcfg(function_dict, delete_old=delete_old)
+    @staticmethod
+    def _encodeFunction(function_dict: Dict, delete_old: bool = True) -> None:
+        MongoDbStorage._encodePichash(function_dict, delete_old=delete_old)
+        MongoDbStorage._encodeXcfg(function_dict, delete_old=delete_old)
 
-    def _decodeFunction(self, function_dict: Dict, delete_old: bool = True) -> None:
-        self._decodePichash(function_dict, delete_old=delete_old)
-        self._decodeXcfg(function_dict, delete_old=delete_old)
+    @staticmethod
+    def _decodeFunction(function_dict: Dict, delete_old: bool = True) -> None:
+        MongoDbStorage._decodePichash(function_dict, delete_old=delete_old)
+        MongoDbStorage._decodeXcfg(function_dict, delete_old=delete_old)
 
     ###############################################################################
     # Interface

--- a/tests/testMongoSearchTranspiler.py
+++ b/tests/testMongoSearchTranspiler.py
@@ -1,0 +1,29 @@
+import unittest
+
+from mcrit.index.SearchQueryTree import SearchConditionNode
+from mcrit.storage.MongoDbStorage import MongoSearchTranspiler
+
+
+class TestMongoSearchTranspiler(unittest.TestCase):
+    def _visit(self, field, operator, value):
+        return MongoSearchTranspiler().visit(SearchConditionNode(field, operator, value))
+
+    def test_pichash_equality_is_encoded(self):
+        # pichashes are stored hex-encoded in the "_pichash" field
+        self.assertEqual(self._visit("pichash", "=", "0x1234"), {"_pichash": "0x1234"})
+
+    def test_pichash_inequality_is_encoded(self):
+        self.assertEqual(self._visit("pichash", "!=", "0x1234"), {"_pichash": {"$ne": "0x1234"}})
+
+    def test_pichash_range_operators_are_rejected(self):
+        for operator in ("<", "<=", ">", ">="):
+            with self.assertRaises(ValueError):
+                self._visit("pichash", operator, "0x1234")
+
+    def test_other_fields_are_untouched(self):
+        self.assertEqual(self._visit("num_functions", ">", "5"), {"num_functions": {"$gt": 5}})
+        self.assertEqual(self._visit("family", "=", "somefamily"), {"family": "somefamily"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

Resolves the `# TODO: fix` in `MongoSearchTranspiler.visitSearchConditionNode()`:

```python
# TODO: fix
MongoDbStorage._encodePichash(None, condition)
```

Two problems with that call:

1. It was invoked on *every* search condition with `None` as `self`, which only worked because `_encodePichash()` happens to not use the instance.
2. For any operator other than `=`, the condition value is an operator dict (e.g. `{"$ne": 0x1234}`), and `hex()` on a dict raises `TypeError`. So a search such as `pichash!=0x1234` crashed instead of returning results.

### Changes

* Only call `_encodePichash()` when the condition is actually about `pichash`.
* Handle operator dicts in `_encodePichash()` / `_decodePichash()`, encoding the inner operand.
* Reject range operators (`<`, `<=`, `>`, `>=`) on `pichash` with a `ValueError`. `_pichash` is stored as a variable-length `hex()` string, so a Mongo range comparison on it is lexicographic and would return wrong results — better to say so than to answer incorrectly.
* Make the `_encode*` / `_decode*` conversion helpers `@staticmethod`, which is what the transpiler needed in the first place.
* Add `tests/testMongoSearchTranspiler.py` for the encoded/rejected cases.

### Note

I deliberately kept the stored encoding as `hex()`. Making pichash range queries actually work would mean switching `_pichash` to a fixed-width, zero-padded representation (`format(v, "016x")`), which is a breaking change for existing databases and would also make `_pichash` inconsistent with the `hash` entries inside `_picblockhashes`. That seems like a migration you'd want to decide on separately.
