### PR TITLE
Deterministic tie-break in minhash match reduction (#104)

### DIFF
--- a/mcrit/matchers/MatcherInterface.py
+++ b/mcrit/matchers/MatcherInterface.py
@@ -199,7 +199,11 @@ class MatcherInterface:
                             key = (sample_id_a, function_id_a, sample_id_b)
                             new_value = (function_id_b, score)
                             original_value = organized_matching_results[key]
-                            organized_matching_results[key] = max([original_value, new_value], key=lambda x: x[1])
+                            # tie-break on the smaller function_id_b so the reported match does
+                            # not depend on worker arrival order (imap_unordered); this matches
+                            # what the single-process path below produces by iterating candidate
+                            # ids in ascending order
+                            organized_matching_results[key] = max([original_value, new_value], key=lambda x: (x[1], -x[0]))
                     if single_batch:
                         self._progress_reporter.step()
         else:
@@ -213,7 +217,7 @@ class MatcherInterface:
                         key = (sample_id_a, function_id_a, sample_id_b)
                         new_value = (function_id_b, score)
                         original_value = organized_matching_results[key]
-                        organized_matching_results[key] = max([original_value, new_value], key=lambda x: x[1])
+                        organized_matching_results[key] = max([original_value, new_value], key=lambda x: (x[1], -x[0]))
                 if single_batch:
                     self._progress_reporter.step()
         full_score_counts = sorted([(item[0] * 64 / 100, item[1]) for item in dict(counted_scores).items()])


### PR DESCRIPTION
Fixes #104.

Both reduction sites in `_performMinHashMatching` now break score ties on the smaller `function_id_b`:

```python
max([original_value, new_value], key=lambda x: (x[1], -x[0]))
```

`max` keeps the first maximal element, so the pooled path previously reported whichever worker's result happened to arrive first through `imap_unordered` — re-matching the same sample could name a different representative function for the same `(sample_a, function_a, sample_b)` triple. The single-process path iterates candidate ids in ascending order (`_unrollGroupsAsPackedTuples` sorts both levels), so "first maximal" already meant "smallest `function_id_b`" there and this change is a behavioural no-op for it.

Verification (11.7 M-function corpus, digests over the full `matches` structure):

- win.merlin (7,018 fns, k=2) — the four-digest repro from #104: two pooled runs now both produce `45fc8043...`, byte-identical to the single-process digest (26,489,297 B payloads).
- win.citadel (2,940 fns, k=1): single-process and two pooled runs all identical (8,077,383 B).
- One end-to-end submit through the real server/queue/worker (pooled, default config) reproduces the single-process digest exactly.
- No assembly-time sort is needed: `_summarizeMatches` pre-populates from `self._function_entries` (deterministic order) and per-function match lists are sorted at assembly (`dict["matches"] = sorted(...)`), so tie selection was the only arrival-order leak.
- 600 tie-stress differential cases (2,109 tie-contested keys) against an independent "smallest function_id_b among maximum scorers" reference: 0 mismatches.

Beyond reproducibility for users, this makes pooled runs verifiable: any future change to the matching path can be A/B-checked against the default `MINHASH_POOL_MATCHING = True` configuration by digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwSfzAD1ZwEoWY3eWvbYvX
