### PR TITLE
Fix repair()'s stale-lock threshold: timedelta days vs seconds

### DIFF
--- a/mcrit/libs/mongoqueue.py
+++ b/mcrit/libs/mongoqueue.py
@@ -212,9 +212,18 @@ class MongoQueue:
         """Clear out stale locks.
 
         Increments per job attempt counter.
+
+        NOTE: this currently has no callers. Before wiring it up, be aware that the
+        staleness threshold only means what it says for jobs that refresh their lock:
+        `locked_at` is only bumped by Job.progressor(), and a matcher running as a single
+        batch never steps its progress reporter, so a long job can look "stale" while it
+        is healthily running. Reclaiming it would decrement attempts_left underneath a
+        live worker.
         """
         self._getCollection().find_one_and_update(
-            filter={"locked_by": {"$ne": None}, "locked_at": {"$lt": datetime.now() - timedelta(self.timeout)}},
+            # timedelta()'s first positional argument is DAYS: the timeout, which is
+            # seconds everywhere else (QUEUE_TIMEOUT, default 300), has to be named
+            filter={"locked_by": {"$ne": None}, "locked_at": {"$lt": datetime.now() - timedelta(seconds=self.timeout)}},
             update={"$set": {"locked_by": None, "locked_at": None}, "$inc": {"attempts_left": -1}},
         )
 

--- a/tests/testMongoQueue.py
+++ b/tests/testMongoQueue.py
@@ -2,7 +2,7 @@ import logging
 import os
 import time
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest import TestCase
 
 import pymongo
@@ -60,6 +60,35 @@ class MongoQueueTest(TestCase):
         job = self.queue.next()
         job.complete()
         self.assertEqual(self.queue.size(), 0)
+
+    def test_repair_uses_seconds_not_days(self):
+        # timedelta()'s first positional argument is days, so the seconds-denominated
+        # timeout (QUEUE_TIMEOUT, default 300) used to describe 300 DAYS and repair()
+        # could never reclaim anything
+        data = {"method": "test_method", "context_id": "alpha", "data": [1]}
+        self.queue.put(data)
+        job = self.queue.next()
+        self.assertIsNotNone(job.job_id)
+        # age the lock past the timeout without touching anything else
+        stale_locked_at = datetime.now() - timedelta(seconds=self.queue.timeout + 60)
+        self.queue.collection.update_one({"_id": job.job_id}, {"$set": {"locked_at": stale_locked_at}})
+        self.queue.repair()
+        repaired = self.queue.collection.find_one({"_id": job.job_id})
+        self.assertIsNone(repaired["locked_by"])
+        self.assertIsNone(repaired["locked_at"])
+        self.assertEqual(repaired["attempts_left"], self.queue.max_attempts - 1)
+        # and the job is claimable again
+        self.assertIsNotNone(self.queue.next().job_id)
+
+    def test_repair_leaves_fresh_locks_alone(self):
+        data = {"method": "test_method", "context_id": "alpha", "data": [1]}
+        self.queue.put(data)
+        job = self.queue.next()
+        self.queue.repair()
+        untouched = self.queue.collection.find_one({"_id": job.job_id})
+        self.assertEqual(untouched["locked_by"], self.queue.consumer_id)
+        self.assertIsNotNone(untouched["locked_at"])
+        self.assertEqual(untouched["attempts_left"], self.queue.max_attempts)
 
     def test_release(self):
         data = {"method": "test_method", "context_id": "alpha", "data": [1, 2, 3], "more-data": time.time()}


### PR DESCRIPTION
`MongoQueue.repair()` computes its staleness threshold as `timedelta(self.timeout)`. `timedelta()`'s first positional argument is **days**, while the timeout is seconds everywhere else (`QUEUE_TIMEOUT`, default 300, passed through `QueueFactory`). The filter therefore asks for locks older than **300 days**, and stale-lock repair could never fire on any realistic instance.

```python
filter={"locked_by": {"$ne": None}, "locked_at": {"$lt": datetime.now() - timedelta(self.timeout)}},
```

Found while reproducing #106 (see #133); reported there as a follow-up and split out here because it stands on its own.

## Scope: this is landmine removal, not a behaviour change

`repair()` has **no callers** in the codebase today (`self.timeout` is used nowhere else), so fixing the unit changes nothing at runtime — which is also what makes it safe to fix on its own.

**Wiring it up is a separate decision, and not a safe one to take casually.** `locked_at` is only refreshed by `Job.progressor()`, and `MatcherInterface` only steps its progress reporter when a job has more than one batch (`if self._num_batches > 1`). At the shipped `MINHASH_MATCHING_FUNCTION_BATCH_SIZE` of 10000, real matching jobs run as a *single* batch — on our corpus one such job takes ~250 s and larger ones considerably more — so they never heartbeat after the initial progress write. A 300 s reclaim threshold would therefore pull the lock out from under a perfectly healthy worker and decrement its `attempts_left`. I have left the method uncalled and recorded that constraint in its docstring rather than guessing at the right design; proper orphan detection probably wants worker liveness (a heartbeat with expiry) rather than a wall-clock lock age.

## Tests

Two cases in `tests/testMongoQueue.py`, both **measured** against a throwaway mongod:

- `test_repair_uses_seconds_not_days`: a lock aged past `timeout` is released (`locked_by`/`locked_at` cleared), `attempts_left` is decremented, and the job becomes claimable again. **This test fails on the unfixed code** (verified by reverting the one-line change: `1 failed, 11 passed`).
- `test_repair_leaves_fresh_locks_alone`: a freshly claimed job keeps its lock and its attempt count.

Full suite: **97 passed, 5 subtests passed, 0 failed** (95 baseline + 2 new), using an environment with smda 4.4.4. The `Unit tests` CI job will show four unrelated `testMatcher` failures here as it does on unmodified `main` — see #134.

---

**Coordination:** touches `mcrit/libs/mongoqueue.py`, as do #127 (`_ensure_indices`, `_jobs_in_progress`) and #133 (`next()`, `Job.progressor()`). All three edit different methods; expect at most a trivial textual conflict for whichever merges later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwSfzAD1ZwEoWY3eWvbYvX
