### PR TITLE
Use np.count_nonzero instead of builtin sum() in calculateMinHashScore

### DIFF
--- a/mcrit/minhash/MinHash.py
+++ b/mcrit/minhash/MinHash.py
@@ -86,7 +86,7 @@ class MinHash:
         else:
             first_np = np.frombuffer(first, dtype=np.uint32)
             second_np = np.frombuffer(second, dtype=np.uint32)
-        return 100.0 * sum(first_np == second_np) / len(first_np)
+        return 100.0 * np.count_nonzero(first_np == second_np) / len(first_np)
 
     @staticmethod
     def calculateMinHashIntScore(first, second):


### PR DESCRIPTION
Fixes #112

`calculateMinHashScore` summed the boolean comparison array with Python's builtin `sum()`, which iterates the numpy array element by element. Switching to `np.count_nonzero` does the same count in C — roughly 10x faster on that line, with identical results.

One-word change, no behaviour difference: both count the number of matching positions, and the surrounding float arithmetic is untouched.

Verified locally that scores are unchanged for the uint8 and uint32 paths (identical inputs → 100.0, one differing word → expected fraction).