### PR TITLE
Split `_xcfg` out of the functions collection (#137)

### DIFF
--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -424,7 +424,8 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
         return infos
 
     def getStatus(self, with_pichash=True):
-        storage_stats = self.getStorage().getStats(with_pichash=with_pichash)
+        storage = self.getStorage()
+        storage_stats = storage.getStats(with_pichash=with_pichash)
         status = {
             "status": {
                 "db_state": storage_stats["db_state"],
@@ -437,6 +438,15 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
                 "num_pichashes": storage_stats["num_pichashes"],
             }
         }
+        # operator signal for a half-migrated instance (#137): the inline fallback keeps serving
+        # correct, but the split's space reclamation only happens once migrate_xcfg_split ran.
+        # Omitted rather than False when a backend cannot determine it cheaply.
+        inline_xcfg_remaining = None
+        storage_inline_check = getattr(storage, "hasInlineXcfgRemaining", None)
+        if callable(storage_inline_check):
+            inline_xcfg_remaining = storage_inline_check()
+        if inline_xcfg_remaining is not None:
+            status["status"]["inline_xcfg_remaining"] = inline_xcfg_remaining
         return status
 
     def getVersion(self):

--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -440,11 +440,9 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
         }
         # operator signal for a half-migrated instance (#137): the inline fallback keeps serving
         # correct, but the split's space reclamation only happens once migrate_xcfg_split ran.
-        # Omitted rather than False when a backend cannot determine it cheaply.
-        inline_xcfg_remaining = None
-        storage_inline_check = getattr(storage, "hasInlineXcfgRemaining", None)
-        if callable(storage_inline_check):
-            inline_xcfg_remaining = storage_inline_check()
+        # Every storage answers this - the interface default is None ("not applicable") - so the
+        # field is simply omitted when a backend cannot determine it.
+        inline_xcfg_remaining = storage.hasInlineXcfgRemaining()
         if inline_xcfg_remaining is not None:
             status["status"]["inline_xcfg_remaining"] = inline_xcfg_remaining
         return status

--- a/mcrit/migrations/migrate_xcfg_split.py
+++ b/mcrit/migrations/migrate_xcfg_split.py
@@ -27,7 +27,7 @@ import sys
 import time
 from datetime import UTC, datetime
 
-from pymongo import ASCENDING, MongoClient, UpdateOne
+from pymongo import ASCENDING, MongoClient, ReplaceOne, UpdateOne
 
 from mcrit.config.McritConfig import McritConfig
 
@@ -52,10 +52,29 @@ def put_state(target_db, state):
     target_db[STATE_COLLECTION].replace_one({"_id": state["_id"]}, state, upsert=True)
 
 
+def recreate_indexes(source_db, target_db, collection_name):
+    """Rebuild every secondary index, carrying over its options.
+
+    Only key order and `unique` would survive a hand-rolled copy; TTL, sparse,
+    partialFilterExpression and friends live in the spec alongside them and are lost if
+    not forwarded - so forward everything the server reports except the fields
+    `create_index` derives itself.
+    """
+    for index in source_db[collection_name].list_indexes():
+        keys = list(index["key"].items())
+        if keys == [("_id", 1)]:
+            continue
+        options = {key: value for key, value in index.items() if key not in ("key", "v", "name", "ns")}
+        target_db[collection_name].create_index(keys, **options)
+        log("  recreated index %s %s" % (keys, options or ""))
+
+
 def copy_verbatim(source_db, target_db, batch_size):
     names = [n for n in source_db.list_collection_names() if n in VERBATIM_COLLECTIONS or n.startswith(VERBATIM_PREFIXES)]
     for name in sorted(names):
-        if target_db[name].estimated_document_count() >= source_db[name].estimated_document_count():
+        # exact counts, not estimated_document_count(): the estimate reads cached collection
+        # metadata and can misread a partially copied target as "already present"
+        if target_db[name].count_documents({}) >= source_db[name].count_documents({}):
             log("verbatim %s already present, skipping" % name)
             continue
         target_db[name].drop()
@@ -70,12 +89,7 @@ def copy_verbatim(source_db, target_db, batch_size):
         if batch:
             target_db[name].insert_many(batch, ordered=False)
             copied += len(batch)
-        # recreate the indexes the matching path relies on
-        for index in source_db[name].list_indexes():
-            keys = list(index["key"].items())
-            if keys == [("_id", 1)]:
-                continue
-            target_db[name].create_index(keys, unique=index.get("unique", False))
+        recreate_indexes(source_db, target_db, name)
         log("verbatim %s: %d documents" % (name, copied))
 
 
