### PR TITLE
Storage smalls: indexes for filtered fields, drop count-before-find, keyset paging (#115)

### DIFF
--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -163,14 +163,20 @@ class MongoDbStorage(StorageInterface):
         if "settings" not in self._getDb().list_collection_names():
             self._getDb()["settings"].insert_one({"mcrit_db_id": str(uuid.uuid4()), "db_state": 0})
         self._getDb()["samples"].create_index("sample_id")
+        self._getDb()["samples"].create_index("sha256")
+        self._getDb()["samples"].create_index("family_id")
         self._getDb()["families"].create_index("family_id")
+        self._getDb()["families"].create_index("family_name")
         self._getDb()["functions"].create_index("function_id")
         self._getDb()["functions"].create_index("sample_id")
+        self._getDb()["functions"].create_index("family_id")
+        self._getDb()["functions"].create_index("function_name")
         self._getDb()["functions"].create_index("_pichash")
         self._getDb()["functions"].create_index("_picblockhashes.hash")
         self._getDb()["functions"].create_index("_picblockhashes.offset")
         # stored without guarantee of existence
         self._getDb()["query_samples"].create_index("sample_id")
+        self._getDb()["query_samples"].create_index("sha256")
         self._getDb()["query_functions"].create_index("function_id")
         self._getDb()["query_functions"].create_index("sample_id")
         # ensure that their counters are at least 1, so that they never contain items with sample_id/function_id 0

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -649,15 +649,11 @@ class MongoDbStorage(StorageInterface):
     def getSampleBySha256(self, sha256: str, is_query=False) -> Optional["SampleEntry"]:
         target_sample = None
         if is_query:
-            if self._getDb().query_samples.count_documents(filter={}):
-                report_dict = self._getDb().query_samples.find_one({"sha256": sha256})
-                if report_dict:
-                    target_sample = SampleEntry.fromDict(report_dict)
+            report_dict = self._getDb().query_samples.find_one({"sha256": sha256})
         else:
-            if self._getDb().samples.count_documents(filter={}):
-                report_dict = self._getDb().samples.find_one({"sha256": sha256})
-                if report_dict:
-                    target_sample = SampleEntry.fromDict(report_dict)
+            report_dict = self._getDb().samples.find_one({"sha256": sha256})
+        if report_dict:
+            target_sample = SampleEntry.fromDict(report_dict)
         return target_sample
 
     def updateFunctionLabels(self, smda_report: "SmdaReport", username) -> Optional["SampleEntry"]:

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -1381,9 +1381,16 @@ class MongoDbStorage(StorageInterface):
         batch_size = self._minhash_config.MINHASH_BAND_REBUILD_WORK_PACKAGE_SIZE
         if progress_reporter:
             progress_reporter.set_total((total_functions // batch_size) + 1)
-        for start_index in range(0, total_functions, batch_size):
+        # keyset paging on the indexed function_id, as skip() would walk and discard all skipped documents on every batch
+        last_function_id = None
+        while True:
+            batch_query = {} if last_function_id is None else {"function_id": {"$gt": last_function_id}}
+            function_documents = list(self._getDb().functions.find(batch_query, {"function_id": 1, "minhash": 1, "_id": 0}).sort("function_id", 1).limit(batch_size))
+            if not function_documents:
+                break
+            last_function_id = function_documents[-1]["function_id"]
             minhashes = []
-            for function_document in self._getDb().functions.find({}, {"function_id": 1, "minhash": 1, "_id": 0}).skip(start_index).limit(batch_size):
+            for function_document in function_documents:
                 if function_document["minhash"]:
                     function_id = function_document["function_id"]
                     minhash_bytes = bytes.fromhex(function_document["minhash"])

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -450,6 +450,28 @@ class MongoDbStorageTest(MemoryStorageTest):
         # the regular sample collection must remain unaffected
         self.assertEqual(None, self.storage.getSampleBySha256(smda_report.sha256))
 
+    def testRebuildMinhashBandIndexMatchesIncrementalBands(self):
+        self.storage.clearStorage()
+        smda_report = SmdaReport.fromFile(self.example_file_path)
+        self.storage.addSmdaReport(smda_report)
+        # give a subset of the 10 functions minhashes, leave the others unhashed
+        minhashes = [MinHash(function_id=function_id, minhash_signature=[0x30 + function_id + index for index in range(10)], minhash_bits=8) for function_id in [0, 2, 3, 5, 7, 8]]
+        self.storage.addMinHashes(minhashes)
+        band_collections = ["band_%d" % band_id for band_id in range(self._storage_config.STORAGE_NUM_BANDS)]
+
+        def dumpBands():
+            return {
+                collection: sorted((document["band_hash"], sorted(document["function_ids"])) for document in self.storage._getDb()[collection].find({}, {"_id": 0}))
+                for collection in band_collections
+            }
+
+        bands_before = dumpBands()
+        # a batch size of 2 forces the rebuild through multiple keyset pages
+        self.storage._minhash_config.MINHASH_BAND_REBUILD_WORK_PACKAGE_SIZE = 2
+        rebuild_result = self.storage.rebuildMinhashBandIndex()
+        self.assertEqual(len(minhashes), rebuild_result["minhash_functions_indexed"])
+        self.assertEqual(bands_before, dumpBands())
+
 
 if __name__ == "__main__":
     main()

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -420,6 +420,18 @@ class MongoDbStorageTest(MemoryStorageTest):
         self.assertEqual(17, counters.find_one({"name": "job"})["value"])
         self.assertTrue(counters.index_information()["name_1"].get("unique", False))
 
+    def testStorageInitializationCreatesIndexes(self):
+        expected_indexed_fields = {
+            "samples": {"sample_id", "sha256", "family_id"},
+            "families": {"family_id", "family_name"},
+            "functions": {"function_id", "sample_id", "family_id", "function_name", "_pichash", "_picblockhashes.hash", "_picblockhashes.offset"},
+            "query_samples": {"sample_id", "sha256"},
+        }
+        for collection, expected_fields in expected_indexed_fields.items():
+            index_information = self.storage._getDb()[collection].index_information()
+            indexed_fields = set(key for index in index_information.values() for key, _direction in index["key"])
+            self.assertTrue(expected_fields.issubset(indexed_fields), f"missing indexes on {collection}: {expected_fields - indexed_fields}")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -178,6 +178,15 @@ class MemoryStorageTest(TestCase):
         self.assertEqual(new_report_d.sample_id, 4)
         self.assertTrue(self.storage.isFunctionId(49))
 
+    def testGetSampleBySha256(self):
+        self.storage.clearStorage()
+        # an empty collection must yield None straight from the lookup, without a count-based emptiness guard
+        self.assertEqual(None, self.storage.getSampleBySha256(64 * "0"))
+        smda_report = SmdaReport.fromFile(self.example_file_path)
+        sample_entry = self.storage.addSmdaReport(smda_report)
+        self.assertEqual(sample_entry.sample_id, self.storage.getSampleBySha256(smda_report.sha256).sample_id)
+        self.assertEqual(None, self.storage.getSampleBySha256(64 * "0"))
+
     def testFunctionHandling(self):
         self.storage.clearStorage()
         # TODO use SmdaReport.fromFile
@@ -431,6 +440,15 @@ class MongoDbStorageTest(MemoryStorageTest):
             index_information = self.storage._getDb()[collection].index_information()
             indexed_fields = set(key for index in index_information.values() for key, _direction in index["key"])
             self.assertTrue(expected_fields.issubset(indexed_fields), f"missing indexes on {collection}: {expected_fields - indexed_fields}")
+
+    def testGetSampleBySha256ForQuerySamples(self):
+        self.storage.clearStorage()
+        self.assertEqual(None, self.storage.getSampleBySha256(64 * "0", is_query=True))
+        smda_report = SmdaReport.fromFile(self.example_file_path)
+        query_entry = self.storage.addSmdaReport(smda_report, isQuery=True)
+        self.assertEqual(query_entry.sample_id, self.storage.getSampleBySha256(smda_report.sha256, is_query=True).sample_id)
+        # the regular sample collection must remain unaffected
+        self.assertEqual(None, self.storage.getSampleBySha256(smda_report.sha256))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #115

Three small, independent storage-layer fixes, one commit each so they can be
cherry-picked individually. The issue's fourth item (transpiler layering) is
**not** included: #100 already fixes it, and more thoroughly — besides removing
the unbound `_encodePichash(None, condition)` call it also fixes a real crash
(`hex()` on an operator dict, so `pichash!=0x1234` raised `TypeError`) and makes
the encode/decode helpers static. Nothing to add there; item 4 of #115 should be
ticked off by #100. Where the issue flagged its diagnosis as inferred,
it has been confirmed by measurement first; each item below is tagged.

| # | item | change | evidence |
|---|------|--------|----------|
| 1 | missing indexes | `_ensureIndexAndUnknownFamily` now also indexes `samples.sha256`, `samples.family_id`, `families.family_name`, `functions.family_id`, `functions.function_name` (and `query_samples.sha256`, which serves the same `getSampleBySha256` lookup) | **measured** — explain() on a live 11.7M-function instance |
| 2 | count-before-find | `getSampleBySha256` no longer runs `count_documents(filter={})` before the `find_one`; `find_one` returning `None` answers the emptiness question | **inferred** (semantically redundant guard); behavior pinned by tests |
| 3 | skip() paging | `rebuildMinhashBandIndex` pages by keyset on the indexed `function_id` instead of `.skip(offset).limit(n)` | **measured** — synthetic 250k/500k-function corpora |

## Item 1 — indexes (measured)

All five fields are filtered in current code: `samples.sha256` by
`getSampleBySha256` (every submit/import dedup check), `samples.family_id` by
`getSamplesByFamilyId`/`modifyFamily`/`deleteFamily`, `functions.family_id` by
`modifyFamily`/`deleteFamily` (`update_many` filters), `families.family_name` by
`getFamilyId`/`addFamily`/`findFamilyByString`, and `functions.function_name` by
`findFunctionByString`.

`explain("executionStats")` on a live instance (8,689 samples / 11,665,054
functions / 2,175 families), read-only, before the change:

| query shape | plan | nReturned | docsExamined | execMs |
|---|---|---|---|---|
| `samples.find({sha256})` | COLLSCAN | 1 | 8,689 | 25 |
| `samples.find({family_id})` | COLLSCAN | 327 | 8,689 | 5 |
| `functions.find({family_id})` | COLLSCAN | 310,944 | 11,665,054 | 141,689 |
| `families.find({family_name})` | COLLSCAN | 1 | 2,175 | 4 |
| `functions.find({function_name})` | COLLSCAN | 102 | 11,665,054 | 150,029 |

Every shape scans the full collection with `keysExamined=0`; the two
functions-collection shapes each walk ~48 GB of documents and take 2.4–2.5
minutes per query on that instance.

Index size cost, anchored on `collStats` of existing indexes on the same
instance (`functions.sample_id` = 51.1 MB, `functions._pichash` = 258.1 MB):
`functions.family_id` ~50 MB, `functions.function_name` ~150–300 MB (string
keys, prefix-compressed), the three samples/families indexes ~1 MB combined —
small next to the ~2.3 GB the existing functions indexes already occupy.
For the search regex case (`?` operator, case-insensitive), the new string
indexes still help: an index scan over keys replaces fetching every document.

## Item 2 — count-before-find (inferred, behavior pinned by tests)

The `count_documents(filter={})` emptiness guard in `getSampleBySha256` ran a
full collection count before every lookup; `find_one` on an empty collection
already returns `None`. With item 1 the `find_one` is an index hit and the
count was the remaining full-collection touch on the submit dedup path.
No other count-before-find instances exist in the file — the remaining
`count_documents` calls feed progress totals. Tests cover empty-collection,
found, and missing-sha256 cases for both the regular and query collections.

## Item 3 — keyset paging (measured)

`skip(offset)` walks and discards all skipped documents server-side, so a full
pass is O(n²) in collection size. The rebuild now carries `last_function_id`
forward and pages with `{"function_id": {"$gt": last_function_id}}` +
`sort("function_id", 1)` on the already-indexed field — no schema change.

Synthetic corpora of minimal `{function_id, minhash}` docs on a throwaway
mongo:5.0, batch size 10,000, band writes kept negligible (1 in 50 docs carries
a minhash) so the paging cost dominates:

| corpus | old skip() | new keyset | speedup |
|---|---|---|---|
| 125,000 docs | 0.44 s | 0.27 s | 1.65x |
| 250,000 docs | 1.29 s | 0.64 s | 2.03x |
| 500,000 docs | 4.52 s | 1.27 s | 3.57x |

(mean of 2 ABBA-interleaved passes each; both variants accumulate a document
count and `sum(function_id)` per pass and agree exactly at every size.)

The scaling is what confirms the diagnosis, not the speedup itself. Per
doubling, `skip()` grows ×2.9 then ×3.5 — superlinear, converging on the ×4
an O(n²) pass predicts — while keyset grows ×2.4 then ×2.0, i.e. linearly.
The advantage therefore widens with collection size; **extrapolated, not
measured**, the live 11.7M-function collection is ~23x the largest point here,
putting the `skip()` path in the tens of minutes of pure paging overhead.

Result identity is pinned separately by a unit test comparing full band
collection dumps against the incrementally built state across multiple keyset
pages.

The other `skip()` sites — `getSamples` (:587/:590) and `getFunctions` (:755)
— implement user-facing pagination (`start_index`/`limit` API semantics on
`SampleResource`/`FunctionResource`) and are intentionally left unchanged:
they serve one page per request, not a full pass.

## Tests

- `MemoryStorageTest`/`MongoDbStorageTest.testGetSampleBySha256` (item 2, both backends)
- `MongoDbStorageTest.testGetSampleBySha256ForQuerySamples` (item 2, query collection)
- `MongoDbStorageTest.testStorageInitializationCreatesIndexes` (item 1)
- `MongoDbStorageTest.testRebuildMinhashBandIndexMatchesIncrementalBands` (item 3)

Full suite (mcrit-server:1.6.0 image + throwaway mongod): **100 passed, 5
subtests passed, 0 failed** (95 baseline + 5 new). The 1.6.1 image carries
smda 4.4.5, which fails 4 `testMatcher` expectations on unmodified main — a
separate pre-existing issue, unrelated to this PR.

Raw evidence: `session-06/results/115-explain-evidence.md` (item 1),
`session-06/results/115-keyset-timing.md` (item 3).
---

**Coordination:** item 1 touches `_ensureIndexAndUnknownFamily` alongside the storage PRs for #105 and #109 (trivial textual conflict, no semantic interaction). Item 4 of the issue is deliberately left to #100, see above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwSfzAD1ZwEoWY3eWvbYvX
