### PR TITLE
Report num_pichashes as null when the aggregation was skipped (#108)

### DIFF
--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -780,7 +780,7 @@ class MemoryStorage(StorageInterface):
                     self._pichashes[function_entry.pichash] = set()
                 self._pichashes[function_entry.pichash].add((function_entry.sample_id, function_entry.function_id))
 
-    def getStats(self) -> Dict[str, Union[int, Dict[int, int]]]:
+    def getStats(self, with_pichash=True) -> Dict[str, Union[int, Dict[int, int]]]:
         stats = {
             "db_state": self._db_state,
             "db_timestamp": self._db_timestamp,
@@ -788,7 +788,8 @@ class MemoryStorage(StorageInterface):
             "num_samples": len(self._samples),
             "num_functions": len(self._functions),
             "num_bands": len(self._bands),
-            "num_pichashes": len(self._pichashes),
+            # None signals "not computed", so that consumers can distinguish it from an actual count of 0
+            "num_pichashes": len(self._pichashes) if with_pichash else None,
         }
         return stats
 

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -1285,8 +1285,10 @@ class MongoDbStorage(StorageInterface):
     def getStats(self, with_pichash=True) -> Dict:
         # we will have to work around using .aggregate(), as a collection with unique pic hashes will easily exceed 16M
         # https://stackoverflow.com/questions/20348093/mongodb-aggregation-how-to-get-total-records-count
-        num_unique_pichashes = 0
+        # None signals "not computed", so that consumers can distinguish it from an actual count of 0
+        num_unique_pichashes = None
         if with_pichash:
+            num_unique_pichashes = 0
             for result in self._getDb().functions.aggregate([{"$group": {"_id": "$_pichash"}}, {"$count": "Total"}]):
                 num_unique_pichashes = result["Total"]
         # use family statistics to derive relevant values

--- a/mcrit/storage/StorageInterface.py
+++ b/mcrit/storage/StorageInterface.py
@@ -608,7 +608,16 @@ class StorageInterface:
         """
         raise NotImplementedError
 
-    def getStats(self) -> Dict[str, Union[int, Dict[int, int]]]:
+    def getStats(self, with_pichash=True) -> Dict[str, Union[int, Dict[int, int]]]:
+        """Get statistics for the stored data, as a dict with counts per type of entry.
+
+        Args:
+            with_pichash: (optional) if False, skip the (potentially expensive) aggregation of
+                unique pichashes and report the field "num_pichashes" as None instead.
+
+        Returns:
+            a dict with statistics describing the stored data
+        """
         raise NotImplementedError
 
     def getUnhashedFunctions(self, function_ids: Optional[List[int]] = None, only_function_ids=False) -> List["FunctionEntry"]:

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -51,6 +51,11 @@ class MemoryStorageTest(TestCase):
         self.assertEqual(1, stats["num_samples"])
         self.assertEqual(10, stats["num_functions"])
         self.assertEqual(10, stats["num_pichashes"])
+        # without pichash aggregation, the field is reported as None instead of a misleading 0
+        stats_without_pichash = self.storage.getStats(with_pichash=False)
+        self.assertEqual(1, stats_without_pichash["num_samples"])
+        self.assertEqual(10, stats_without_pichash["num_functions"])
+        self.assertIsNone(stats_without_pichash["num_pichashes"])
 
     def testFamilyHandling(self):
         self.storage.clearStorage()


### PR DESCRIPTION
Fixes #108.

`/status` reported `"num_pichashes": 0` on an instance with 11.7 M functions that all carry pichashes. The aggregation is not broken — the HTTP layer defaults `with_pichash` to False, `getStats(with_pichash=False)` skips the `$group`/`$count` stage entirely, and the initialised sentinel `0` was emitted as if it were data, indistinguishable from a genuinely empty corpus.

Before (live v1.6.1 instance, bare `curl -s 127.0.0.1:8000/status`):

```
"num_pichashes": 0
```

The aggregation stays off by default — a `$group` over every function document is genuinely expensive — so only the reporting changes:

1. **`MongoDbStorage.getStats`** — `num_unique_pichashes` initialises to `None` and only becomes a number (including a real `0`) when `with_pichash` is True and the aggregation actually ran. The `None` flows unchanged through `MinHashIndex.getStatus` and `jsonify`, so the bare HTTP call now emits `"num_pichashes": null`.
2. **`MemoryStorage.getStats`** — gains the same `with_pichash=True` parameter and `None` semantics. It previously accepted no such argument at all, so `MinHashIndex.getStatus(with_pichash=False)` raised `TypeError` on a memory-backed instance; the two backends now expose the same contract.
3. **`StorageInterface.getStats`** — signature updated and the contract documented: `with_pichash=False` skips the aggregation and reports the field as `None`.

**Why null rather than omitting the key:** `MinHashIndex.getStatus` accesses `storage_stats["num_pichashes"]` directly, and any downstream consumer may do the same on the response dict — omitting the key can raise `KeyError` where `0` did not; `null` cannot break dict access anywhere. The known consumers were checked: mcritweb calls `McritClient.getStatus()` with the default `with_pichash=True` (statistics view and API pass-through), so it always receives the computed value; `McritConsole` passes `with_pichash=False` but never reads `num_pichashes`. Neither cares either way — `null` is the option that also cannot break consumers we have not seen. JSON `null` for "not computed" is also self-describing where an absent key is ambiguous (typo? version skew?).

After (throwaway server container running this branch against a scratch mongod, shipped default config):

```
$ curl -s 127.0.0.1:8000/status | python3 -m json.tool | grep -i pichash
            "num_pichashes": null
$ curl -s '127.0.0.1:8000/status?with_pichash=True' | python3 -m json.tool | grep -i pichash
            "num_pichashes": 0
```

(the second value is a genuine count on an empty scratch database — exactly the "none" that must stay distinguishable from "not computed").

## Verification

- `tests/testStorage.py::testBasicStorageUsage` extended (runs for both `MemoryStorageTest` and the inheriting `MongoDbStorageTest`): `getStats()` still reports the computed `num_pichashes == 10`, and `getStats(with_pichash=False)` reports `num_pichashes is None` while the cheap counters (`num_samples`, `num_functions`) remain populated.
- Full pytest suite against a throwaway mongod (mcrit-server:1.6.0 image, smda 4.4.4): **95 passed, 5 subtests passed, 0 failed**. (The 1.6.1 image carries smda 4.4.5, whose changed disassembly makes 4 `tests/testMatcher.py` tests fail even on unmodified v1.6.1 main — an environment caveat unrelated to this change.)
- `ruff format --check .` and `ruff check mcrit/ tests/` both pass.
- End-to-end demonstrated with a throwaway server container (this branch mounted over `/opt/mcrit`, no config mount) sharing a network namespace with the scratch mongod — output shown above. The live instance was not restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwSfzAD1ZwEoWY3eWvbYvX
