### PR TITLE
Index the queue polling query; fix $gt typo in _jobs_in_progress (#117)

### DIFF
--- a/mcrit/libs/mongoqueue.py
+++ b/mcrit/libs/mongoqueue.py
@@ -110,6 +110,15 @@ class MongoQueue:
         # should only be called, after self.collection has been initiated
         self.collection.create_index("payload.method")
         self.collection.create_index("payload.descriptor")
+        # serves the polling query in next() and _jobs_to_do(): equality on locked_by/finished_at, then the sort keys
+        self.collection.create_index(
+            [
+                ("locked_by", pymongo.ASCENDING),
+                ("finished_at", pymongo.ASCENDING),
+                ("priority", pymongo.DESCENDING),
+                ("created_at", pymongo.ASCENDING),
+            ]
+        )
         self.fs_files.create_index("metadata.sha256")
 
     def _identifyJobState(self, doc):
@@ -303,7 +312,7 @@ class MongoQueue:
             filter={
                 "locked_by": {"$ne": None},
                 "locked_at": {"$ne": None},
-                "attempts_left": {"gt": 0},
+                "attempts_left": {"$gt": 0},
                 "finished_at": None,
             },
             sort=[("priority", pymongo.DESCENDING)],

--- a/tests/testMongoQueue.py
+++ b/tests/testMongoQueue.py
@@ -116,6 +116,24 @@ class MongoQueueTest(TestCase):
         stats = self.queue.stats()
         self.assertEqual({"available": 5, "total": 5, "locked": 0, "errors": 0}, stats)
 
+    def test_ensure_indices(self):
+        self.queue._getCollection()
+        index_information = self.queue.collection.index_information()
+        self.assertIn("locked_by_1_finished_at_1_priority_-1_created_at_1", index_information)
+        self.assertEqual(
+            [("locked_by", 1), ("finished_at", 1), ("priority", -1), ("created_at", 1)],
+            index_information["locked_by_1_finished_at_1_priority_-1_created_at_1"]["key"],
+        )
+
+    def test_jobs_in_progress(self):
+        self.queue.put({"method": "test_method", "name": "alice"})
+        self.queue.put({"method": "test_method", "name": "bob"})
+        self.assertEqual(0, len(list(self.queue._jobs_in_progress())))
+        job = self.queue.next()
+        jobs_in_progress = list(self.queue._jobs_in_progress())
+        self.assertEqual(1, len(jobs_in_progress))
+        self.assertEqual(job.job_id, jobs_in_progress[0]["_id"])
+
     def test_context_manager_error(self):
         self.queue.put({"method": "test_method", "context_id": "alpha", "data": [1, 2, 3], "more-data": time.time()})
         job = self.queue.next()


### PR DESCRIPTION
Fixes #117.

`_ensure_indices` now creates the compound index

```python
self.collection.create_index(
    [
        ("locked_by", pymongo.ASCENDING),
        ("finished_at", pymongo.ASCENDING),
        ("priority", pymongo.DESCENDING),
        ("created_at", pymongo.ASCENDING),
    ]
)
```

which serves the polling `find_one_and_update` in `next()` (and the `_jobs_to_do` find): the two `null`-equality fields first, then the sort keys with matching directions, per the equality-sort-range rule. The remaining predicates stay in the residual filter deliberately — `locked_at` is redundant next to `locked_by` (jobs are always locked by both or neither), `unfinished_dependencies` is an array (multikey), and `attempts_left` is a range; at 28 examined documents per poll none of them is worth widening the index for.

Second change: `_jobs_in_progress` filtered `"attempts_left": {"gt": 0}` — missing `$`, so it matched only documents whose field literally equals the object `{gt: 0}`, i.e. nothing. Now `{"$gt": 0}`. (Dead code today, but a landmine for whoever wires it up.)

## Measured (replica of the reporting box's queue: mongodump of its real 11,301-document `queue` collection into a scratch mongod, profiler at level 2, the exact poll `find_one_and_update` in a loop for 60 s per phase; 0 actionable jobs, i.e. the idle-instance scenario from the issue)

| | before | after |
|---|---|---|
| plan | COLLSCAN + in-memory SORT | IXSCAN `{locked_by: 1, finished_at: 1, priority: -1, created_at: 1}`, no SORT stage |
| docsExamined per poll | 11,301 (entire collection) | 28 |
| keysExamined per poll | 0 | 28 |
| polls in 60 s | 8,391 | 128,885 (15.4x) |
| docsExamined per 60 s window | ~94.8 M | ~3.6 M |

The 28 documents are exactly the `locked_by: null && finished_at: null` set — "currently actionable jobs" — so the per-poll cost is now independent of accumulated queue history. `explain()` after: `UPDATE ← LIMIT ← FETCH ← SORT_MERGE ← 4x IXSCAN` (the four branches are the `[undefined,undefined]`/`[null,null]` point-bound expansion of the two null equalities; SORT_MERGE merges them in index order and is not a blocking sort — the profiler reports `hasSortStage: false`). Before: `UPDATE ← SORT ← COLLSCAN`. The before-phase profiler sample (501 polls, 5,661,801 docsExamined, 0 returned) reproduces the issue's live measurement (545 polls, 6,155,775 docsExamined, 0 returned) per-poll exactly.

## Tests

- `test_ensure_indices`: asserts the index (name and full key spec) exists after collection initialisation.
- `test_jobs_in_progress`: a claimed job is now actually returned by `_jobs_in_progress` (and an unclaimed queue yields none) — this asserts the `$gt` fix, since the old filter returned nothing ever.
- Full suite: 97 passed, 5 subtests passed, 0 failed (95 baseline + the 2 new). `ruff format --check` / `ruff check` clean.

## Out of scope

The issue's remaining structural point stands: finished jobs accumulate in the collection forever, so periodic pruning/archiving of `finished_at != None` documents (or a TTL) would keep even the index bounded and matters more than further query tuning for long-lived instances — future work, not this PR. Same for `repair()`'s unindexed `$ne` filter, which runs rarely and becomes moot with pruning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwSfzAD1ZwEoWY3eWvbYvX
