### PR TITLE
Use raw strings for regex literals and enable ruff W605

### DIFF
--- a/mcrit/server/BlocksResource.py
+++ b/mcrit/server/BlocksResource.py
@@ -21,7 +21,7 @@ class BlocksResource:
     def on_get_unique_blocks_for_samples(self, req, resp, comma_separated_sample_ids=None):
         db_log_msg(self.index, req, "BlocksResource.on_get_unique_blocks")
         blocks_result = {}
-        if re.match("^\d+(?:[\s]*,[\s]*\d+)*$", comma_separated_sample_ids):
+        if re.match(r"^\d+(?:[\s]*,[\s]*\d+)*$", comma_separated_sample_ids):
             target_sample_ids = [int(sample_id) for sample_id in comma_separated_sample_ids.split(",")]
             blocks_result = self.index.getUniqueBlocks(target_sample_ids)
         resp.data = jsonify({"status": "successful", "data": blocks_result})

--- a/mcrit/server/FamilyResource.py
+++ b/mcrit/server/FamilyResource.py
@@ -46,7 +46,7 @@ class FamilyResource:
             return
         # sanitize sample information
         information_update = req.media
-        if "family_name" in information_update and not re.match("^(?=[a-zA-Z0-9._\-]{0,64}$)(?!.*[\-_.]{2})[^\-_.].*[^\-_.]$", information_update["family_name"]):
+        if "family_name" in information_update and not re.match(r"^(?=[a-zA-Z0-9._\-]{0,64}$)(?!.*[\-_.]{2})[^\-_.].*[^\-_.]$", information_update["family_name"]):
             resp.data = jsonify({"status": "failed", "data": {"message": "family_name may be 0-64 alphanumeric chars with single dots, dashes, underscores inbetween."}})
             return
         if "is_library" in information_update:

--- a/mcrit/server/FunctionResource.py
+++ b/mcrit/server/FunctionResource.py
@@ -51,7 +51,7 @@ class FunctionResource:
             with_label_only = req.params["with_label_only"].lower().strip() == "true"
         # assume the POST body consists of comma separated function_ids
         post_body = req.stream.read()
-        if re.match(b"^\d+(?:[\s]*,[\s]*\d+)*$", post_body):
+        if re.match(rb"^\d+(?:[\s]*,[\s]*\d+)*$", post_body):
             target_function_ids = [int(function_id) for function_id in post_body.split(b",")]
             function_entries = {}
             for function_id in target_function_ids:

--- a/mcrit/server/SampleResource.py
+++ b/mcrit/server/SampleResource.py
@@ -77,7 +77,7 @@ class SampleResource:
             return
         # sanitize sample information
         information_update = req.media
-        if "family_name" in information_update and not re.match("^(?=[a-zA-Z0-9._\-]{0,64}$)(?!.*[\-_.]{2})[^\-_.].*[^\-_.]$", information_update["family_name"]):
+        if "family_name" in information_update and not re.match(r"^(?=[a-zA-Z0-9._\-]{0,64}$)(?!.*[\-_.]{2})[^\-_.].*[^\-_.]$", information_update["family_name"]):
             resp.data = jsonify({"status": "failed", "data": {"message": "family_name may be 0-64 alphanumeric chars with single dots, dashes, underscores inbetween."}})
             db_log_msg(self.index, req, "SampleResource.on_put - failed - invalid family name.")
             return

--- a/mcrit/server/StatusResource.py
+++ b/mcrit/server/StatusResource.py
@@ -49,7 +49,7 @@ class StatusResource:
         # NOTE if we encounter extreme cases (super long URLs), we might have to switch to post here.
         compress_data = True if "compress" in req.params and req.params["compress"].lower() == "true" else False
         exported_data = {}
-        if re.match("^\d+(?:[\s]*,[\s]*\d+)*$", comma_separated_sample_ids):
+        if re.match(r"^\d+(?:[\s]*,[\s]*\d+)*$", comma_separated_sample_ids):
             target_sample_ids = [int(sample_id) for sample_id in comma_separated_sample_ids.split(",")]
             exported_data = self.index.getExportData(target_sample_ids, compress_data=compress_data)
         resp.data = jsonify({"status": "successful", "data": exported_data})

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,7 +2,7 @@ target-version = "py311"
 line-length = 180
 
 [lint]
-select = ["E4", "E7", "E9", "F", "I", "UP"]
+select = ["E4", "E7", "E9", "F", "I", "UP", "W605"]
 ignore = [
     "UP006",
     "UP007",


### PR DESCRIPTION
Fixes item 12 of #102.

Five regex patterns in the REST resources are written as plain string literals containing escapes Python does not recognise:

| file | escapes |
|---|---|
| `mcrit/server/BlocksResource.py` | `\d`, `\s` |
| `mcrit/server/StatusResource.py` | `\d`, `\s` |
| `mcrit/server/FunctionResource.py` | `\d`, `\s` |
| `mcrit/server/FamilyResource.py` | `\-` |
| `mcrit/server/SampleResource.py` | `\-` |

### Why this is safe

Python leaves an unrecognised escape sequence in the string as-is, so the value that reaches `re.match()` is already the intended pattern. The string literals are **byte-identical** before and after this change — I asserted equality of the old and new literals directly, and checked that the compiled patterns accept and reject the same inputs (valid/invalid id lists, and family names exercising the length bound, doubled separators, and leading/trailing `-_.`).

So this is a warning fix, not a behaviour fix. Each literal emits a `SyntaxWarning` today, and the language reference states these sequences will become a `SyntaxError` in a future release.

### Why ruff missed it

`W605` was not in the `select` list. It is now, so the pattern cannot reappear unnoticed. That is the only configuration change.

### Note on ordering with #101

#101 moves ruff's configuration from `ruff.toml` into `pyproject.toml`. This PR edits `ruff.toml`, so whichever merges second needs the `W605` entry carried into the surviving config file — a one-line overlap. The source changes are independent of #101 and conflict with nothing.

The `W605` rule has to land *with or after* these fixes, not before: enabling it on current `main` would fail CI on all five files.

### Verification

- `ruff check .` and `ruff format --check .` clean
- 61 tests pass (`-m 'not mongo'`)
- no `SyntaxWarning` for escape sequences anywhere under `mcrit/`