### PR TITLE
docs: add DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # MinHash-based Code Relationship & Investigation Toolkit (MCRIT)
 [![Test](https://github.com/danielplohmann/mcrit/actions/workflows/test.yml/badge.svg)](https://github.com/danielplohmann/mcrit/actions/workflows/test.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/danielplohmann/mcrit)
 
 MCRIT is a framework created to simplify the application of the MinHash algorithm in the context of code similarity.
 It can be used to rapidly implement "shinglers", i.e. methods which encode properties of disassembled functions, to then be used for similarity estimation via the MinHash algorithm.


### PR DESCRIPTION
## Summary

- Add the Ask DeepWiki badge to the README badge section.
- Link the badge to this repository's DeepWiki page.

## Validation

- Confirmed the README diff contains only the badge addition.
- Ran `git diff --check`.