### PR TITLE
Synchronise lazy database init in MongoDbStorage (#109)

### DIFF
--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import logging
 import re
+import threading
 import traceback
 import uuid
 from concurrent.futures import ThreadPoolExecutor
@@ -124,18 +125,28 @@ class MongoDbStorage(StorageInterface):
         super().__init__(config)  # sets config
         self.blockhasher = BlockHasher()
         self._database = None
+        # guards the lazy initialisation in _getDb(); a threading.Lock is per-process, which is
+        # what we want: forking servers (gunicorn) fork before the first request, so every child
+        # inherits an unlocked copy and synchronises its own threads independently
+        self._database_lock = threading.Lock()
 
     def _getDb(self):
         # because of gunicorn and forking workers, we want to delay creation of MongoClient until actual usage and avoid it within __init__()
         if self._database is None:
-            self._initDb(
-                self._storage_config.STORAGE_SERVER,
-                self._storage_config.STORAGE_PORT,
-                self._storage_config.STORAGE_MONGODB_DBNAME,
-                self._storage_config.STORAGE_MONGODB_USERNAME,
-                self._storage_config.STORAGE_MONGODB_PASSWORD,
-                self._storage_config.STORAGE_MONGODB_FLAGS,
-            )
+            # double-checked locking: the server shares one storage object across all request
+            # threads, and two threads arriving cold must not both construct a MongoClient (#109).
+            # _initDb assigns self._database before ensuring indexes, so its re-entrant _getDb
+            # calls take the fast path above and do not deadlock on this non-reentrant lock.
+            with self._database_lock:
+                if self._database is None:
+                    self._initDb(
+                        self._storage_config.STORAGE_SERVER,
+                        self._storage_config.STORAGE_PORT,
+                        self._storage_config.STORAGE_MONGODB_DBNAME,
+                        self._storage_config.STORAGE_MONGODB_USERNAME,
+                        self._storage_config.STORAGE_MONGODB_PASSWORD,
+                        self._storage_config.STORAGE_MONGODB_FLAGS,
+                    )
         return self._database
 
     def _initDb(self, server, port, db_name, username="", password="", flags=""):
@@ -179,9 +190,15 @@ class MongoDbStorage(StorageInterface):
         self._getDb()["logs"].create_index("username")
         for band_id in range(self._storage_config.STORAGE_NUM_BANDS):
             self._getDb()["band_%d" % band_id].create_index("band_hash")
-        # Add Family "" if it is not already in storage
-        if self.getFamily(0) is None:
-            self.addFamily("")
+        # Add Family "" (family_id 0) if it is not already in storage. Two processes can bootstrap
+        # the same database concurrently (e.g. server and worker), so instead of check-then-addFamily
+        # (which would hand out two different family_ids for "") this uses a single upsert keyed on
+        # family_id. First push the families counter past 0 so addFamily can never hand out id 0.
+        self._getDb().counters.find_one_and_update(filter={"name": "families"}, update={"$max": {"value": 1}}, upsert=True)
+        unknown_family = FamilyEntry(family_name="", family_id=0)
+        upsert_result = self._getDb()["families"].update_one({"family_id": 0}, {"$setOnInsert": unknown_family.toDict()}, upsert=True)
+        if upsert_result.upserted_id is not None:
+            self._updateDbState()
         assert self.getFamily(0).family_name == ""
 
     def _removeCounterDuplicates(self) -> None:

--- a/tests/testMongoDbStorageInit.py
+++ b/tests/testMongoDbStorageInit.py
@@ -1,0 +1,120 @@
+import logging
+import os
+import threading
+import time
+from unittest import TestCase, main
+
+import pytest
+
+import mcrit.storage.MongoDbStorage as mongo_db_storage_module
+from mcrit.config.McritConfig import McritConfig
+from mcrit.config.MinHashConfig import MinHashConfig
+from mcrit.config.QueueConfig import QueueConfig
+from mcrit.config.ShinglerConfig import ShinglerConfig
+from mcrit.config.StorageConfig import StorageConfig
+from mcrit.storage.MongoDbStorage import MongoDbStorage
+from mcrit.storage.StorageFactory import StorageFactory
+
+LOG = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)-15s %(message)s")
+logging.disable(logging.CRITICAL)
+
+
+def buildMcritConfig():
+    mongodb_server = os.environ.get("TEST_MONGODB", "127.0.0.1")
+    # split host:port when the env var contains both
+    if ":" in mongodb_server:
+        server, port = mongodb_server.rsplit(":", 1)
+    else:
+        server, port = mongodb_server, "27017"
+    storage_config = StorageConfig(
+        STORAGE_METHOD=StorageFactory.STORAGE_METHOD_MONGODB,
+        STORAGE_SERVER=server,
+        STORAGE_PORT=port,
+        STORAGE_MONGODB_DBNAME="test_mongodbstorage_init_mcrit",
+        STORAGE_DROP_DISASSEMBLY=False,
+    )
+    mcrit_config = McritConfig()
+    mcrit_config.STORAGE_CONFIG = storage_config
+    mcrit_config.MINHASH_CONFIG = MinHashConfig()
+    mcrit_config.MINHASH_CONFIG.MINHASH_SIGNATURE_LENGTH = 10
+    mcrit_config.MINHASH_CONFIG.MINHASH_SIGNATURE_BITS = 8
+    mcrit_config.SHINGLER_CONFIG = ShinglerConfig()
+    mcrit_config.QUEUE_CONFIG = QueueConfig()
+    return mcrit_config
+
+
+@pytest.mark.mongo
+class MongoDbStorageInitTest(TestCase):
+    """The server shares one MongoDbStorage across all request threads, so the lazy
+    initialisation in _getDb() must construct exactly one MongoClient no matter how
+    many threads arrive cold at the same time (#109)."""
+
+    def setUp(self):
+        self.config = buildMcritConfig()
+        self.storage = MongoDbStorage(self.config)
+
+    def tearDown(self):
+        if self.storage._database is not None:
+            db_name = self.config.STORAGE_CONFIG.STORAGE_MONGODB_DBNAME
+            self.storage._database.client.drop_database(db_name)
+
+    def testConcurrentColdGetDbCreatesExactlyOneClient(self):
+        num_threads = 8
+        construction_count = [0]
+        count_lock = threading.Lock()
+        real_mongo_client = mongo_db_storage_module.MongoClient
+
+        def countingMongoClient(*args, **kwargs):
+            with count_lock:
+                construction_count[0] += 1
+            # hold the check-to-assign window open, so that without synchronisation in
+            # _getDb() every cold thread would reliably construct its own client
+            time.sleep(0.1)
+            return real_mongo_client(*args, **kwargs)
+
+        barrier = threading.Barrier(num_threads)
+        databases = [None] * num_threads
+        errors = []
+
+        def hitGetDb(slot):
+            try:
+                barrier.wait()
+                databases[slot] = self.storage._getDb()
+            except Exception as exc:
+                errors.append(exc)
+
+        mongo_db_storage_module.MongoClient = countingMongoClient
+        try:
+            threads = [threading.Thread(target=hitGetDb, args=(slot,)) for slot in range(num_threads)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+        finally:
+            mongo_db_storage_module.MongoClient = real_mongo_client
+
+        self.assertEqual([], errors)
+        self.assertEqual(1, construction_count[0])
+        for database in databases:
+            self.assertIs(databases[0], database)
+
+    def testEnsureIndexAndUnknownFamilyIsIdempotent(self):
+        self.storage._getDb()
+        db_name = self.config.STORAGE_CONFIG.STORAGE_MONGODB_DBNAME
+        self.storage._database.client.drop_database(db_name)
+        # bootstrapping twice (as the server and worker processes do against a shared
+        # database) must yield exactly one family "" with family_id 0
+        self.storage._ensureIndexAndUnknownFamily()
+        self.storage._ensureIndexAndUnknownFamily()
+        second_storage = MongoDbStorage(self.config)
+        second_storage._getDb()
+        self.assertEqual(1, self.storage._database.families.count_documents({"family_id": 0}))
+        self.assertEqual(1, self.storage._database.families.count_documents({"family_name": ""}))
+        self.assertEqual("", self.storage.getFamily(0).family_name)
+        # the families counter must be past 0, so the next family can never collide with id 0
+        self.assertEqual(1, self.storage.addFamily("another_family"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #109

`MongoDbStorage._getDb()` lazily initialised `self._database` without synchronisation, while `application_routes.py` shares one storage object across all of waitress's request threads (default 4). Two threads arriving cold could both construct a `MongoClient` — the loser's topology-monitor threads leak until GC, since pymongo does not close on `__del__` — and both run `_ensureIndexAndUnknownFamily()`, whose family-0 check is non-atomic and ends in an `assert`. As the issue says, this was inferred from reading, never observed in the wild; the fix is worth having on the general principle that a shared mutable singleton behind a multi-threaded server should not be lazily initialised without a lock.

### The fix (two parts)

**1. Double-checked locking in `_getDb()`** — exactly the sketch from the issue: an instance `threading.Lock` created in `__init__`, an uncontended fast path (`self._database is None` check unchanged), and construction under the lock with a second check. `_initDb()` assigns `self._database` before `_ensureIndexAndUnknownFamily()` runs, so the re-entrant `_getDb()` calls inside index creation take the fast path and never touch the (non-reentrant) lock — no deadlock.

Two concerns checked before adding a lock attribute:

- **Forking.** The "delay creation because of gunicorn" comment on `_getDb()` stays valid: a `threading.Lock` is per-process, and forking servers fork before the first request, so each child inherits an unlocked copy and synchronises its own threads independently. Verified against the codebase (measured, via grep): the only `multiprocessing` use is `libs/parallel.py`, which is spawn-based.
- **Pickling.** Locks are not picklable, but no `MongoDbStorage` instance ever crosses a process boundary: the spawn pools in `Worker.indexSmdaReports` and `MatcherInterface` pickle bound methods of `MinHasher`, which holds only configs and shinglers, no storage reference. A stray future pickle of storage would now fail loudly instead of silently duplicating clients, which is the right failure mode.

**2. Family-0 bootstrap made idempotent across processes.** With the lock, same-instance racing is gone, but server and worker are separate processes bootstrapping the same database, and the old `if self.getFamily(0) is None: self.addFamily("")` could hand out **two different family_ids for ""** when interleaved (`addFamily` is find-then-insert around a counter increment). Replaced with a single upsert keyed on `family_id: 0` (`$setOnInsert`), preceded by an idempotent `$max` bump of the families counter so `addFamily` can never hand out id 0 again. `_updateDbState()` is called only when the upsert actually inserted, preserving the previous fresh-DB behaviour (db_state 0→1, timestamp set). Warm databases created by the old code path are untouched (both operations are no-ops there).

### Residual window, documented honestly

The family-0 upsert narrows but does not fully close the cross-process race: MongoDB upserts are only atomic against duplicates when a unique index backs the query, and `families.family_id` is indexed non-unique. Two processes upserting in the same instant can, per documented MongoDB behaviour, still both insert — but the duplicates would now be content-identical `family_id: 0` docs (harmless to the assert and to `getFamilyId("")`), instead of two distinct families for "". Making the index unique would close it completely but risks failing index builds on existing databases that already carry duplicates — deliberately out of scope here.

One adjacent observation (measured against a throwaway mongod, not changed in this PR): the existing `query_samples`/`query_functions` counter bootstrap upserts with `filter={"name": ..., "value": 0}`, which no longer matches once the counter has advanced, so every warm restart inserts an extra `{name, value: 1}` counter doc. `_useCounterBulk` happens to keep reading the oldest doc, so it stays functional; the new families bootstrap uses `$max` keyed on name only, which does not accumulate duplicates. Can file separately if wanted.

### Test

`tests/testMongoDbStorageInit.py` (runs under the existing `mongo` marker):

- **Threaded cold-init test**: 8 threads released by a barrier into `_getDb()` on a cold storage, with the module-level `MongoClient` wrapped by a counting constructor that sleeps 100 ms to hold the check-to-assign window open. Asserts exactly one client construction and that all 8 threads get the identical database object.
  - **Measured pre-fix failure**: on the unfixed v1.6.1 code this test fails with `AssertionError: 1 != 8` — all eight threads constructed their own client. With the fix: passes.
  - What it cannot prove: it forces the window with a sleep rather than catching the natural ~ms window, and it exercises threads in one process, not the waitress stack itself. It proves the synchronisation is correct, and the pre-fix run proves the test would catch a regression.
- **Bootstrap idempotency test**: drops the DB, runs `_ensureIndexAndUnknownFamily()` twice plus a second storage instance's full init, asserts exactly one `family_id: 0` / `family_name: ""` document and that the next `addFamily` returns 1, never 0. This covers sequential double-bootstrap; the simultaneous cross-process upsert race is not test-forced (see residual window above).

### Verification

- Full suite (throwaway mongod 5.0, mcrit-server:1.6.0 image, smda 4.4.4): **97 passed, 5 subtests passed, 0 failed** (95 baseline + the 2 new tests).
- Caveat: under smda 4.4.5 (the 1.6.1 image) 4 `testMatcher` tests fail on *unmodified* main due to changed disassembly — pre-existing, unrelated.
- `ruff format --check .` and `ruff check mcrit/ tests/` both clean.

---

**Coordination:** touches `_ensureIndexAndUnknownFamily` alongside the storage PRs for #105 and #115 — trivial textual conflict for whichever merges later, no semantic interaction. The family-0 bootstrap here uses `$max` on the families counter for the same reason #105 does on the query counters; if #105 lands first the intent is already familiar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwSfzAD1ZwEoWY3eWvbYvX
