### PR TITLE
Optional persistent MatchingCache, owned by the matcher (#110)

### DIFF
--- a/mcrit/config/StorageConfig.py
+++ b/mcrit/config/StorageConfig.py
@@ -39,6 +39,13 @@ class StorageConfig(ConfigInterface):
     STORAGE_BANDS: Dict[int, int] = default_field(_default_storage_bands)
     # use a hashmap to cache all banding data - very memory intensive, but great speedups.
     STORAGE_CACHE: bool = False
+    # Reuse the MatchingCache across the batches of a single matching job instead of
+    # rebuilding it per batch. Measured redundancy of the per-batch rebuild on real data:
+    # 1.54x (citadel) to 12.21x (merlin). Costs ~314 B resident per retained function.
+    STORAGE_MATCHING_CACHE_PERSIST: bool = False
+    # Ceiling on retained functions. Least-recently-needed are evicted first, and never those
+    # required by the batch currently being served. 0 disables the ceiling.
+    STORAGE_MATCHING_CACHE_MAX_ENTRIES: int = 2000000
     # How getCandidatesForMinHashes accumulates band hits:
     #  * "dict":  dict[query_fid][candidate_fid] -> count  (stock)
     #  * "numpy": per-query-function int32 hit arrays + np.unique(return_counts)

--- a/mcrit/matchers/MatcherInterface.py
+++ b/mcrit/matchers/MatcherInterface.py
@@ -68,6 +68,11 @@ class MatcherInterface:
         self._sample_id: Optional[int] = None
         self._progress_reporter = progress_reporter
         self._num_batches = None
+        # job-scoped MatchingCache handle: with STORAGE_MATCHING_CACHE_PERSIST the cache is
+        # retained across this job's batches by passing it back into createMatchingCache as
+        # previous=. It lives on the matcher, never on the shared storage object, so
+        # concurrent jobs/requests cannot see each other's entries (#110).
+        self._matching_cache = None
         self._minhash_threshold = minhash_threshold
         self._exclude_self_matches = exclude_self_matches
         if pichash_size is None:
@@ -120,7 +125,8 @@ class MatcherInterface:
             cache_function_ids.add(candidate_key)
             cache_function_ids.update(candidate_functions)
         LOGGER.info("creating cache for %d functions", len(cache_function_ids))
-        return self._storage.createMatchingCache(cache_function_ids)
+        self._matching_cache = self._storage.createMatchingCache(cache_function_ids, previous=self._matching_cache)
+        return self._matching_cache
 
     ######## Below this line, nothing will be overwritten by Subclasses #########
 
@@ -140,6 +146,16 @@ class MatcherInterface:
     def _getMatchesRoutine(self):
         # Query, VS, Sample
         # All use this version
+        try:
+            return self._getMatchesRoutineInner()
+        finally:
+            # the matching cache may be retained across batches; the job is over either way,
+            # so drop it even if the job raised - a cancelled job (JobProgressReporter raises
+            # from inside the batch loop) would otherwise keep up to
+            # STORAGE_MATCHING_CACHE_MAX_ENTRIES minhashes pinned for this matcher's lifetime.
+            self._matching_cache = None
+
+    def _getMatchesRoutineInner(self):
         pichash_matches = self._harmonizePicHashMatches(self._getPicHashMatches())
         LOGGER.info("Calculated PicHash matches")
         all_minhash_matches = {}
@@ -240,7 +256,6 @@ class MatcherInterface:
         LOGGER.info("Minhash Signature Field Match Counts: " + ", ".join("(%s: %d)" % (float(matches), int(count)) for matches, count in enumerate(score_counts) if count))
         LOGGER.info("Vectorized matching over %d pairs in %d candidate groups", num_pairs, len(candidate_groups))
         matching_results = [k + v for k, v in organized_matching_results.items()]
-        self._storage.clearMatchingCache()
         return matching_results
 
     # Reports PROGRESS
@@ -307,7 +322,6 @@ class MatcherInterface:
         full_score_counts = sorted([(item[0] * 64 / 100, item[1]) for item in dict(counted_scores).items()])
         LOGGER.info("Minhash Signature Field Match Counts: " + ", ".join([f"({i[0]}: {i[1]})" for i in full_score_counts]))
         matching_results = [k + v for k, v in organized_matching_results.items()]
-        self._storage.clearMatchingCache()
         return matching_results
 
     def _countPackedTuples(self, candidate_pairs) -> int:

--- a/mcrit/matchers/MatcherQuery.py
+++ b/mcrit/matchers/MatcherQuery.py
@@ -56,6 +56,7 @@ class MatcherQuery(MatcherInterface):
             for function_id in other_function_ids:
                 if function_id >= 0:
                     function_ids_from_storage.add(function_id)
-        cache = self._storage.createMatchingCache(function_ids_from_storage, allow_self_return=True)
+        cache = self._storage.createMatchingCache(function_ids_from_storage, allow_self_return=True, previous=self._matching_cache)
+        self._matching_cache = cache
         cache.addFunctionEntriesToCache(self._function_entries)
         return cache

--- a/mcrit/matchers/MatcherQueryFunction.py
+++ b/mcrit/matchers/MatcherQueryFunction.py
@@ -60,6 +60,7 @@ class MatcherQueryFunction(MatcherInterface):
             for function_id in other_function_ids:
                 if function_id >= 0:
                     function_ids_from_storage.add(function_id)
-        cache = self._storage.createMatchingCache(function_ids_from_storage, allow_self_return=True)
+        cache = self._storage.createMatchingCache(function_ids_from_storage, allow_self_return=True, previous=self._matching_cache)
+        self._matching_cache = cache
         cache.addFunctionEntriesToCache(self._function_entries)
         return cache

--- a/mcrit/storage/MatchingCache.py
+++ b/mcrit/storage/MatchingCache.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 import numpy as np
 
 
@@ -13,6 +15,10 @@ class MatchingCache:
         self._version = 0
         self._signature_view = None
         self._signature_version = None
+        # function_ids fetched from storage (and therefore evictable), in
+        # least-recently-needed order; lives on the cache so that the cache and its LRU
+        # bookkeeping share one scope - the job/matcher that owns this object
+        self._evictable = OrderedDict()
 
     def invalidateSignatureMatrix(self):
         """Callers that mutate _func_id_to_minhash directly must announce it."""
@@ -110,6 +116,7 @@ class StorageBackedMatchingCache(MatchingCache):
         self._version = 0
         self._signature_view = None
         self._signature_version = None
+        self._evictable = OrderedDict()
         self._func_id_to_minhash = {}
         unique_function_ids = set(function_ids)
         self._func_id_to_sample_id = dict(self._storage.getSampleIdsByFunctionIds(list(unique_function_ids)))

--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -484,7 +484,9 @@ class MemoryStorage(StorageInterface):
         for minhash in minhashes:
             self.addMinHash(minhash)
 
-    def createMatchingCache(self, function_ids: List[int], allow_self_return: bool = False) -> MatchingCache:
+    def createMatchingCache(self, function_ids: List[int], allow_self_return: bool = False, previous: Optional[MatchingCache] = None) -> MatchingCache:
+        # previous is accepted for interface compatibility; MemoryStorage serves from memory
+        # anyway, so there is nothing to retain across batches
         if allow_self_return:
             return StorageBackedMatchingCache(self, function_ids)
         cache_data = self._getCacheDataForFunctionIds(function_ids)

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -118,11 +118,9 @@ class MongoDbStorage(StorageInterface):
     _DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
     _database: "Database"
-    _matching_cache: Optional[MatchingCache]
 
     def __init__(self, config: "StorageConfig") -> None:
         super().__init__(config)  # sets config
-        self._matching_cache = None
         self.blockhasher = BlockHasher()
         self._database = None
 
@@ -1098,14 +1096,88 @@ class MongoDbStorage(StorageInterface):
         self._encodeFunction(function_dict)
         return function_dict
 
-    def createMatchingCache(self, function_ids: List[int], allow_self_return: bool = False) -> MatchingCache:
-        cache_data = self._getCacheDataForFunctionIds(function_ids)
-        # TODO dont store this as attribute
-        self._matching_cache = MatchingCache(cache_data)
-        return self._matching_cache
+    def createMatchingCache(self, function_ids: List[int], allow_self_return: bool = False, previous: Optional[MatchingCache] = None) -> MatchingCache:
+        if not getattr(self._storage_config, "STORAGE_MATCHING_CACHE_PERSIST", False):
+            cache_data = self._getCacheDataForFunctionIds(function_ids)
+            return MatchingCache(cache_data)
+        return self._createIncrementalMatchingCache(function_ids, previous)
+
+    def _createIncrementalMatchingCache(self, function_ids: List[int], previous: Optional[MatchingCache] = None) -> MatchingCache:
+        """Serve a batch from a job-scoped cache, fetching only what is not already held.
+
+        The per-batch rebuild re-fetches the same candidate signatures many times over
+        (measured 1.54x-12.21x on real samples). Retaining them across the batches of one job
+        turns total fetches into the distinct union, and decouples the batch size from I/O
+        cost entirely.
+
+        The cache is owned by the calling matcher, which passes it back in as `previous` on
+        every batch after the first - the storage object holds NO reference to it. One
+        matcher instance is one job (worker) or one request (server), so concurrent matchers
+        on a shared storage can never see each other's entries, evict each other's rows, or
+        overwrite each other's query minhashes (the function_id = -1 collision of #110).
+
+        Only entries fetched from storage are evictable (tracked in cache._evictable).
+        Entries injected by the query matchers via addFunctionEntriesToCache are left alone,
+        and the whole cache dies with the matcher that owns it, so nothing leaks between jobs.
+        """
+        requested = set(function_ids)
+        cache = previous
+        if cache is None:
+            cache = MatchingCache({"func_id_to_minhash": {}, "func_id_to_sample_id": {}, "sample_id_to_func_ids": {}})
+        held = cache._func_id_to_minhash
+        missing = [function_id for function_id in requested if function_id not in held]
+
+        max_entries = getattr(self._storage_config, "STORAGE_MATCHING_CACHE_MAX_ENTRIES", 0)
+        if max_entries:
+            overflow = len(held) + len(missing) - max_entries
+            if overflow > 0:
+                self._evictFromMatchingCache(cache, overflow, protected=requested)
+
+        if missing:
+            cache_data = self._getCacheDataForFunctionIds(missing)
+            fetched_sample_ids = cache_data["func_id_to_sample_id"]
+            for function_id, minhash in cache_data["func_id_to_minhash"].items():
+                cache._setFunctionEntry(function_id, fetched_sample_ids[function_id], minhash)
+                cache._evictable[function_id] = None
+
+        # refresh recency for everything this batch needs, so eviction is least-recently-needed
+        for function_id in requested:
+            if function_id in cache._evictable:
+                cache._evictable.move_to_end(function_id)
+        return cache
+
+    def _evictFromMatchingCache(self, cache: MatchingCache, count: int, protected: Set[int]) -> int:
+        evicted = 0
+        for function_id in list(cache._evictable):
+            if evicted >= count:
+                break
+            if function_id in protected:
+                continue
+            sample_id = cache._func_id_to_sample_id.pop(function_id, None)
+            cache._func_id_to_minhash.pop(function_id, None)
+            if sample_id is not None and sample_id in cache._sample_id_to_func_ids:
+                cache._sample_id_to_func_ids[sample_id].discard(function_id)
+                if not cache._sample_id_to_func_ids[sample_id]:
+                    del cache._sample_id_to_func_ids[sample_id]
+            del cache._evictable[function_id]
+            evicted += 1
+        if evicted:
+            cache.invalidateSignatureMatrix()
+            # the ceiling is otherwise silent when it binds, which has already caused wrong
+            # performance readings - make every eviction visible
+            LOGGER.info(
+                "MatchingCache eviction: evicted %d of %d requested, %d entries retained (ceiling %d)",
+                evicted,
+                count,
+                len(cache._func_id_to_minhash),
+                getattr(self._storage_config, "STORAGE_MATCHING_CACHE_MAX_ENTRIES", 0),
+            )
+        return evicted
 
     def clearMatchingCache(self) -> None:
-        self._matching_cache = None
+        # the matching cache is owned by the matcher that created it and dies with that
+        # matcher; the storage object holds no reference to it, so there is nothing to clear
+        return
 
     def getFamilyId(self, family_name: str) -> Optional[int]:
         family_document = self._getDb().families.find_one({"family_name": family_name})

--- a/mcrit/storage/StorageInterface.py
+++ b/mcrit/storage/StorageInterface.py
@@ -385,7 +385,7 @@ class StorageInterface:
 
     # TODO: make a MatchingCacheInterface for all backends.
     # TODO rename -> get?
-    def createMatchingCache(self, function_ids: List[int], allow_self_return: bool = False) -> "MatchingCache":
+    def createMatchingCache(self, function_ids: List[int], allow_self_return: bool = False, previous: Optional["MatchingCache"] = None) -> "MatchingCache":
         """Creates a temporary matching cache, for a list of function_ids
 
         Args:


### PR DESCRIPTION
Fixes #110. Stacked on the vectorised-scoring PR (first commit here) — review only the last commit; will retarget automatically once that PR merges.

Two things land together because the second makes the first safe:

**1. `STORAGE_MATCHING_CACHE_PERSIST` (default off):** keep the MatchingCache across the batches of one matching job, fetching only each batch's delta. The per-batch rebuild re-fetches the same candidate signatures 1.54x (citadel) to 12.21x (merlin) over; retaining them turns total fetches into the distinct union. `STORAGE_MATCHING_CACHE_MAX_ENTRIES` caps retained entries (~314 B each) with least-recently-needed eviction that never evicts what the current batch requires — and logs every eviction, because a silently-binding ceiling is indistinguishable from a fix that does not work.

**2. The cache is owned by the matcher, never by the storage object (#110):** `createMatchingCache(..., previous=cache)` — the matcher passes its cache back in each batch; the storage object holds no reference at all, and the LRU bookkeeping lives on the cache. One matcher instance is one job (worker) or one request (server), so the `/query/function` scenario from #110 — concurrent in-process requests sharing one cache with every query function hardcoded to `function_id = -1` — is impossible by construction, not by locking. A `try/finally` drops the matcher's cache even when a job raises (e.g. user cancellation), so nothing survives into a reused worker process.

Verification:
- The reproduction checks from #110: with persist on, independent `createMatchingCache` calls return distinct objects and concurrent `function_id = -1` injections do not collide.
- 12 concurrent `POST /query/function` requests (4-way × 3 rounds, persist on) against a live server: all responses identical to the sequential reference.
- Digest-identical on all four matcher types, including a persist+eviction+vectorised run and an 81-sample sweep; ~160 recorded runs across two sessions.
- Measured (with the other opt-in flags): the four optimisations together give 4.39x aggregate wall over a 74-sample sweep, 8–10x on pathological samples; memory cost is the retained union (median +215 MiB, worst +1.4 GiB at an uncapped ceiling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwSfzAD1ZwEoWY3eWvbYvX