@@ -115,7 +129,10 @@ def migrate_functions(source_db, target_db, mode, batch_size, limit, source_coll
             # copy the function documents themselves, minus the blob
             function_documents = list(source_db[source_collection].find({"function_id": {"$in": function_ids_done}}, {"_xcfg": 0}))
             if function_documents:
-                target_db[source_collection].insert_many(function_documents, ordered=False)
+                # upserts, not insert_many: a resume can re-enter the batch whose inserts
+                # landed before the state save was killed - plain inserts would die on
+                # duplicate _id there and make copy mode unresumable
+                target_db[source_collection].bulk_write([ReplaceOne({"_id": document["_id"]}, document, upsert=True) for document in function_documents], ordered=False)
         elif mode == "inplace":
             # only now that the xcfg documents are durable, drop the blobs. Restricted to
             # ids we just wrote, so a crash can never unset an xcfg that was not saved.
@@ -139,12 +156,7 @@ def migrate_functions(source_db, target_db, mode, batch_size, limit, source_coll
         # without these the target is not a like-for-like copy and any benchmark against it
         # measures missing indexes rather than the schema change
         index_started = time.perf_counter()
-        for index in source_db[source_collection].list_indexes():
-            keys = list(index["key"].items())
-            if keys == [("_id", 1)]:
-                continue
-            target_db[source_collection].create_index(keys, unique=index.get("unique", False))
-            log("  recreated index %s" % keys)
+        recreate_indexes(source_db, target_db, source_collection)
         log("indexes rebuilt in %.1f s" % (time.perf_counter() - index_started))
 
     elapsed = time.perf_counter() - started
@@ -243,17 +255,25 @@ def verify(source_db, target_db, sample_size, source_collection, xcfg_collection
     # After an inplace migration the source no longer holds blobs, so content comparison is
     # impossible - saying "problems: []" then would be a silent pass. Check coverage instead and
     # label what was actually established.
-    coverage_gaps = []
+    gap_function_ids = []
     if checked == 0 and empty_source:
-        blob_ids = {document["_id"] for document in target_db[xcfg_collection].find({}, {"_id": 1})}
-        function_filter = dict(range_filter)
-        for document in source_db[source_collection].find(function_filter, {"function_id": 1, "_id": 0}).limit(200000):
-            if document["function_id"] not in blob_ids:
-                coverage_gaps.append(document["function_id"])
-                if len(coverage_gaps) >= 20:
-                    break
-        if coverage_gaps:
-            problems.append("no blob document for function ids %s%s" % (coverage_gaps[:5], " (and more)" if len(coverage_gaps) >= 20 else ""))
+        # probe the sampled function ids against the blob collection in batches instead of
+        # materializing every blob _id: at production scale that set alone would not fit memory
+        function_ids = [document["function_id"] for document in source_db[source_collection].find(range_filter, {"function_id": 1, "_id": 0}).limit(200000)]
+        covered_ids = set()
+        for start in range(0, len(function_ids), 10000):
+            chunk = function_ids[start : start + 10000]
+            covered_ids.update(document["_id"] for document in target_db[xcfg_collection].find({"_id": {"$in": chunk}}, {"_id": 1}))
+        gap_function_ids = [function_id for function_id in function_ids if function_id not in covered_ids]
+        if gap_function_ids:
+            problems.append(
+                "no blob document for %d of %d sampled function ids, e.g. %s"
+                % (
+                    len(gap_function_ids),
+                    len(function_ids),
+                    gap_function_ids[:5],
+                )
+            )
     return {
         "checked": checked,
         "established": (
@@ -261,7 +281,7 @@ def verify(source_db, target_db, sample_size, source_collection, xcfg_collection
             if checked
             else "coverage only - the source no longer holds blobs, so contents could not be compared (take a dump before an inplace run)"
         ),
-        "coverage_gaps_sampled": len(coverage_gaps),
+        "coverage_gaps_sampled": len(gap_function_ids),
         "verified_range_max_function_id": max_function_id,
         "empty_source": empty_source,
         "source_functions": source_count,

--- a/mcrit/migrations/migrate_xcfg_split.py
+++ b/mcrit/migrations/migrate_xcfg_split.py
@@ -104,6 +104,7 @@ def migrate_functions(source_db, target_db, mode, batch_size, limit, source_coll
     started = time.perf_counter()
     log("migrating %s (mode=%s) from function_id > %s" % (source_collection, mode, last_function_id))
 
+    finished = True
     while True:
         query = {} if last_function_id is None else {"function_id": {"$gt": last_function_id}}
         # keyset paging on the indexed function_id: skip() would re-walk the collection
@@ -150,6 +151,7 @@ def migrate_functions(source_db, target_db, mode, batch_size, limit, source_coll
             log("  %d migrated, %.0f docs/s, %.1f GB of xcfg moved" % (migrated, migrated / max(elapsed, 1e-9), xcfg_bytes / 1073741824))
         if limit and migrated >= limit:
             log("stopping at --limit %d" % limit)
+            finished = False
             break
 
     if mode == "copy":
@@ -158,6 +160,16 @@ def migrate_functions(source_db, target_db, mode, batch_size, limit, source_coll
         index_started = time.perf_counter()
         recreate_indexes(source_db, target_db, source_collection)
         log("indexes rebuilt in %.1f s" % (time.perf_counter() - index_started))
+
+    if finished:
+        # terminal marker, read by MongoDbStorage.hasInlineXcfgRemaining: an inplace phase that
+        # drained guarantees no inline `_xcfg` remains (the $unset only runs after the blob write),
+        # so storage can report the migrated state O(1) instead of COLLSCAN-ing functions to prove
+        # a negative. A --limit run deliberately writes none. unsplit deletes state documents, so
+        # a rollback also removes the marker.
+        state["finished_at"] = datetime.now(UTC).isoformat()
+        put_state(target_db, state)
+        log("phase finished, terminal marker written")
 
     elapsed = time.perf_counter() - started
     log("done: %d documents, %.1f GB xcfg, %.1f s (%.0f docs/s)" % (migrated, xcfg_bytes / 1073741824, elapsed, migrated / max(elapsed, 1e-9)))

--- a/mcrit/migrations/migrate_xcfg_split.py
+++ b/mcrit/migrations/migrate_xcfg_split.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""C1 migration: move `_xcfg` out of `functions` into its own collection.
+
+Two modes, sharing one code path so the rehearsal exercises the real thing:
+
+  copy    - read SOURCE read-only, write the migrated shape into TARGET. Used to
+            rehearse against production data without touching it, and to measure
+            what the real migration will cost.
+  inplace - the production migration: write each batch's xcfg documents, then
+            $unset `_xcfg` on those functions only after the write is durable.
+
+Both are **resumable**: progress is a keyset cursor (last migrated function_id) kept
+in a state document, so a killed run costs only the batch in flight. Re-running after
+completion is a no-op. Neither mode deletes anything the other copy does not already
+hold - `inplace` only unsets `_xcfg` for ids whose xcfg document is confirmed present.
+
+Usage:
+    python -m mcrit.migrations.migrate_xcfg_split --mode copy --target mcrit_rehearsal
+    python -m mcrit.migrations.migrate_xcfg_split --mode verify --target mcrit_rehearsal
+    python -m mcrit.migrations.migrate_xcfg_split --mode inplace
+    python -m mcrit.migrations.migrate_xcfg_split --mode unsplit   # rollback
+"""
+
+import argparse
+import json
+import sys
+import time
+from datetime import UTC, datetime
+
+from pymongo import ASCENDING, MongoClient, UpdateOne
+
+from mcrit.config.McritConfig import McritConfig
+
+STATE_COLLECTION = "c1_migration_state"
+XCFG_COLLECTION = "xcfg"
+# collections copied verbatim in copy mode, so the rehearsal target can serve a real
+# matching job (bands + sample/family metadata + the counters ids are drawn from)
+VERBATIM_PREFIXES = ("band_",)
+VERBATIM_COLLECTIONS = ("samples", "families", "counters", "query_samples")
+
+
+def log(message):
+    print("%s %s" % (datetime.now(UTC).strftime("%H:%M:%S"), message), flush=True)
+
+
+def get_state(target_db, key):
+    document = target_db[STATE_COLLECTION].find_one({"_id": key})
+    return document or {"_id": key, "last_function_id": None, "migrated": 0, "started_at": None}
+
+
+def put_state(target_db, state):
+    target_db[STATE_COLLECTION].replace_one({"_id": state["_id"]}, state, upsert=True)
+
+
+def copy_verbatim(source_db, target_db, batch_size):
+    names = [n for n in source_db.list_collection_names() if n in VERBATIM_COLLECTIONS or n.startswith(VERBATIM_PREFIXES)]
+    for name in sorted(names):
+        if target_db[name].estimated_document_count() >= source_db[name].estimated_document_count():
+            log("verbatim %s already present, skipping" % name)
+            continue
+        target_db[name].drop()
+        copied = 0
+        batch = []
+        for document in source_db[name].find({}):
+            batch.append(document)
+            if len(batch) >= batch_size:
+                target_db[name].insert_many(batch, ordered=False)
+                copied += len(batch)
+                batch = []
+        if batch:
+            target_db[name].insert_many(batch, ordered=False)
+            copied += len(batch)
+        # recreate the indexes the matching path relies on
+        for index in source_db[name].list_indexes():
+            keys = list(index["key"].items())
+            if keys == [("_id", 1)]:
+                continue
+            target_db[name].create_index(keys, unique=index.get("unique", False))
+        log("verbatim %s: %d documents" % (name, copied))
+
+
+def migrate_functions(source_db, target_db, mode, batch_size, limit, source_collection, xcfg_collection):
+    state_key = "%s:%s:%s" % (mode, source_collection, xcfg_collection)
+    state = get_state(target_db, state_key)
+    if state["started_at"] is None:
+        state["started_at"] = datetime.now(UTC).isoformat()
+    last_function_id = state["last_function_id"]
+    migrated = state["migrated"]
+    xcfg_bytes = 0
+    started = time.perf_counter()
+    log("migrating %s (mode=%s) from function_id > %s" % (source_collection, mode, last_function_id))
+
+    while True:
+        query = {} if last_function_id is None else {"function_id": {"$gt": last_function_id}}
+        # keyset paging on the indexed function_id: skip() would re-walk the collection
+        documents = list(source_db[source_collection].find(query, {"function_id": 1, "_xcfg": 1, "_id": 0}).sort("function_id", ASCENDING).limit(batch_size))
+        if not documents:
+            break
+
+        xcfg_documents = []
+        function_ids_done = []
+        for document in documents:
+            function_id = document["function_id"]
+            function_ids_done.append(function_id)
+            xcfg = document.get("_xcfg")
+            if xcfg:
+                xcfg_bytes += len(xcfg)
+                # _id IS the function_id: no secondary index needed, one lookup, minimal storage
+                xcfg_documents.append(UpdateOne({"_id": function_id}, {"$set": {"_xcfg": xcfg}}, upsert=True))
+
+        if xcfg_documents:
+            target_db[xcfg_collection].bulk_write(xcfg_documents, ordered=False)
+
+        if mode == "copy":
+            # copy the function documents themselves, minus the blob
+            function_documents = list(source_db[source_collection].find({"function_id": {"$in": function_ids_done}}, {"_xcfg": 0}))
+            if function_documents:
+                target_db[source_collection].insert_many(function_documents, ordered=False)
+        elif mode == "inplace":
+            # only now that the xcfg documents are durable, drop the blobs. Restricted to
+            # ids we just wrote, so a crash can never unset an xcfg that was not saved.
+            written_ids = [op._filter["_id"] for op in xcfg_documents]
+            if written_ids:
+                source_db[source_collection].update_many({"function_id": {"$in": written_ids}}, {"$unset": {"_xcfg": ""}})
+
+        last_function_id = function_ids_done[-1]
+        migrated += len(documents)
+        state.update({"last_function_id": last_function_id, "migrated": migrated})
+        put_state(target_db, state)
+
+        if migrated % (batch_size * 10) == 0:
+            elapsed = time.perf_counter() - started
+            log("  %d migrated, %.0f docs/s, %.1f GB of xcfg moved" % (migrated, migrated / max(elapsed, 1e-9), xcfg_bytes / 1073741824))
+        if limit and migrated >= limit:
+            log("stopping at --limit %d" % limit)
+            break
+
+    if mode == "copy":
+        # without these the target is not a like-for-like copy and any benchmark against it
+        # measures missing indexes rather than the schema change
+        index_started = time.perf_counter()
+        for index in source_db[source_collection].list_indexes():
+            keys = list(index["key"].items())
+            if keys == [("_id", 1)]:
+                continue
+            target_db[source_collection].create_index(keys, unique=index.get("unique", False))
+            log("  recreated index %s" % keys)
+        log("indexes rebuilt in %.1f s" % (time.perf_counter() - index_started))
+
+    elapsed = time.perf_counter() - started
+    log("done: %d documents, %.1f GB xcfg, %.1f s (%.0f docs/s)" % (migrated, xcfg_bytes / 1073741824, elapsed, migrated / max(elapsed, 1e-9)))
+    return {"migrated": migrated, "xcfg_bytes": xcfg_bytes, "seconds": elapsed}
+
+
+def unsplit(db, batch_size, source_collection, xcfg_collection):
+    """Rollback: write `_xcfg` back into the function documents and drop the blob collection.
+
+    Needed because rollback is only free before the `$unset` phase of an inplace migration.
+    After it, the blobs exist ONLY in the split collection, so undoing the migration means
+    putting them back - this is that inverse. Same ordering discipline as forward: a function
+    document is only updated from a blob that was read successfully, and the blob collection is
+    dropped at the very end, so an interrupted run leaves duplicated data rather than none.
+    """
+    restored = 0
+    missing = 0
+    started = time.perf_counter()
+    last_id = None
+    while True:
+        query = {} if last_id is None else {"_id": {"$gt": last_id}}
+        blob_documents = list(db[xcfg_collection].find(query).sort("_id", ASCENDING).limit(batch_size))
+        if not blob_documents:
+            break
+        operations = []
+        for blob_document in blob_documents:
+            operations.append(UpdateOne({"function_id": blob_document["_id"]}, {"$set": {"_xcfg": blob_document["_xcfg"]}}))
+        result = db[source_collection].bulk_write(operations, ordered=False)
+        restored += result.matched_count
+        missing += len(operations) - result.matched_count
+        last_id = blob_documents[-1]["_id"]
+        if restored % (batch_size * 10) == 0:
+            log("  %d restored, %d without a function document, %.0f docs/s" % (restored, missing, restored / max(time.perf_counter() - started, 1e-9)))
+    log("restored %d blobs (%d had no matching function document) in %.1f s" % (restored, missing, time.perf_counter() - started))
+    # Clear the forward migration's resume state. Without this a later re-migration finds the
+    # cursor at the end, does nothing, and logs "done" - a silent no-op after a rollback.
+    state_result = db[STATE_COLLECTION].delete_many({"_id": {"$regex": ":%s:%s$" % (source_collection, xcfg_collection)}})
+    if state_result.deleted_count:
+        log("cleared %d migration state document(s) so a re-migration starts from the beginning" % state_result.deleted_count)
+    dropped = False
+    if missing:
+        # dropping now would destroy blobs whose function document is gone - keep them and say so
+        log("KEEPING %s: %d blobs have no matching function document and would be lost" % (xcfg_collection, missing))
+    else:
+        db[xcfg_collection].drop()
+        dropped = True
+        log("dropped %s: every blob was restored into a function document" % xcfg_collection)
+    return {
+        "restored": restored,
+        "orphaned_blobs": missing,
+        "dropped_blob_collection": dropped,
+        "cleared_state_documents": state_result.deleted_count,
+        "seconds": time.perf_counter() - started,
+    }
+
+
+def verify(source_db, target_db, sample_size, source_collection, xcfg_collection, max_function_id=None):
+    """Spot-check that no xcfg was lost or altered, and that counts line up.
+
+    Sampling is restricted to the range the migration has actually reached, taken from the
+    resume state unless overridden, so a partial rehearsal can be verified without every
+    not-yet-migrated function being reported as a loss.
+    """
+    problems = []
+    # exact counts, not estimated_document_count(): the latter reads cached collection
+    # metadata and was measured 36,662 documents (0.3%) stale on the live instance, which
+    # would report a perfectly faithful migration as a count mismatch
+    source_count = source_db[source_collection].count_documents({})
+    target_count = target_db[source_collection].count_documents({})
+
+    if max_function_id is None:
+        for state_document in target_db[STATE_COLLECTION].find({"_id": {"$regex": ":%s:%s$" % (source_collection, xcfg_collection)}}):
+            if state_document.get("last_function_id") is not None:
+                max_function_id = max(max_function_id or 0, state_document["last_function_id"])
+    complete = max_function_id is None
+    if complete and target_count and source_count != target_count:
+        problems.append("function count mismatch: source %d target %d" % (source_count, target_count))
+
+    range_filter = {} if complete else {"function_id": {"$lte": max_function_id}}
+    pipeline = [{"$match": range_filter}, {"$sample": {"size": sample_size}}, {"$project": {"function_id": 1, "_xcfg": 1, "_id": 0}}]
+    checked = 0
+    empty_source = 0
+    for document in source_db[source_collection].aggregate(pipeline):
+        function_id = document["function_id"]
+        source_xcfg = document.get("_xcfg")
+        migrated = target_db[xcfg_collection].find_one({"_id": function_id})
+        if not source_xcfg:
+            empty_source += 1
+            continue
+        if migrated is None:
+            problems.append("function %d: no xcfg document in target" % function_id)
+        elif migrated["_xcfg"] != source_xcfg:
+            problems.append("function %d: xcfg differs (%d vs %d bytes)" % (function_id, len(source_xcfg), len(migrated["_xcfg"])))
+        checked += 1
+    # After an inplace migration the source no longer holds blobs, so content comparison is
+    # impossible - saying "problems: []" then would be a silent pass. Check coverage instead and
+    # label what was actually established.
+    coverage_gaps = []
+    if checked == 0 and empty_source:
+        blob_ids = {document["_id"] for document in target_db[xcfg_collection].find({}, {"_id": 1})}
+        function_filter = dict(range_filter)
+        for document in source_db[source_collection].find(function_filter, {"function_id": 1, "_id": 0}).limit(200000):
+            if document["function_id"] not in blob_ids:
+                coverage_gaps.append(document["function_id"])
+                if len(coverage_gaps) >= 20:
+                    break
+        if coverage_gaps:
+            problems.append("no blob document for function ids %s%s" % (coverage_gaps[:5], " (and more)" if len(coverage_gaps) >= 20 else ""))
+    return {
+        "checked": checked,
+        "established": (
+            "blob contents compared byte-for-byte"
+            if checked
+            else "coverage only - the source no longer holds blobs, so contents could not be compared (take a dump before an inplace run)"
+        ),
+        "coverage_gaps_sampled": len(coverage_gaps),
+        "verified_range_max_function_id": max_function_id,
+        "empty_source": empty_source,
+        "source_functions": source_count,
+        "target_functions": target_count,
+        "target_xcfg_documents": target_db[xcfg_collection].estimated_document_count(),
+        "problems": problems,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=["copy", "inplace", "verify", "unsplit"], required=True)
+    storage_config = McritConfig().STORAGE_CONFIG
+    parser.add_argument("--host", default=storage_config.STORAGE_SERVER)
+    parser.add_argument("--port", type=int, default=int(storage_config.STORAGE_PORT))
+    parser.add_argument("--source", default=storage_config.STORAGE_MONGODB_DBNAME)
+    parser.add_argument("--target", default=None, help="target DB for copy/verify; defaults to source for inplace")
+    parser.add_argument("--batch", type=int, default=2000)
+    parser.add_argument("--limit", type=int, default=0, help="stop after N functions (rehearsal/sampling)")
+    parser.add_argument("--sample", type=int, default=2000, help="verify: how many functions to spot-check")
+    parser.add_argument("--max-function-id", type=int, default=None, help="verify: cap the sampled range (defaults to how far the migration got)")
+    parser.add_argument("--include-query-functions", action="store_true")
+    parser.add_argument("--skip-verbatim", action="store_true")
+    parser.add_argument("--out", default=None)
+    args = parser.parse_args()
+
+    client = MongoClient("mongodb://%s:%d" % (args.host, args.port), connect=True)
+    source_db = client[args.source]
+    target_db = client[args.target] if args.target else source_db
+    if args.mode == "inplace" and args.target and args.target != args.source:
+        parser.error("inplace mode migrates within one database; drop --target")
+
+    result = {"mode": args.mode, "source": args.source, "target": args.target or args.source, "utc": datetime.now(UTC).isoformat()}
+
+    if args.mode == "unsplit":
+        result["functions"] = unsplit(source_db, args.batch, "functions", XCFG_COLLECTION)
+        if args.include_query_functions:
+            result["query_functions"] = unsplit(source_db, args.batch, "query_functions", "query_" + XCFG_COLLECTION)
+    elif args.mode == "verify":
+        result["functions"] = verify(source_db, target_db, args.sample, "functions", XCFG_COLLECTION, args.max_function_id)
+        if args.include_query_functions:
+            result["query_functions"] = verify(source_db, target_db, args.sample, "query_functions", "query_" + XCFG_COLLECTION, args.max_function_id)
+    else:
+        if args.mode == "copy" and not args.skip_verbatim:
+            copy_verbatim(source_db, target_db, args.batch)
+        result["functions"] = migrate_functions(source_db, target_db, args.mode, args.batch, args.limit, "functions", XCFG_COLLECTION)
+        if args.include_query_functions:
+            result["query_functions"] = migrate_functions(source_db, target_db, args.mode, args.batch, args.limit, "query_functions", "query_" + XCFG_COLLECTION)
+
+    print(json.dumps(result, indent=2, default=str))
+    if args.out:
+        with open(args.out, "w") as handle:
+            json.dump(result, handle, indent=2, default=str)
+    problems = result.get("functions", {}).get("problems") if args.mode == "verify" else None
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -168,7 +168,21 @@ class MongoDbStorage(StorageInterface):
         things are broken and scans the whole collection when healthy, so it must never sit on
         the job path - SpawningWorker runs each job as a fresh process, which would pay the scan
         (and the WiredTiger cache churn of walking the collection) once per job.
+
+        Decision order:
+        1. the terminal marker migrate_xcfg_split writes when an inplace phase drains is O(1)
+           and definitive for "migrated" - without it, the only honest answer to the healthy
+           case would be a full scan (~33s post-split), which no /status poll should pay
+        2. otherwise the bounded probe decides; it exits at the first hit in milliseconds
+           precisely in the un-migrated case, where the answer is needed
+
+        Only an inplace completion counts: copy mode migrating into a rehearsal target says
+        nothing about this instance. Instances migrated by a script version older than the
+        marker have no marker and fall through to the probe returning None (field omitted).
         """
+        completed_marker = self._getDb()["c1_migration_state"].find_one({"_id": "inplace:functions:xcfg", "finished_at": {"$exists": True}}, {"_id": 1})
+        if completed_marker:
+            return False
         try:
             return self._getDb().functions.find_one({"_xcfg": {"$exists": True}}, {"_id": 1}, max_time_ms=5000) is not None
         except Exception:

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -45,6 +45,9 @@ from mcrit.storage.SampleEntry import SampleEntry
 from mcrit.storage.StorageInterface import StorageInterface
 
 LOGGER = logging.getLogger(__name__)
+
+# one inline-`_xcfg` remnant probe per process (see _warnOnInlineXcfgRemaining)
+_INLINE_XCFG_CHECKED = False
 if MongoClient is None:
     LOGGER.warning("pymongo package import failed - MongoDB backend will not be available.")
 
@@ -159,7 +162,28 @@ class MongoDbStorage(StorageInterface):
         self._database = MongoClient(mongo_uri, connect=False)[db_name]
         self._ensureIndexAndUnknownFamily()
 
+    def _warnOnInlineXcfgRemaining(self) -> None:
+        """Announce an instance whose functions collection still carries inline disassembly (#137).
+
+        The split readers fall back to an inline `_xcfg`, so serving is correct before
+        migrate_xcfg_split has run - but leftover inline blobs also mean the migration has not
+        completed, and that is worth saying loudly rather than leaving the instance quietly on
+        the pre-split shape. Runs once per process: cheap while inline blobs exist (the probe
+        stops at the first hit), a single collection scan once everything is migrated.
+        """
+        global _INLINE_XCFG_CHECKED
+        if _INLINE_XCFG_CHECKED:
+            return
+        _INLINE_XCFG_CHECKED = True
+        if self._getDb().functions.find_one({"_xcfg": {"$exists": True}}, {"_id": 1}):
+            LOGGER.warning(
+                "The functions collection still carries inline _xcfg documents - mcrit.migrations.migrate_xcfg_split "
+                "has not run (or not finished). Serving falls back to the inline disassembly, but the #137 "
+                "split (and its space reclamation) only takes effect once the migration has completed."
+            )
+
     def _ensureIndexAndUnknownFamily(self) -> None:
+        self._warnOnInlineXcfgRemaining()
         if "settings" not in self._getDb().list_collection_names():
             self._getDb()["settings"].insert_one({"mcrit_db_id": str(uuid.uuid4()), "db_state": 0})
         self._getDb()["samples"].create_index("sample_id")
@@ -425,12 +449,17 @@ class MongoDbStorage(StorageInterface):
         the same shape: minhash computation (Worker.calculateMinHashes) and the code-reference
         extraction in match reports both read FunctionEntry.xcfg. Missing blobs decode to `{}`,
         never None - see getFunctionById for why that distinction matters.
+
+        An inline `_xcfg` is a fallback, not something to discard: this code ships before
+        migrate_xcfg_split has run, so an un-migrated or half-migrated instance still carries
+        blobs inside function documents. Overwriting those with `{}` would silently serve empty
+        disassembly to minhash computation and match reports.
         """
         if not function_documents:
             return
         blobs = self._fetchXcfgBlobs([document["function_id"] for document in function_documents])
         for function_document in function_documents:
-            function_document["_xcfg"] = blobs.get(function_document["function_id"], "{}")
+            function_document["_xcfg"] = blobs.get(function_document["function_id"]) or function_document.get("_xcfg") or "{}"
 
     def _deleteXcfgForFunctionIds(self, function_ids: List[int]) -> None:
         for collection in ("xcfg", "query_xcfg"):
@@ -1368,12 +1397,14 @@ class MongoDbStorage(StorageInterface):
             return None
         if with_xcfg:
             # the blob lives in its own collection now (#137); inject it so _decodeFunction
-            # and FunctionEntry see exactly the shape they saw before the split
+            # and FunctionEntry see exactly the shape they saw before the split. An inline
+            # `_xcfg` (pre-migration document, see _attachXcfgBlobs) is a fallback, not
+            # something to overwrite with an empty dict.
             # "{}" when no blob is stored, so the caller still gets an empty dict rather than
             # None: xcfg is None means "not requested", {} means "disassembly dropped". Before
             # the split that distinction came from the field being blanked in place instead of
             # removed, and it is part of the contract (tests/testStorage.py).
-            function_document["_xcfg"] = self._fetchXcfgBlobs([function_id]).get(function_id) or "{}"
+            function_document["_xcfg"] = self._fetchXcfgBlobs([function_id]).get(function_id) or function_document.get("_xcfg") or "{}"
         self._decodeFunction(function_document)
         return FunctionEntry.fromDict(function_document)
 
@@ -1528,11 +1559,12 @@ class MongoDbStorage(StorageInterface):
         xcfg_missing = 0
         for sample_id, sample_info in samples_to_be_updated.items():
             pic_hash_updates = []
-            sample_function_documents = list(self._getDb().functions.find({"sample_id": sample_id}, {"function_id": 1, "_pichash": 1, "_picblockhashes": 1, "_id": 0}))
-            # one $in for the whole sample rather than a lookup per function (#137)
+            sample_function_documents = list(self._getDb().functions.find({"sample_id": sample_id}, {"function_id": 1, "_pichash": 1, "_picblockhashes": 1, "_xcfg": 1, "_id": 0}))
+            # one $in for the whole sample rather than a lookup per function (#137); inline
+            # `_xcfg` is the fallback for pre-migration documents (see _attachXcfgBlobs)
             sample_xcfg_blobs = self._fetchXcfgBlobs([document["function_id"] for document in sample_function_documents])
             for function_document in sample_function_documents:
-                function_document["_xcfg"] = sample_xcfg_blobs.get(function_document["function_id"], "")
+                function_document["_xcfg"] = sample_xcfg_blobs.get(function_document["function_id"]) or function_document.get("_xcfg") or ""
                 update_document = {}
                 functions_updatable += 1
                 # create all relevant objects
@@ -1665,9 +1697,10 @@ class MongoDbStorage(StorageInterface):
             function_id_to_block_offsets[entry["function_id"]].append((entry["offset"], picblockhash))
         block_function_ids = list(function_id_to_block_offsets.keys())
         block_xcfg_blobs = self._fetchXcfgBlobs(block_function_ids)
-        for entry in self._getDb().functions.find({"function_id": {"$in": block_function_ids}}, {"function_id": 1, "_id": 0}):
+        for entry in self._getDb().functions.find({"function_id": {"$in": block_function_ids}}, {"function_id": 1, "_xcfg": 1, "_id": 0}):
             function_id = entry["function_id"]
-            entry["_xcfg"] = block_xcfg_blobs.get(function_id, "{}")
+            # inline `_xcfg` is the fallback for pre-migration documents (see _attachXcfgBlobs)
+            entry["_xcfg"] = block_xcfg_blobs.get(function_id) or entry.get("_xcfg") or "{}"
             self._decodeXcfg(entry)
             for block_offset, picblockhash in function_id_to_block_offsets[function_id]:
                 candidate_picblockhashes[picblockhash]["instructions"] = entry["xcfg"]["blocks"][str(block_offset)]

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -380,6 +380,64 @@ class MongoDbStorage(StorageInterface):
             if delete_old:
                 del function_dict["_xcfg"]
 
+    def _xcfgCollectionFor(self, function_id: int) -> str:
+        """Disassembly lives beside the function collection it belongs to, not mixed into one
+        collection keyed by sign (#137). Query functions carry negative ids."""
+        return "query_xcfg" if function_id < 0 else "xcfg"
+
+    def _extractXcfgDocuments(self, function_dicts: List[Dict]) -> Dict[str, List[Dict]]:
+        """Move `_xcfg` out of function documents into standalone documents, keyed by
+        collection name (#137).
+
+        `_id` IS the function id: no secondary index is needed, the lookup is the primary key,
+        and per-document overhead stays minimal. The function documents are mutated in place so
+        the caller inserts them without the blob.
+        """
+        extracted = {}
+        for function_dict in function_dicts:
+            blob = function_dict.pop("_xcfg", None)
+            if not blob:
+                continue
+            collection = self._xcfgCollectionFor(function_dict["function_id"])
+            extracted.setdefault(collection, []).append({"_id": function_dict["function_id"], "_xcfg": blob})
+        return extracted
+
+    def _insertXcfgDocuments(self, function_dicts: List[Dict]) -> None:
+        for collection, documents in self._extractXcfgDocuments(function_dicts).items():
+            self._dbInsertMany(collection, documents)
+
+    def _fetchXcfgBlobs(self, function_ids: List[int]) -> Dict[int, str]:
+        """One `$in` per collection for a whole batch of ids - never one query per function,
+        which is the N+1 shape #111 removed elsewhere."""
+        blobs = {}
+        for collection in ("xcfg", "query_xcfg"):
+            ids = [function_id for function_id in function_ids if self._xcfgCollectionFor(function_id) == collection]
+            if not ids:
+                continue
+            for document in self._getDb()[collection].find({"_id": {"$in": ids}}):
+                blobs[document["_id"]] = document["_xcfg"]
+        return blobs
+
+    def _attachXcfgBlobs(self, function_documents: List[Dict]) -> None:
+        """Put the split-out disassembly back onto function documents, one query per batch.
+
+        Used by the readers that carried `_xcfg` before the split, so their callers keep seeing
+        the same shape: minhash computation (Worker.calculateMinHashes) and the code-reference
+        extraction in match reports both read FunctionEntry.xcfg. Missing blobs decode to `{}`,
+        never None - see getFunctionById for why that distinction matters.
+        """
+        if not function_documents:
+            return
+        blobs = self._fetchXcfgBlobs([document["function_id"] for document in function_documents])
+        for function_document in function_documents:
+            function_document["_xcfg"] = blobs.get(function_document["function_id"], "{}")
+
+    def _deleteXcfgForFunctionIds(self, function_ids: List[int]) -> None:
+        for collection in ("xcfg", "query_xcfg"):
+            ids = [function_id for function_id in function_ids if self._xcfgCollectionFor(function_id) == collection]
+            if ids:
+                self._getDb()[collection].delete_many({"_id": {"$in": ids}})
+
     def _encodePichash(self, function_dict: Dict, delete_old: bool = True) -> None:
         if "pichash" in function_dict:
             function_dict["_pichash"] = hex(function_dict["pichash"])
@@ -474,6 +532,8 @@ class MongoDbStorage(StorageInterface):
             return False
         if sample_id < 0:
             # remove functions
+            query_function_ids = [document["function_id"] for document in self._getDb().query_functions.find({"sample_id": sample_id}, {"function_id": 1, "_id": 0})]
+            self._deleteXcfgForFunctionIds(query_function_ids)
             self._getDb().query_functions.delete_many({"sample_id": sample_id})
             # remove sample
             self._getDb().query_samples.delete_one({"sample_id": sample_id})
@@ -498,6 +558,7 @@ class MongoDbStorage(StorageInterface):
         # update family stats
         self._updateFamilyStats(sample_entry.family_id, -1, -sample_entry.statistics["num_functions"], -int(sample_entry.is_library))
         # remove functions
+        self._deleteXcfgForFunctionIds([function_minhash["function_id"] for function_minhash in function_minhashes])
         self._getDb().functions.delete_many({"sample_id": sample_id})
         # remove sample
         self._getDb().samples.delete_one({"sample_id": sample_id})
@@ -639,7 +700,9 @@ class MongoDbStorage(StorageInterface):
         return sample_entries
 
     def clearStorage(self) -> None:
-        collections = ["samples", "families", "functions", "matches", "candidates", "counters", "query_samples", "query_functions"]
+        # "xcfg"/"query_xcfg" hold the disassembly split out of the function documents (#137);
+        # leaving them behind while the counters reset would collide on _id at the next insert
+        collections = ["samples", "families", "functions", "matches", "candidates", "counters", "query_samples", "query_functions", "xcfg", "query_xcfg"]
         for band_id in range(self._storage_config.STORAGE_NUM_BANDS):
             collections.append("band_%d" % band_id)
         for c in collections:
@@ -697,6 +760,7 @@ class MongoDbStorage(StorageInterface):
             function_dicts = []
             for function_id, smda_function in zip(function_ids, smda_report.getFunctions()):
                 function_dicts.append(self._getFunctionDocument(sample_entry, smda_function, -1 * function_id))
+            self._insertXcfgDocuments(function_dicts)
             self._dbInsertMany("query_functions", function_dicts)
         else:
             if not self.getSampleBySha256(smda_report.sha256):
@@ -707,6 +771,7 @@ class MongoDbStorage(StorageInterface):
                 function_dicts = []
                 for function_id, smda_function in zip(function_ids, smda_report.getFunctions()):
                     function_dicts.append(self._getFunctionDocument(sample_entry, smda_function, function_id))
+                self._insertXcfgDocuments(function_dicts)
                 self._dbInsertMany("functions", function_dicts)
                 self._updateFamilyStats(family_id, +1, sample_entry.statistics["num_functions"], int(sample_entry.is_library))
                 self._updateDbState()
@@ -733,6 +798,7 @@ class MongoDbStorage(StorageInterface):
         # add function to regular storage
         function_dict = function_entry.toDict()
         self._encodeFunction(function_dict)
+        self._insertXcfgDocuments([function_dict])
         self._dbInsert("functions", function_dict)
         return function_entry
 
@@ -748,6 +814,7 @@ class MongoDbStorage(StorageInterface):
             function_dict = function_entry.toDict()
             self._encodeFunction(function_dict)
             functions_as_dicts.append(function_dict)
+        self._insertXcfgDocuments(functions_as_dicts)
         self._dbInsertMany("functions", functions_as_dicts)
         return function_entries
 
@@ -759,6 +826,7 @@ class MongoDbStorage(StorageInterface):
         else:
             function_dicts = list(self._getDb().functions.find({"sample_id": sample_id}, {"_id": 0}))
         functions = []
+        self._attachXcfgBlobs(function_dicts)
         for f in function_dicts:
             self._decodeFunction(f)
             functions.append(FunctionEntry.fromDict(f))
@@ -795,7 +863,9 @@ class MongoDbStorage(StorageInterface):
 
     def getFunctions(self, start_index: int, limit: int) -> Optional["FunctionEntry"]:
         functions = []
-        for function_document in self._getDb().functions.find().skip(start_index).limit(limit):
+        function_documents = list(self._getDb().functions.find().skip(start_index).limit(limit))
+        self._attachXcfgBlobs(function_documents)
+        for function_document in function_documents:
             self._decodeFunction(function_document)
             functions.append(FunctionEntry.fromDict(function_document))
         return functions
@@ -1107,10 +1177,13 @@ class MongoDbStorage(StorageInterface):
         ]
 
     def deleteXcfgForSampleId(self, sample_id: int) -> None:
-        self._getDb().functions.update_many({"sample_id": sample_id}, {"$set": {"_xcfg": "{}"}})
+        function_ids = [document["function_id"] for document in self._getDb().functions.find({"sample_id": sample_id}, {"function_id": 1, "_id": 0})]
+        self._deleteXcfgForFunctionIds(function_ids)
 
     def deleteXcfgData(self) -> None:
-        self._getDb().functions.update_many({}, {"$set": {"_xcfg": "{}"}})
+        # dropping the collection reclaims the space, where blanking the field in place did not:
+        # STORAGE_DROP_DISASSEMBLY now genuinely shrinks the instance (#137)
+        self._getDb()["xcfg"].drop()
 
     # TODO move to storage interface, remove this from memory storage?
     def getLibraryInfoForSampleId(self, sample_id: int) -> Optional[Dict[str, str]]:
@@ -1287,14 +1360,20 @@ class MongoDbStorage(StorageInterface):
 
     def getFunctionById(self, function_id: int, with_xcfg=False) -> Optional["FunctionEntry"]:
         field_selection = {"_id": 0}
-        if not with_xcfg:
-            field_selection["_xcfg"] = 0
         if function_id < 0:
             function_document = self._getDb().query_functions.find_one({"function_id": function_id}, field_selection)
         else:
             function_document = self._getDb().functions.find_one({"function_id": function_id}, field_selection)
         if not function_document:
             return None
+        if with_xcfg:
+            # the blob lives in its own collection now (#137); inject it so _decodeFunction
+            # and FunctionEntry see exactly the shape they saw before the split
+            # "{}" when no blob is stored, so the caller still gets an empty dict rather than
+            # None: xcfg is None means "not requested", {} means "disassembly dropped". Before
+            # the split that distinction came from the field being blanked in place instead of
+            # removed, and it is part of the contract (tests/testStorage.py).
+            function_document["_xcfg"] = self._fetchXcfgBlobs([function_id]).get(function_id) or "{}"
         self._decodeFunction(function_document)
         return FunctionEntry.fromDict(function_document)
 
@@ -1357,13 +1436,19 @@ class MongoDbStorage(StorageInterface):
         search_query = {}
         if function_ids is not None:
             search_query = {"function_id": {"$in": list(function_ids)}}
+        pending_documents = []
         for function_document in self._getDb().functions.find(search_query, {"_id": 0}):
-            if function_document["minhash"] == "":
-                if only_function_ids:
-                    unhashed_functions.append(function_document["function_id"])
-                else:
-                    self._decodeFunction(function_document)
-                    unhashed_functions.append(FunctionEntry.fromDict(function_document))
+            if function_document["minhash"] != "":
+                continue
+            if only_function_ids:
+                unhashed_functions.append(function_document["function_id"])
+            else:
+                pending_documents.append(function_document)
+        # this feeds minhash computation, which needs the disassembly
+        self._attachXcfgBlobs(pending_documents)
+        for function_document in pending_documents:
+            self._decodeFunction(function_document)
+            unhashed_functions.append(FunctionEntry.fromDict(function_document))
         return unhashed_functions
 
     def rebuildMinhashBandIndex(self, progress_reporter=None):
@@ -1443,7 +1528,11 @@ class MongoDbStorage(StorageInterface):
         xcfg_missing = 0
         for sample_id, sample_info in samples_to_be_updated.items():
             pic_hash_updates = []
-            for function_document in self._getDb().functions.find({"sample_id": sample_id}, {"function_id": 1, "_pichash": 1, "_picblockhashes": 1, "_xcfg": 1, "_id": 0}):
+            sample_function_documents = list(self._getDb().functions.find({"sample_id": sample_id}, {"function_id": 1, "_pichash": 1, "_picblockhashes": 1, "_id": 0}))
+            # one $in for the whole sample rather than a lookup per function (#137)
+            sample_xcfg_blobs = self._fetchXcfgBlobs([document["function_id"] for document in sample_function_documents])
+            for function_document in sample_function_documents:
+                function_document["_xcfg"] = sample_xcfg_blobs.get(function_document["function_id"], "")
                 update_document = {}
                 functions_updatable += 1
                 # create all relevant objects
@@ -1574,8 +1663,11 @@ class MongoDbStorage(StorageInterface):
             if entry["function_id"] not in function_id_to_block_offsets:
                 function_id_to_block_offsets[entry["function_id"]] = []
             function_id_to_block_offsets[entry["function_id"]].append((entry["offset"], picblockhash))
-        for entry in self._getDb().functions.find({"function_id": {"$in": list(function_id_to_block_offsets.keys())}}, {"function_id": 1, "_xcfg": 1, "_id": 0}):
+        block_function_ids = list(function_id_to_block_offsets.keys())
+        block_xcfg_blobs = self._fetchXcfgBlobs(block_function_ids)
+        for entry in self._getDb().functions.find({"function_id": {"$in": block_function_ids}}, {"function_id": 1, "_id": 0}):
             function_id = entry["function_id"]
+            entry["_xcfg"] = block_xcfg_blobs.get(function_id, "{}")
             self._decodeXcfg(entry)
             for block_offset, picblockhash in function_id_to_block_offsets[function_id]:
                 candidate_picblockhashes[picblockhash]["instructions"] = entry["xcfg"]["blocks"][str(block_offset)]
@@ -1637,7 +1729,7 @@ class MongoDbStorage(StorageInterface):
         search_fields = ["function_name"]
         query = self._get_search_query(search_fields, search_tree, cursor)
         sort_list = self._get_sort_list_from_cursor(cursor)
-        for function_document in self._getDb().functions.find(query, {"_id": 0, "_xcfg": 0}, sort=sort_list, limit=max_num_results):
+        for function_document in self._getDb().functions.find(query, {"_id": 0}, sort=sort_list, limit=max_num_results):
             self._decodeFunction(function_document)
             entry = FunctionEntry.fromDict(function_document)
             result_dict[entry.function_id] = entry

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -45,9 +45,6 @@ from mcrit.storage.SampleEntry import SampleEntry
 from mcrit.storage.StorageInterface import StorageInterface
 
 LOGGER = logging.getLogger(__name__)
-
-# one inline-`_xcfg` remnant probe per process (see _warnOnInlineXcfgRemaining)
-_INLINE_XCFG_CHECKED = False
 if MongoClient is None:
     LOGGER.warning("pymongo package import failed - MongoDB backend will not be available.")
 
@@ -162,28 +159,23 @@ class MongoDbStorage(StorageInterface):
         self._database = MongoClient(mongo_uri, connect=False)[db_name]
         self._ensureIndexAndUnknownFamily()
 
-    def _warnOnInlineXcfgRemaining(self) -> None:
-        """Announce an instance whose functions collection still carries inline disassembly (#137).
+    def hasInlineXcfgRemaining(self) -> Optional[bool]:
+        """Whether the functions collection still carries inline disassembly (#137).
 
-        The split readers fall back to an inline `_xcfg`, so serving is correct before
-        migrate_xcfg_split has run - but leftover inline blobs also mean the migration has not
-        completed, and that is worth saying loudly rather than leaving the instance quietly on
-        the pre-split shape. Runs once per process: cheap while inline blobs exist (the probe
-        stops at the first hit), a single collection scan once everything is migrated.
+        True = pre-split shape (migrate_xcfg_split not run or not finished), False = migrated,
+        None = could not be determined within the time budget. Surfaced through /status rather
+        than probed in a constructor: the probe is a COLLSCAN that exits early exactly when
+        things are broken and scans the whole collection when healthy, so it must never sit on
+        the job path - SpawningWorker runs each job as a fresh process, which would pay the scan
+        (and the WiredTiger cache churn of walking the collection) once per job.
         """
-        global _INLINE_XCFG_CHECKED
-        if _INLINE_XCFG_CHECKED:
-            return
-        _INLINE_XCFG_CHECKED = True
-        if self._getDb().functions.find_one({"_xcfg": {"$exists": True}}, {"_id": 1}):
-            LOGGER.warning(
-                "The functions collection still carries inline _xcfg documents - mcrit.migrations.migrate_xcfg_split "
-                "has not run (or not finished). Serving falls back to the inline disassembly, but the #137 "
-                "split (and its space reclamation) only takes effect once the migration has completed."
-            )
+        try:
+            return self._getDb().functions.find_one({"_xcfg": {"$exists": True}}, {"_id": 1}, max_time_ms=5000) is not None
+        except Exception:
+            LOGGER.warning("Could not determine whether inline _xcfg remains (probe did not finish within 5000 ms).")
+            return None
 
     def _ensureIndexAndUnknownFamily(self) -> None:
-        self._warnOnInlineXcfgRemaining()
         if "settings" not in self._getDb().list_collection_names():
             self._getDb()["settings"].insert_one({"mcrit_db_id": str(uuid.uuid4()), "db_state": 0})
         self._getDb()["samples"].create_index("sample_id")

--- a/mcrit/storage/StorageInterface.py
+++ b/mcrit/storage/StorageInterface.py
@@ -620,6 +620,19 @@ class StorageInterface:
         """
         raise NotImplementedError
 
+    def hasInlineXcfgRemaining(self) -> Optional[bool]:
+        """Whether function documents still carry inline disassembly (pre-#137 shape).
+
+        True = migrate_xcfg_split has not finished, False = migrated, None = not applicable or
+        could not be determined cheaply. An operator signal, surfaced via /status - never probe
+        this on a per-job path: the MongoDB implementation's check is a COLLSCAN whose healthy
+        answer requires scanning the whole collection.
+
+        Returns:
+            True if inline blobs remain, False if the split is complete, None otherwise
+        """
+        raise NotImplementedError
+
     def getUnhashedFunctions(self, function_ids: Optional[List[int]] = None, only_function_ids=False) -> List["FunctionEntry"]:
         """Given a list of function_ids, return all FunctionEntry objects corresponding to these IDs if they do not have a minhash yet.
         Otherwise, return all FunctionEntry objects that do not have a minhash.

--- a/mcrit/storage/StorageInterface.py
+++ b/mcrit/storage/StorageInterface.py
@@ -628,10 +628,13 @@ class StorageInterface:
         this on a per-job path: the MongoDB implementation's check is a COLLSCAN whose healthy
         answer requires scanning the whole collection.
 
+        The default answers None: backends without the pre-split shape (or that cannot decide
+        cheaply) simply omit the field rather than break every /status call.
+
         Returns:
             True if inline blobs remain, False if the split is complete, None otherwise
         """
-        raise NotImplementedError
+        return None
 
     def getUnhashedFunctions(self, function_ids: Optional[List[int]] = None, only_function_ids=False) -> List["FunctionEntry"]:
         """Given a list of function_ids, return all FunctionEntry objects corresponding to these IDs if they do not have a minhash yet.

--- a/tests/testMongoDbStorageDeleteSample.py
+++ b/tests/testMongoDbStorageDeleteSample.py
@@ -49,7 +49,10 @@ class MongoDbStorageDeleteSampleTest(TestCase):
         )
         samples = FakeCollection()
         families = FakeCollection()
-        self.storage._database = FakeDb(functions=functions, samples=samples, families=families)
+        # deleting a sample also removes the disassembly split out of the function documents (#137)
+        xcfg = FakeCollection()
+        query_xcfg = FakeCollection()
+        self.storage._database = FakeDb(functions=functions, samples=samples, families=families, xcfg=xcfg, query_xcfg=query_xcfg)
         self.storage.getSampleById = MethodType(
             lambda _self, sample_id: SimpleNamespace(
                 family_id=1,

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -529,6 +529,28 @@ class MongoDbXcfgSplitTest(TestCase):
         self._revertToInlineBlobs()
         self.assertTrue(self.storage.hasInlineXcfgRemaining())
 
+    def testFinishedInplaceMarkerDecidesWithoutScanning(self):
+        # the terminal marker migrate_xcfg_split writes on completion is authoritative for
+        # "migrated" and must win over the bounded probe (which could not prove a negative here)
+        db = self.storage._getDb()
+        self._revertToInlineBlobs()
+        db.c1_migration_state.insert_one({"_id": "inplace:functions:xcfg", "finished_at": "2026-08-24T00:00:00+00:00"})
+        try:
+            self.assertFalse(self.storage.hasInlineXcfgRemaining())
+        finally:
+            db.c1_migration_state.drop()
+
+    def testCopyModeMarkerDoesNotDecide(self):
+        # a rehearsal copy completing says nothing about this instance's functions collection -
+        # only an inplace completion is authoritative for "no inline blobs remain"
+        db = self.storage._getDb()
+        self._revertToInlineBlobs()
+        db.c1_migration_state.insert_one({"_id": "copy:functions:xcfg", "finished_at": "2026-08-24T00:00:00+00:00"})
+        try:
+            self.assertTrue(self.storage.hasInlineXcfgRemaining())
+        finally:
+            db.c1_migration_state.drop()
+
     def testStatusSurfacesTheInlineXcfgSignal(self):
         mcrit_config = McritConfig()
         mcrit_config.STORAGE_CONFIG = StorageConfig(STORAGE_METHOD=StorageFactory.STORAGE_METHOD_MONGODB, STORAGE_MONGODB_DBNAME="test_xcfg_split_mcrit")

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -58,6 +58,18 @@ class MemoryStorageTest(TestCase):
         self.assertEqual(10, stats_without_pichash["num_functions"])
         self.assertIsNone(stats_without_pichash["num_pichashes"])
 
+    def testStatusAnswersInlineXcfgOnMemoryStorage(self):
+        # the interface default is None ("not applicable"), so /status must keep working on
+        # backends without the pre-split shape - a raise here broke every memory-backed call.
+        # Any definitive answer is fine; what must not happen is an exception.
+        self.assertIn(self.storage.hasInlineXcfgRemaining(), (True, False, None))
+        # this index is memory-backed regardless of the suite it runs in, so it exercises the
+        # interface default specifically: answered, and omitted from /status rather than False
+        from .context import config as memory_index_config
+
+        status = MinHashIndex(memory_index_config).getStatus(with_pichash=False)["status"]
+        self.assertNotIn("inline_xcfg_remaining", status)
+
     def testFamilyHandling(self):
         self.storage.clearStorage()
         self.storage.addFamily("family_1")

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -11,6 +11,7 @@ from mcrit.config.MinHashConfig import MinHashConfig
 from mcrit.config.QueueConfig import QueueConfig
 from mcrit.config.ShinglerConfig import ShinglerConfig
 from mcrit.config.StorageConfig import StorageConfig
+from mcrit.index.MinHashIndex import MinHashIndex
 from mcrit.minhash.MinHash import MinHash
 from mcrit.storage.FunctionEntry import FunctionEntry
 from mcrit.storage.SampleEntry import SampleEntry
@@ -520,6 +521,22 @@ class MongoDbXcfgSplitTest(TestCase):
         function_id = self.storage.getFunctionsBySampleId(self.sample_entry.sample_id)[0].function_id
         self.assertIsNone(self.storage.getFunctionById(function_id).xcfg)
         self.assertNotEqual({}, self.storage.getFunctionById(function_id, with_xcfg=True).xcfg)
+
+    def testHasInlineXcfgRemainingTracksTheSplitState(self):
+        # False on the split shape, True once blobs sit inline again - this is the /status
+        # signal for a half-migrated instance, so both transitions must be reported
+        self.assertFalse(self.storage.hasInlineXcfgRemaining())
+        self._revertToInlineBlobs()
+        self.assertTrue(self.storage.hasInlineXcfgRemaining())
+
+    def testStatusSurfacesTheInlineXcfgSignal(self):
+        mcrit_config = McritConfig()
+        mcrit_config.STORAGE_CONFIG = StorageConfig(STORAGE_METHOD=StorageFactory.STORAGE_METHOD_MONGODB, STORAGE_MONGODB_DBNAME="test_xcfg_split_mcrit")
+        status = MinHashIndex(mcrit_config).getStatus(with_pichash=False)["status"]
+        self.assertFalse(status["inline_xcfg_remaining"])
+        self._revertToInlineBlobs()
+        status = MinHashIndex(mcrit_config).getStatus(with_pichash=False)["status"]
+        self.assertTrue(status["inline_xcfg_remaining"])
 
     def _revertToInlineBlobs(self):
         """Rewind a sample into the pre-split shape: blobs back inside the function documents,

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -521,6 +521,40 @@ class MongoDbXcfgSplitTest(TestCase):
         self.assertIsNone(self.storage.getFunctionById(function_id).xcfg)
         self.assertNotEqual({}, self.storage.getFunctionById(function_id, with_xcfg=True).xcfg)
 
+    def _revertToInlineBlobs(self):
+        """Rewind a sample into the pre-split shape: blobs back inside the function documents,
+        blob collection gone. This is exactly what an instance looks like between deploying the
+        split code and finishing migrate_xcfg_split."""
+        db = self.storage._getDb()
+        for blob_document in db.xcfg.find({}):
+            db.functions.update_one({"function_id": blob_document["_id"]}, {"$set": {"_xcfg": blob_document["_xcfg"]}})
+        db.xcfg.drop()
+
+    def testReadersFallBackToInlineBlobsBeforeMigration(self):
+        """This code ships before the migration runs, so readers must serve inline `_xcfg`
+        instead of reporting empty disassembly - calculateMinHashes and match reports would
+        otherwise silently compute from nothing on an un-migrated instance."""
+        self._revertToInlineBlobs()
+        db = self.storage._getDb()
+        self.assertGreater(db.functions.count_documents({"_xcfg": {"$exists": True}}), 0)
+        functions = self.storage.getFunctionsBySampleId(self.sample_entry.sample_id)
+        self.assertTrue(all(entry.xcfg for entry in functions))
+        function_id = functions[0].function_id
+        self.assertNotEqual({}, self.storage.getFunctionById(function_id, with_xcfg=True).xcfg)
+        unhashed = self.storage.getUnhashedFunctions()
+        self.assertTrue(unhashed)
+        self.assertTrue(all(entry.xcfg for entry in unhashed))
+
+    def testBlobWinsOverStaleInlineCopy(self):
+        """Once a blob exists it is the source of truth; a leftover inline copy (e.g. after a
+        rollback to the pre-$unset state) must not shadow it."""
+        db = self.storage._getDb()
+        function_id = self.storage.getFunctionsBySampleId(self.sample_entry.sample_id)[0].function_id
+        fresh = self.storage.getFunctionById(function_id, with_xcfg=True).xcfg
+        db.functions.update_one({"function_id": function_id}, {"$set": {"_xcfg": "{}"}})
+        served = self.storage.getFunctionById(function_id, with_xcfg=True).xcfg
+        self.assertEqual(fresh, served)
+
     def testDroppedDisassemblyReadsAsEmptyDictNotNone(self):
         # None means "not requested", {} means "dropped" - the distinction the pre-split code
         # preserved by blanking the field in place instead of removing it

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -473,10 +473,7 @@ class MongoDbStorageTest(MemoryStorageTest):
         self.assertEqual(bands_before, dumpBands())
 
 
-if __name__ == "__main__":
-    main()
-
-
+@pytest.mark.mongo
 class MongoDbXcfgSplitTest(TestCase):
     """The disassembly split (#137): `_xcfg` lives in its own collection keyed by function id,
     and every reader that carried it before must still hand callers the same shape."""
@@ -554,3 +551,7 @@ class MongoDbXcfgSplitTest(TestCase):
         self.assertNotEqual({}, self.storage.getFunctionById(query_function_id, with_xcfg=True).xcfg)
         self.storage.deleteSample(query_entry.sample_id)
         self.assertEqual(0, db.query_xcfg.count_documents({}))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -475,3 +475,82 @@ class MongoDbStorageTest(MemoryStorageTest):
 
 if __name__ == "__main__":
     main()
+
+
+class MongoDbXcfgSplitTest(TestCase):
+    """The disassembly split (#137): `_xcfg` lives in its own collection keyed by function id,
+    and every reader that carried it before must still hand callers the same shape."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.example_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "example_report.smda")
+
+    def setUp(self):
+        config = McritConfig()
+        config.STORAGE_CONFIG = StorageConfig(STORAGE_METHOD=StorageFactory.STORAGE_METHOD_MONGODB, STORAGE_MONGODB_DBNAME="test_xcfg_split_mcrit")
+        config.MINHASH_CONFIG = MinHashConfig()
+        config.SHINGLER_CONFIG = ShinglerConfig()
+        self.storage = StorageFactory.getStorage(config)
+        self.storage.clearStorage()
+        report = SmdaReport.fromFile(self.example_file_path)
+        report.family = "xcfg_split"
+        self.sample_entry = self.storage.addSmdaReport(report)
+
+    def testBlobsLiveOutsideTheFunctionDocuments(self):
+        db = self.storage._getDb()
+        self.assertEqual(db.functions.count_documents({}), db.xcfg.count_documents({}))
+        for function_document in db.functions.find({}, {"_id": 0}):
+            self.assertNotIn("_xcfg", function_document)
+        # keyed by function id, so no secondary index is needed for the lookup
+        self.assertEqual(
+            sorted(document["_id"] for document in db.xcfg.find({}, {"_id": 1})),
+            sorted(document["function_id"] for document in db.functions.find({}, {"function_id": 1, "_id": 0})),
+        )
+
+    def testReadersThatCarriedTheBlobStillDo(self):
+        functions = self.storage.getFunctionsBySampleId(self.sample_entry.sample_id)
+        self.assertTrue(functions)
+        # feeds Worker.calculateMinHashes and the code-reference extraction in match reports
+        self.assertTrue(all(entry.xcfg for entry in functions))
+        unhashed = self.storage.getUnhashedFunctions()
+        self.assertTrue(unhashed)
+        self.assertTrue(all(entry.xcfg for entry in unhashed))
+        paged = self.storage.getFunctions(0, 5)
+        self.assertTrue(paged)
+        self.assertTrue(all(entry.xcfg for entry in paged))
+
+    def testWithXcfgFlagStillGatesTheBlob(self):
+        function_id = self.storage.getFunctionsBySampleId(self.sample_entry.sample_id)[0].function_id
+        self.assertIsNone(self.storage.getFunctionById(function_id).xcfg)
+        self.assertNotEqual({}, self.storage.getFunctionById(function_id, with_xcfg=True).xcfg)
+
+    def testDroppedDisassemblyReadsAsEmptyDictNotNone(self):
+        # None means "not requested", {} means "dropped" - the distinction the pre-split code
+        # preserved by blanking the field in place instead of removing it
+        function_id = self.storage.getFunctionsBySampleId(self.sample_entry.sample_id)[0].function_id
+        self.storage.deleteXcfgForSampleId(self.sample_entry.sample_id)
+        self.assertEqual(0, self.storage._getDb().xcfg.count_documents({}))
+        self.assertEqual({}, self.storage.getFunctionById(function_id, with_xcfg=True).xcfg)
+
+    def testDeleteXcfgDataDropsTheCollection(self):
+        self.assertGreater(self.storage._getDb().xcfg.count_documents({}), 0)
+        self.storage.deleteXcfgData()
+        self.assertEqual(0, self.storage._getDb().xcfg.count_documents({}))
+
+    def testDeleteSampleTakesItsBlobsWithIt(self):
+        self.assertGreater(self.storage._getDb().xcfg.count_documents({}), 0)
+        self.storage.deleteSample(self.sample_entry.sample_id)
+        self.assertEqual(0, self.storage._getDb().functions.count_documents({}))
+        self.assertEqual(0, self.storage._getDb().xcfg.count_documents({}))
+
+    def testQueryFunctionsUseTheirOwnBlobCollection(self):
+        report = SmdaReport.fromFile(self.example_file_path)
+        report.sha256 = 64 * "e"
+        query_entry = self.storage.addSmdaReport(report, isQuery=True)
+        db = self.storage._getDb()
+        self.assertGreater(db.query_xcfg.count_documents({}), 0)
+        self.assertTrue(all(document["_id"] < 0 for document in db.query_xcfg.find({}, {"_id": 1})))
+        query_function_id = self.storage.getFunctionsBySampleId(query_entry.sample_id)[0].function_id
+        self.assertNotEqual({}, self.storage.getFunctionById(query_function_id, with_xcfg=True).xcfg)
+        self.storage.deleteSample(query_entry.sample_id)
+        self.assertEqual(0, db.query_xcfg.count_documents({}))


### PR DESCRIPTION
Implements #137.

`_xcfg` moves out of `functions` into its own collection keyed by function id (`_id` **is** the function id, so no secondary index is needed and the lookup is the primary key). Query functions mirror this in `query_xcfg`, keeping the existing `functions` / `query_functions` separation rather than mixing sign conventions in one collection.

**Matching queries do not change.** `_getCacheDataForFunctionIds` already projected the blob away, so the entire gain is page density — which is also why match reports must come out byte-identical, and any digest difference here would be a bug rather than an expected change.

## Measured on an 11.7 M-function corpus

| | before | after |
|---|---|---|
| `functions` storage | 18,353 MB | **3,130 MB** (5.9x smaller) |
| average document | 4,188 B | **721 B** |
| bytes read into WT cache per matching job | 37,778 MiB | **8,248 MiB** (4.58x less) |
| total storage | 18,353 MB | 17,340 MB (slightly **less**) |
| known-good match digests | `f3c4aeba…` | **identical** |

Whole-job wall-clock gain remains the earlier controlled **1.10–1.48x** (Amdahl: scoring, pichash filtering and result assembly are untouched). The 4.58x is measured as WiredTiger `bytes read into cache` after a restart, which is cache-state-independent; a first wall-clock reading of ~2.8x was discarded as contaminated by OS page-cache asymmetry (the migrated copy fits in RAM, the original does not).

## Verification

- **124 tests pass** (117 + 7 new in `MongoDbXcfgSplitTest`), under smda 4.4.4, 4.4.5 and 4.4.7.
- **Matching digests** against a fully migrated 11.7 M-function database: citadel `f3c4aeba…` and photoloader `30a3e58a…`, both match.
- **Blob-reader equivalence** — the check that actually exercises this change. Old code against the unsplit database vs new code against the migrated one, comparing hashes of what callers receive:

| sample | functions | `getFunctionsBySampleId` | `getFunctionById(with_xcfg)` | unique blocks |
|---|---|---|---|---|
| citadel 601 | 850 | identical | identical | identical |
| photoloader 7455 | 40 | identical | identical | identical (empty result) |
| bumblebee 8263 | 4,557 | identical | identical | identical |

- **Migration and rollback** rehearsed on a 40,000-function copy of live data: migrate 2.8 s, rollback 3.3 s, and a fingerprint over every `(function_id -> blob)` pair is identical before and after a full cycle. The copy path was separately rehearsed at full scale: 40.3 GB in 20.1 minutes.

## Where review should look hardest

Writing this, the existing test suite caught three things my plan had wrong. They are the parts most worth a second pair of eyes:

1. **The reader audit.** My plan listed four readers and missed three. `getUnhashedFunctions` feeds *minhash computation* — the indexing path needs the disassembly — and `getFunctionsBySampleId` feeds both `Worker.calculateMinHashes` and the code-reference links in match reports, while `getFunctions` had no projection at all before and so carried the blob too. All now go through one `_attachXcfgBlobs` helper. **If any consumer of `FunctionEntry.xcfg` is still unaccounted for, that is the bug class to look for.**
2. **The `None` vs `{}` contract.** `testFunctionHandling` asserts that after `deleteXcfgForSampleId`, `with_xcfg=True` yields `{}` rather than `None`. That distinction existed *because* the old code blanked the field in place instead of removing it, and it is preserved by decoding a missing blob as `{}`.
3. **`_id` uniqueness.** `functions.function_id` is a non-unique index, so duplicate ids were previously tolerated; an `_id`-keyed collection makes them a `DuplicateKeyError`. `clearStorage` therefore has to drop the new collections in lockstep with resetting the counters — and any other code path that resets counters needs the same treatment.

## Not established, stated plainly

- **`inplace` at full scale.** Rehearsed at 40,000 functions, not 11.7 M. The copy path was measured at full scale and `inplace` does strictly less work per document, but the number is not measured.
- **A restored-dump rehearsal.** Rollback works, but the recommended production sequence is still dump → migrate → verify, because rollback depends on the blob collection being intact.
- **Concurrency.** Nothing here tests migrating while a worker indexes new samples; the migration should run with writers stopped.

## Operator-facing notes for the release

- The migration is required: this is a schema change, and a database that has not been migrated will read empty disassembly.
- `STORAGE_DROP_DISASSEMBLY` now genuinely reclaims space. `deleteXcfgData` drops the collection instead of blanking every document, which is what that flag always implied.
- Suggested release-note line: take a dump before running `--mode inplace`, and run it with the worker stopped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwSfzAD1ZwEoWY3eWvbYvX
