### PR TITLE
Record that docs/TUNING.md is canonical here and mirrored into docker-mcrit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,13 @@ For the full methodology (PicHash/MinHash, LSH banding, case studies) see [`READ
 - `examples/`, `experiments/`, `diagnosis/` — auxiliary scripts.
 - `setup.py`, `requirements.txt`, `ruff.toml`, `pytest.ini` — build/config.
 
+`docs/TUNING.md` is mirrored verbatim into the [docker-mcrit](https://github.com/danielplohmann/docker-mcrit)
+deployment repository. This repository holds the canonical copy, because the document describes the
+defaults in `MinHashConfig` and `StorageConfig`: changing one of those defaults, or adding a knob,
+should update `docs/TUNING.md` in the same commit, then be copied downstream. Never edit the
+docker-mcrit copy directly - it silently diverged that way once already, and a release shipped tuning
+advice that had stopped being true.
+
 ## Development setup
 
 Requires **Python 3.11 or 3.12**.

--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -1,5 +1,11 @@
 # Tuning an MCRIT deployment
 
+> **Canonical copy:** `docs/TUNING.md` in the [mcrit](https://github.com/danielplohmann/mcrit)
+> repository, which is where the config classes whose defaults this document describes live. The
+> copy in [docker-mcrit](https://github.com/danielplohmann/docker-mcrit) is a verbatim mirror:
+> edit mcrit's, then copy the file over, and never the other way round. A change to a default in
+> `MinHashConfig` or `StorageConfig` should update this document in the same commit.
+
 These recommendations come from a benchmarking campaign against a real Malpedia corpus
 (11,697,468 functions / 8,483 samples / 2,175 families, 20 bands `{4:20}`, threshold 50) on an
 8-core / 32 GiB host with mongod 5.0. Roughly 200 full matching jobs were measured across 81


### PR DESCRIPTION
Follow-up to #139, which fixed the symptom (a stale mirror) without recording the policy that prevents it.

`docs/TUNING.md` lives in this repository and in [docker-mcrit](https://github.com/danielplohmann/docker-mcrit). Nothing stated which way copies flow, and they diverged: docker-mcrit's copy was revised for 1.6.1 while the untracked copy here was not, so 1.6.2 shipped tuning advice that had stopped being true.

- **Canonical here**, because the document describes defaults in `MinHashConfig` and `StorageConfig`. A default change and its documentation can only land in a single commit if they live in a single repository.
- **The note is in the document itself, not only in `AGENTS.md`** — docker-mcrit has no `AGENTS.md`, so an agent editing the mirror would never read a policy kept only here.
- **Same wording in both copies**, so they remain byte-identical and any future drift still shows up as a plain diff rather than as an expected difference to be ignored.

The matching note is pushed to docker-mcrit separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)