### PR TITLE
Optional concurrent fetch of candidate signatures

### DIFF
--- a/mcrit/config/StorageConfig.py
+++ b/mcrit/config/StorageConfig.py
@@ -44,6 +44,14 @@ class StorageConfig(ConfigInterface):
     #  * "numpy": per-query-function int32 hit arrays + np.unique(return_counts)
     # Same results either way; "numpy" avoids the ~100 B/pair Python dict and the O(pairs) loop.
     STORAGE_CANDIDATE_ACCUMULATION: str = "dict"
+    # Fetch candidate signatures for the MatchingCache with this many concurrent queries.
+    # The call is latency-bound (186 B returned per ~4 kB document read), so concurrency
+    # overlaps mongod's disk reads: measured 6.81x warm / 15.3x cold at 8 threads on 500k ids,
+    # byte-identical results. 1 keeps the sequential behaviour.
+    STORAGE_CACHE_FETCH_THREADS: int = 1
+    # function_ids per $in query. Must stay well under Mongo's 16 MB command limit; smaller
+    # slices also give the thread pool something to overlap.
+    STORAGE_CACHE_FETCH_SLICE_SIZE: int = 500000
     # limit maximum export size to protect the system against running OOM, default: 1 GB
     STORAGE_MAX_EXPORT_SIZE = 1024 * 1024 * 1024
 

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -4,6 +4,7 @@ import logging
 import re
 import traceback
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from itertools import zip_longest
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Tuple
@@ -1002,21 +1003,44 @@ class MongoDbStorage(StorageInterface):
         # process this in batches as the number of function_ids can be exceedingly large, pushing beyond Mongo's 16M limit
         positive_function_ids = [function_id for function_id in set(function_ids) if function_id >= 0]
         negative_function_ids = [function_id for function_id in set(function_ids) if function_id < 0]
+        # This call is latency-bound, not bandwidth-bound: the projection returns 186 B per
+        # document but WiredTiger reads the whole ~4 kB record to produce it, so a single
+        # sequential cursor leaves mongod's I/O parallelism unused. Measured on 500k ids:
+        # 1 thread 12.96 s, 8 threads 1.90 s (6.81x) for a byte-identical result. Threads, not
+        # processes - pymongo releases the GIL for socket I/O and BSON decode.
+        fetch_threads = max(1, getattr(self._storage_config, "STORAGE_CACHE_FETCH_THREADS", 1))
+        slice_size = max(1, getattr(self._storage_config, "STORAGE_CACHE_FETCH_SLICE_SIZE", 500000))
+        if fetch_threads > 1:
+            # the two knobs are not independent: with the 500k default almost every batch is a
+            # single slice and the pool is never built, so the thread count silently does
+            # nothing (measured: 1.09 effective workers on bumblebee). Derive it instead.
+            # aim for several slices per worker rather than exactly one: equal-sized slices
+            # do not take equal time, and with one slice each a single straggler leaves the
+            # other workers idle. Measured on citadel (824k ids, 8 threads): one slice per
+            # worker 65.2 s, four 46.4 s.
+            # Several slices per worker, because equal-sized slices do not take equal time.
+            # But floor it: with fix 01 the per-batch delta shrinks steadily, and dividing a
+            # small delta by 32 produces dozens of tiny round trips whose per-query overhead
+            # costs more than the concurrency saves.
+            widest = max(len(positive_function_ids), len(negative_function_ids))
+            target = -(-widest // (fetch_threads * 4))
+            slice_size = max(10000, min(slice_size, target))
         for collection_name, collection_ids in (
             ("functions", positive_function_ids),
             ("query_functions", negative_function_ids),
         ):
             if not collection_ids:
                 continue
-            for sliced_ids in zip_longest(*[iter(collection_ids)] * 500000):
-                query_function_ids = [function_id for function_id in sliced_ids if function_id is not None]
-                for function_document in self._getDb()[collection_name].find(
-                    {"function_id": {"$in": query_function_ids}},
-                    {"_id": 0, "sample_id": 1, "minhash": 1, "function_id": 1},
-                ):
-                    function_id = function_document["function_id"]
-                    sample_id = function_document["sample_id"]
-                    minhash = bytes.fromhex(function_document["minhash"])
+            slices = [[function_id for function_id in sliced_ids if function_id is not None] for sliced_ids in zip_longest(*[iter(collection_ids)] * slice_size)]
+            if fetch_threads > 1 and len(slices) > 1:
+                with ThreadPoolExecutor(max_workers=min(fetch_threads, len(slices))) as pool:
+                    # map preserves input order, so the resulting dicts are built in the same
+                    # order a sequential fetch would build them
+                    decoded_slices = list(pool.map(lambda ids: self._fetchCacheSlice(collection_name, ids), slices))
+            else:
+                decoded_slices = [self._fetchCacheSlice(collection_name, ids) for ids in slices]
+            for decoded in decoded_slices:
+                for function_id, sample_id, minhash in decoded:
                     minhashes[function_id] = minhash
                     sample_ids[function_id] = sample_id
                     if sample_id not in sample_to_func_ids:
@@ -1026,6 +1050,20 @@ class MongoDbStorage(StorageInterface):
         cache_data["func_id_to_sample_id"] = sample_ids
         cache_data["sample_id_to_func_ids"] = sample_to_func_ids
         return cache_data
+
+    def _fetchCacheSlice(self, collection_name: str, query_function_ids: List[int]) -> List[Tuple[int, int, bytes]]:
+        """One $in query's worth of (function_id, sample_id, minhash), decoded but not merged.
+
+        Kept free of shared state so it can be run from a thread pool; merging into the cache
+        dicts happens in the calling thread, in input order.
+        """
+        return [
+            (function_document["function_id"], function_document["sample_id"], bytes.fromhex(function_document["minhash"]))
+            for function_document in self._getDb()[collection_name].find(
+                {"function_id": {"$in": query_function_ids}},
+                {"_id": 0, "sample_id": 1, "minhash": 1, "function_id": 1},
+            )
+        ]
 
     def deleteXcfgForSampleId(self, sample_id: int) -> None:
         self._getDb().functions.update_many({"sample_id": sample_id}, {"$set": {"_xcfg": "{}"}})


### PR DESCRIPTION
`STORAGE_CACHE_FETCH_THREADS` (**default 1** = sequential): fetch the MatchingCache's candidate signatures with N concurrent `$in` queries. The call is latency-bound — a 186 B projection out of ~4 kB documents — so a single sequential cursor leaves mongod's I/O parallelism unused. Threads, not processes: pymongo releases the GIL for socket I/O and BSON decode. Slices are merged in input order, so the result is byte-identical to sequential.

The slice size is derived when threading is on (several slices per worker, floored at 10,000 ids) because the two knobs are otherwise silently coupled: at the 500k default slice, almost every fetch is single-slice and a thread setting does nothing (measured: 1.09 effective workers).

Verification & numbers (11.7 M-function corpus): 6.81x warm / 15.3x cold on a 500k-id fetch at 8 threads; whole-job effect 1.05x–2.2x depending on the sample's candidate volume. Digest-identical at 1 and 8 threads (per-branch spot checks incl. the restructured sequential path, plus an 81-sample sweep). Sizing guidance: `min(8, cores)` on a dedicated instance; with N concurrent jobs keep N × threads ≤ pymongo's `maxPoolSize` (100).

Related context: #69 (memory/IO behaviour of matching), #107 (batch size), #115 (storage layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwSfzAD1ZwEoWY3eWvbYvX
