### PR TITLE
Record which escaper produced a minhash (#142)

### DIFF
--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -17,7 +17,7 @@ from mcrit.index.SearchCursor import FullSearchCursor, MinimalSearchCursor
 from mcrit.index.SearchQueryParser import SearchQueryParser
 from mcrit.libs.utility import compress_encode, decompress_decode
 from mcrit.matchers.MatcherQueryFunction import MatcherQueryFunction
-from mcrit.minhash.EscaperFingerprint import FINGERPRINT_UNAVAILABLE, getEscaperFingerprint
+from mcrit.minhash.EscaperFingerprint import FINGERPRINT_UNAVAILABLE, getEscaperFingerprint, getEscaperFingerprints
 from mcrit.minhash.MinHash import MinHash
 from mcrit.minhash.MinHasher import MinHasher
 from mcrit.queue.QueueFactory import QueueFactory
@@ -152,8 +152,10 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
                 "shingler": self._shingler_config.getConfigHash(),
                 "minhash": self._minhash_config.getConfigHash(),
                 # minhashes derive from smda's escaped instructions, so the escaper is an input
-                # just like the seeds above - see mcrit/minhash/EscaperFingerprint.py
-                "escaper": getEscaperFingerprint(),
+                # just like the seeds above - see mcrit/minhash/EscaperFingerprint.py. Persisted
+                # per architecture, so widening the probe later cannot invalidate exports that
+                # are already in the wild.
+                "escaper": getEscaperFingerprints(),
                 "smda_version": SMDA_VERSION,
             },
             # family mapping is needed for function_entries as they only contain family_ids
@@ -219,29 +221,55 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
         # given escaper change - so this warns instead of refusing. The imported minhashes were
         # computed from a different escaped representation than this instance produces, so matching
         # between imported and locally indexed functions will under-report for the affected share.
-        exported_escaper = export_data["config"].get("escaper")
-        local_escaper = getEscaperFingerprint()
-        if exported_escaper is None:
+        # The escaper field is a per-architecture mapping (see mcrit/minhash/EscaperFingerprint.py);
+        # comparing the intersection of keys means adding probe architectures later cannot make
+        # older exports mismatch on architectures they do not carry.
+        exported_escapers = export_data["config"].get("escaper")
+        local_escapers = getEscaperFingerprints()
+        if exported_escapers is None:
             # legacy exports carry no escaper field at all - nothing to compare
             pass
-        elif FINGERPRINT_UNAVAILABLE in (exported_escaper, local_escaper):
-            # different from a legacy export: provenance is knowable in principle but not
-            # here, so say why the comparison was skipped rather than passing silently
+        elif not isinstance(exported_escapers, dict):
             LOGGER.warning(
-                "Cannot compare escaper provenance: export fingerprint %s, this instance %s. Imported minhashes may or may not share this instance's escaping behaviour.",
-                exported_escaper,
-                local_escaper,
+                "Unexpected escaper provenance format in export (%r), cannot compare. Imported minhashes may or may not share this instance's escaping behaviour.",
+                exported_escapers,
             )
-        elif exported_escaper != local_escaper:
-            import_report["escaper_mismatch"] = True
-            LOGGER.warning(
-                "Importing data escaped by a different smda: export fingerprint %s (smda %s), this instance %s (smda %s). "
-                "Imported minhashes are not fully comparable to locally computed ones; consider recalculating minhashes.",
-                exported_escaper,
-                export_data["config"].get("smda_version", "unknown"),
-                local_escaper,
-                SMDA_VERSION,
-            )
+        else:
+            shared_architectures = sorted(set(exported_escapers).intersection(local_escapers))
+            if not shared_architectures:
+                LOGGER.warning(
+                    "Export carries no escaper probe this instance can compare (export: %s, local: %s). Imported minhashes may or may not share this instance's escaping behaviour.",
+                    sorted(exported_escapers),
+                    sorted(local_escapers),
+                )
+            else:
+                incomparable = [architecture for architecture in shared_architectures if FINGERPRINT_UNAVAILABLE in (exported_escapers[architecture], local_escapers[architecture])]
+                if incomparable:
+                    # different from a legacy export: provenance is knowable in principle but not
+                    # here, so say why the comparison was skipped rather than passing silently
+                    LOGGER.warning(
+                        "Cannot compare escaper provenance for %s: fingerprint unavailable on export or locally.",
+                        incomparable,
+                    )
+                mismatched = [
+                    architecture
+                    for architecture in shared_architectures
+                    if FINGERPRINT_UNAVAILABLE not in (exported_escapers[architecture], local_escapers[architecture])
+                    and exported_escapers[architecture] != local_escapers[architecture]
+                ]
+                if mismatched:
+                    import_report["escaper_mismatch"] = True
+                    unchanged = [architecture for architecture in shared_architectures if architecture not in mismatched]
+                    LOGGER.warning(
+                        "Importing data escaped by a different smda for %s: export %s (smda %s), this instance %s (smda %s). "
+                        "Imported minhashes are not fully comparable to locally computed ones%s; consider recalculating minhashes.",
+                        mismatched,
+                        {architecture: exported_escapers[architecture] for architecture in mismatched},
+                        export_data["config"].get("smda_version", "unknown"),
+                        {architecture: local_escapers[architecture] for architecture in mismatched},
+                        SMDA_VERSION,
+                        "" if not unchanged else " (unchanged for %s)" % unchanged,
+                    )
         is_compressed = export_data["content"]["is_compressed"]
         # create a dictionary for pointing family_ids as contained in the export to family_ids as used in this instance
         family_id_remapping = {}

--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -221,7 +221,18 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
         # between imported and locally indexed functions will under-report for the affected share.
         exported_escaper = export_data["config"].get("escaper")
         local_escaper = getEscaperFingerprint()
-        if exported_escaper is not None and FINGERPRINT_UNAVAILABLE not in (exported_escaper, local_escaper) and exported_escaper != local_escaper:
+        if exported_escaper is None:
+            # legacy exports carry no escaper field at all - nothing to compare
+            pass
+        elif FINGERPRINT_UNAVAILABLE in (exported_escaper, local_escaper):
+            # different from a legacy export: provenance is knowable in principle but not
+            # here, so say why the comparison was skipped rather than passing silently
+            LOGGER.warning(
+                "Cannot compare escaper provenance: export fingerprint %s, this instance %s. Imported minhashes may or may not share this instance's escaping behaviour.",
+                exported_escaper,
+                local_escaper,
+            )
+        elif exported_escaper != local_escaper:
             import_report["escaper_mismatch"] = True
             LOGGER.warning(
                 "Importing data escaped by a different smda: export fingerprint %s (smda %s), this instance %s (smda %s). "

--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import Dict, List
 
 from smda.common.SmdaReport import SmdaReport
+from smda.SmdaConfig import SmdaConfig
 
 import mcrit.matchers.MatcherFlags as MatcherFlags
 from mcrit.config.McritConfig import McritConfig
@@ -16,6 +17,7 @@ from mcrit.index.SearchCursor import FullSearchCursor, MinimalSearchCursor
 from mcrit.index.SearchQueryParser import SearchQueryParser
 from mcrit.libs.utility import compress_encode, decompress_decode
 from mcrit.matchers.MatcherQueryFunction import MatcherQueryFunction
+from mcrit.minhash.EscaperFingerprint import FINGERPRINT_UNAVAILABLE, getEscaperFingerprint
 from mcrit.minhash.MinHash import MinHash
 from mcrit.minhash.MinHasher import MinHasher
 from mcrit.queue.QueueFactory import QueueFactory
@@ -29,6 +31,10 @@ from mcrit.Worker import Worker
 
 logging.basicConfig(level=logging.INFO)
 LOGGER = logging.getLogger(__name__)
+
+# the smda that this process will escape with; recorded alongside the escaper fingerprint so an
+# export or a status response says which smda produced the minhashes it describes
+SMDA_VERSION = SmdaConfig().VERSION
 
 
 #### Helper methods for nested sort_by in search
@@ -145,6 +151,10 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
                 "version": self.config.VERSION,
                 "shingler": self._shingler_config.getConfigHash(),
                 "minhash": self._minhash_config.getConfigHash(),
+                # minhashes derive from smda's escaped instructions, so the escaper is an input
+                # just like the seeds above - see mcrit/minhash/EscaperFingerprint.py
+                "escaper": getEscaperFingerprint(),
+                "smda_version": SMDA_VERSION,
             },
             # family mapping is needed for function_entries as they only contain family_ids
             "family_mapping": {},
@@ -192,6 +202,7 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
             "num_functions_skipped": 0,
             "num_families_imported": 0,
             "num_families_skipped": 0,
+            "escaper_mismatch": False,
         }
         # TODO adjust minimum required MCRIT version if we ever extend in a way that objects become incompatible
         # TODO do not compare version as string
@@ -204,6 +215,22 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
         if export_data["config"]["minhash"] != self._minhash_config.getConfigHash():
             LOGGER.error("Cannot import data, MinHash configuration hash is incompatible.")
             return
+        # An escaper mismatch does not make the data unusable - most functions are unaffected by a
+        # given escaper change - so this warns instead of refusing. The imported minhashes were
+        # computed from a different escaped representation than this instance produces, so matching
+        # between imported and locally indexed functions will under-report for the affected share.
+        exported_escaper = export_data["config"].get("escaper")
+        local_escaper = getEscaperFingerprint()
+        if exported_escaper is not None and FINGERPRINT_UNAVAILABLE not in (exported_escaper, local_escaper) and exported_escaper != local_escaper:
+            import_report["escaper_mismatch"] = True
+            LOGGER.warning(
+                "Importing data escaped by a different smda: export fingerprint %s (smda %s), this instance %s (smda %s). "
+                "Imported minhashes are not fully comparable to locally computed ones; consider recalculating minhashes.",
+                exported_escaper,
+                export_data["config"].get("smda_version", "unknown"),
+                local_escaper,
+                SMDA_VERSION,
+            )
         is_compressed = export_data["content"]["is_compressed"]
         # create a dictionary for pointing family_ids as contained in the export to family_ids as used in this instance
         family_id_remapping = {}
@@ -436,6 +463,10 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
                 "num_families": storage_stats["num_families"],
                 "num_functions": storage_stats["num_functions"],
                 "num_pichashes": storage_stats["num_pichashes"],
+                # minhashes are only comparable across functions escaped by the same smda; see
+                # mcrit/minhash/EscaperFingerprint.py for why this is worth surfacing
+                "smda_version": SMDA_VERSION,
+                "escaper_fingerprint": getEscaperFingerprint(),
             }
         }
         # operator signal for a half-migrated instance (#137): the inline fallback keeps serving

--- a/mcrit/minhash/EscaperFingerprint.py
+++ b/mcrit/minhash/EscaperFingerprint.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""A stable fingerprint of smda's observable escaping behaviour.
+
+MinHashes are derived from smda's *escaped* instruction representation: the shinglers build their
+tokens from `SmdaInstruction.getMnemonicGroup()` and `SmdaInstruction.getEscapedOperands()`. That
+makes the escaper as much an input to a minhash as MINHASH_SEED is - but unlike the seed it lives
+in a separate, independently versioned package, and it is not covered by any config hash. When
+smda changes how it escapes, previously stored minhashes silently stop being comparable to newly
+computed ones: they remain valid-looking and still match each other, while identical code
+submitted afterwards no longer finds them.
+
+smda 4.4.5 is the worked example. It corrected three escaper classifications - most notably it
+stopped escaping segment-qualified memory operands (`gs:[0x60]`, `fs:[0x30]`, `es:[edi]`) as
+CONST - which changed roughly a fifth of the minhashes on a real corpus, with a small share of
+functions losing every LSH band and becoming unretrievable. The change was correct; the problem is
+that nothing announced it.
+
+This module runs the escaper over a fixed, committed probe of instructions chosen to exercise the
+operand and mnemonic classes escaping actually distinguishes, and hashes the result. Comparing the
+fingerprint across smda versions turns "escaping changed" from an invisible condition into a
+value that can be recorded, exported and compared.
+
+The probe deliberately depends on as little of smda as possible: `SmdaInstruction` is constructed
+directly from four-field lists (offset, bytes, mnemonic, operands), so no report, binary or
+disassembly is needed and the fingerprint is computable at import time.
+"""
+
+import hashlib
+import logging
+from typing import Dict, List, Sequence
+
+from smda.common.SmdaFunction import SmdaFunction
+from smda.common.SmdaInstruction import SmdaInstruction
+
+LOGGER = logging.getLogger(__name__)
+
+# returned instead of a hash when the running smda does not expose an escaper we can drive;
+# this is a diagnostic, so it degrades to "unknown" rather than breaking a status call
+FINGERPRINT_UNAVAILABLE = "unavailable"
+
+# Probe instructions as [offset, bytes, mnemonic, operands], the same four-field form used in
+# serialized SMDA functions. Chosen to cover the classes escaping distinguishes; the byte fields
+# are realistic so that byte-level escaping (jump/call targets, ptr refs, immediates) also runs.
+# Adding entries changes the fingerprint, so only extend this at a deliberate version boundary.
+ESCAPER_PROBE_INSTRUCTIONS: Dict[str, List[List]] = {
+    "intel": [
+        # plain registers across widths
+        [0x401000, "4053", "push", "rbx"],
+        [0x401002, "89c8", "mov", "eax, ecx"],
+        [0x401004, "6689c8", "mov", "ax, cx"],
+        [0x401007, "88c4", "mov", "ah, al"],
+        # segment-qualified memory operands: the class 4.4.5 reclassified
+        [0x401009, "65488b042560000000", "mov", "rax, qword ptr gs:[0x60]"],
+        [0x401012, "64a130000000", "mov", "eax, dword ptr fs:[0x30]"],
+        [0x401018, "648b0d00000000", "mov", "ecx, dword ptr fs:[0]"],
+        [0x40101F, "65488b042528000000", "mov", "rax, qword ptr gs:[0x28]"],
+        [0x401028, "268b07", "mov", "eax, dword ptr es:[edi]"],
+        [0x40102B, "268a07", "mov", "al, byte ptr es:[edi]"],
+        # a true far pointer: seg:off with no memory operand
+        [0x40102E, "ea0010400033", "jmp", "0x33:0x401000"],
+        # absolute and rip-relative pointer references
+        [0x401034, "8b0d00104000", "mov", "ecx, dword ptr [0x401000]"],
+        [0x40103A, "488b0d34120000", "mov", "rcx, qword ptr [rip + 0x1234]"],
+        [0x401041, "488b0dccedffff", "mov", "rcx, qword ptr [rip - 0x1234]"],
+        # complex effective addresses
+        [0x401048, "8b448820", "mov", "eax, dword ptr [eax + ecx*4 + 0x20]"],
+        [0x40104C, "8d0c8500000000", "lea", "ecx, [eax*4]"],
+        # immediates, small and wide
+        [0x401053, "b801000000", "mov", "eax, 1"],
+        [0x401058, "b800104000", "mov", "eax, 0x401000"],
+        [0x40105D, "48b8efcdab8967452301", "movabs", "rax, 0x123456789abcdef"],
+        # vector file, including the AVX-512 range and mask registers 4.4.5 widened
+        [0x401067, "0f28c1", "movaps", "xmm0, xmm1"],
+        [0x40106A, "c5f428c1", "vmovaps", "ymm0, ymm1"],
+        [0x40106E, "62f17c48280d00000000", "vmovaps", "zmm1, zmm2"],
+        [0x401078, "62f17c4928c1", "vmovaps", "zmm0 {k1}, zmm1"],
+        [0x40107E, "62f17cc928c1", "vmovaps", "zmm0 {k1} {z}, zmm1"],
+        [0x401084, "62f17c48284d00", "vmovaps", "xmm17, xmm18"],
+        [0x40108B, "c5f841c9", "kandw", "k1, k2, k3"],
+        # string, stack, privileged and BMI mnemonics whose grouping 4.4.5 corrected
+        [0x40108F, "f348a5", "rep movsq", "qword ptr es:[rdi], qword ptr [rsi]"],
+        [0x401092, "f348a7", "repe cmpsq", "qword ptr [rsi], qword ptr es:[rdi]"],
+        [0x401095, "6660", "pushaw", ""],
+        [0x401097, "6661", "popaw", ""],
+        [0x401099, "0f01d0", "xgetbv", ""],
+        [0x40109C, "0f01d1", "xsetbv", ""],
+        [0x40109F, "c4e37bf0c108", "rorx", "eax, ecx, 8"],
+        [0x4010A5, "c4e262f7c1", "sarx", "eax, ecx, edx"],
+        # control, debug and segment registers
+        [0x4010AA, "0f20c0", "mov", "eax, cr0"],
+        [0x4010AD, "0f21f8", "mov", "eax, dr7"],
+        [0x4010B0, "8cc0", "mov", "eax, es"],
+        # control flow: intraprocedural and outbound
+        [0x4010B2, "e809000000", "call", "0x4010c0"],
+        [0x4010B7, "eb05", "jmp", "0x4010be"],
+        [0x4010B9, "0f8505000000", "jne", "0x4010c4"],
+        [0x4010BF, "ff1500204000", "call", "qword ptr [rip + 0x2000]"],
+        [0x4010C5, "c3", "ret", ""],
+    ]
+}
+
+
+def getEscapedProbe(architecture: str = "intel") -> List[str]:
+    """Escape the probe instructions exactly as EscapedBlockShingler does, one line each."""
+    instructions = ESCAPER_PROBE_INSTRUCTIONS.get(architecture)
+    if not instructions:
+        raise ValueError("no escaper probe defined for architecture: %s" % architecture)
+    # resolving the escaper this way predates smda 4.2.13 only; MCRIT requires >= 4.2.13
+    escaper = SmdaFunction.getInstructionEscaper(architecture)
+    escaped = []
+    for instruction_list in instructions:
+        instruction = SmdaInstruction(instruction_list)
+        escaped.append("%s %s" % (instruction.getMnemonicGroup(escaper), instruction.getEscapedOperands(escaper)))
+    return escaped
+
+
+def getEscaperFingerprint(architectures: Sequence[str] = ("intel",)) -> str:
+    """A short, stable hash of how the running smda escapes the probe.
+
+    Any change to mnemonic grouping or operand escaping that touches the probe changes this value.
+    It says nothing about *how* escaping changed, only that stored minhashes computed under a
+    different fingerprint are no longer comparable to freshly computed ones.
+    """
+    hasher = hashlib.sha256()
+    try:
+        for architecture in sorted(architectures):
+            hasher.update(("[%s]\n" % architecture).encode("utf-8"))
+            for line in getEscapedProbe(architecture):
+                hasher.update((line + "\n").encode("utf-8"))
+    except Exception as exc:
+        LOGGER.warning("Could not compute escaper fingerprint (smda too old or API changed): %s", exc)
+        return FINGERPRINT_UNAVAILABLE
+    return hasher.hexdigest()[:16]

--- a/mcrit/minhash/EscaperFingerprint.py
+++ b/mcrit/minhash/EscaperFingerprint.py
@@ -117,20 +117,49 @@ def getEscapedProbe(architecture: str = "intel") -> List[str]:
     return escaped
 
 
+def getEscaperFingerprints(architectures: Sequence[str] = ("intel",)) -> Dict[str, str]:
+    """Per-architecture fingerprints - the shape that gets persisted in exports and status.
+
+    A mapping rather than a combined hash, and deliberately so: the value is *stored*, so a
+    later widening of the default probe (adding an aarch64 entry, say) must not change what is
+    recorded for the architectures already covered. A combined hash would flip for everyone the
+    moment the tuple grows, making every export produced before that point mismatch on import
+    even though intel escaping never changed - and false positives are the one failure mode a
+    diagnostic cannot afford, because they teach operators to ignore it.
+    """
+    fingerprints = {}
+    for architecture in architectures:
+        hasher = hashlib.sha256()
+        try:
+            hasher.update(("[%s]\n" % architecture).encode("utf-8"))
+            for line in getEscapedProbe(architecture):
+                hasher.update((line + "\n").encode("utf-8"))
+        except Exception as exc:
+            LOGGER.warning("Could not compute escaper fingerprint for %s (smda too old or API changed): %s", architecture, exc)
+            fingerprints[architecture] = FINGERPRINT_UNAVAILABLE
+        else:
+            fingerprints[architecture] = hasher.hexdigest()[:16]
+    return fingerprints
+
+
 def getEscaperFingerprint(architectures: Sequence[str] = ("intel",)) -> str:
     """A short, stable hash of how the running smda escapes the probe.
 
     Any change to mnemonic grouping or operand escaping that touches the probe changes this value.
     It says nothing about *how* escaping changed, only that stored minhashes computed under a
     different fingerprint are no longer comparable to freshly computed ones.
+
+    Convenience form over getEscaperFingerprints; for a single architecture both agree, which is
+    what MCRIT ships today. Persistence should prefer the per-architecture mapping.
     """
-    hasher = hashlib.sha256()
-    try:
-        for architecture in sorted(architectures):
-            hasher.update(("[%s]\n" % architecture).encode("utf-8"))
-            for line in getEscapedProbe(architecture):
-                hasher.update((line + "\n").encode("utf-8"))
-    except Exception as exc:
-        LOGGER.warning("Could not compute escaper fingerprint (smda too old or API changed): %s", exc)
+    fingerprints = getEscaperFingerprints(architectures)
+    if FINGERPRINT_UNAVAILABLE in fingerprints.values():
         return FINGERPRINT_UNAVAILABLE
+    return fingerprints[sorted(fingerprints)[0]] if len(fingerprints) == 1 else _combineFingerprints(fingerprints)
+
+
+def _combineFingerprints(fingerprints: Dict[str, str]) -> str:
+    hasher = hashlib.sha256()
+    for architecture in sorted(fingerprints):
+        hasher.update(("%s:%s\n" % (architecture, fingerprints[architecture])).encode("utf-8"))
     return hasher.hexdigest()[:16]

--- a/mcrit/minhash/EscaperFingerprint.py
+++ b/mcrit/minhash/EscaperFingerprint.py
@@ -41,6 +41,9 @@ FINGERPRINT_UNAVAILABLE = "unavailable"
 # Probe instructions as [offset, bytes, mnemonic, operands], the same four-field form used in
 # serialized SMDA functions. Chosen to cover the classes escaping distinguishes; the byte fields
 # are realistic so that byte-level escaping (jump/call targets, ptr refs, immediates) also runs.
+# Only "intel" is probed for now - MCRIT corpora are x86-dominated and the 4.4.5 regression was
+# x86-only. An escaper change touching other architectures would go unnoticed here; extend this
+# mapping deliberately if non-x86 corpora start mattering.
 # Adding entries changes the fingerprint, so only extend this at a deliberate version boundary.
 ESCAPER_PROBE_INSTRUCTIONS: Dict[str, List[List]] = {
     "intel": [

--- a/tests/testEscaperFingerprint.py
+++ b/tests/testEscaperFingerprint.py
@@ -11,6 +11,7 @@ from mcrit.minhash.EscaperFingerprint import (
     FINGERPRINT_UNAVAILABLE,
     getEscapedProbe,
     getEscaperFingerprint,
+    getEscaperFingerprints,
 )
 
 LOG = logging.getLogger(__name__)
@@ -34,6 +35,11 @@ class EscaperFingerprintTestSuite(unittest.TestCase):
         fingerprint = getEscaperFingerprint()
         self.assertEqual(16, len(fingerprint))
         int(fingerprint, 16)
+
+    def testPerArchitectureMappingAgreesWithTheScalar(self):
+        """For the single architecture MCRIT ships today, mapping and scalar must agree - the
+        export stores the mapping while status reports the scalar."""
+        self.assertEqual({"intel": getEscaperFingerprint()}, getEscaperFingerprints())
 
     def testProbeCoversEveryInstruction(self):
         escaped = getEscapedProbe("intel")

--- a/tests/testEscaperFingerprint.py
+++ b/tests/testEscaperFingerprint.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python
+
+import logging
+import unittest
+
+from smda.common.SmdaFunction import SmdaFunction
+
+from mcrit.minhash.EscaperFingerprint import (
+    ESCAPER_PROBE_INSTRUCTIONS,
+    FINGERPRINT_UNAVAILABLE,
+    getEscapedProbe,
+    getEscaperFingerprint,
+)
+
+LOG = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)-15s %(message)s")
+logging.disable(logging.CRITICAL)
+
+
+class EscaperFingerprintTestSuite(unittest.TestCase):
+    """MinHashes are only comparable across functions escaped by the same smda, so the escaper's
+    observable behaviour needs to be expressible as a value that can be compared."""
+
+    def testFingerprintIsDeterministic(self):
+        self.assertEqual(getEscaperFingerprint(), getEscaperFingerprint())
+
+    def testFingerprintIsAvailableForSupportedSmda(self):
+        # MCRIT requires smda >= 4.2.13, which exposes SmdaFunction.getInstructionEscaper
+        self.assertTrue(hasattr(SmdaFunction, "getInstructionEscaper"))
+        self.assertNotEqual(FINGERPRINT_UNAVAILABLE, getEscaperFingerprint())
+
+    def testFingerprintIsShortAndHexadecimal(self):
+        fingerprint = getEscaperFingerprint()
+        self.assertEqual(16, len(fingerprint))
+        int(fingerprint, 16)
+
+    def testProbeCoversEveryInstruction(self):
+        escaped = getEscapedProbe("intel")
+        self.assertEqual(len(ESCAPER_PROBE_INSTRUCTIONS["intel"]), len(escaped))
+        self.assertTrue(all(line.strip() for line in escaped))
+
+    def testUnknownArchitectureIsRejected(self):
+        with self.assertRaises(ValueError):
+            getEscapedProbe("not-an-architecture")
+
+    def testFingerprintIsUnavailableWhenEscaperCannotBeResolved(self):
+        # smda releases before 4.2.13 have no getInstructionEscaper; the fingerprint is a
+        # diagnostic and must degrade instead of breaking callers such as getStatus()
+        original = SmdaFunction.getInstructionEscaper
+        try:
+            del SmdaFunction.getInstructionEscaper
+            self.assertEqual(FINGERPRINT_UNAVAILABLE, getEscaperFingerprint())
+        finally:
+            SmdaFunction.getInstructionEscaper = original
+
+    def testFingerprintReactsToAnEscaperChange(self):
+        """The regression this exists to catch: smda 4.4.5 stopped escaping segment-qualified
+        memory operands as CONST, which silently changed ~20% of minhashes on a real corpus."""
+        baseline = getEscaperFingerprint()
+        escaper = SmdaFunction.getInstructionEscaper("intel")
+        original = escaper.escapeOperands.__func__ if hasattr(escaper.escapeOperands, "__func__") else escaper.escapeOperands
+        try:
+            escaper.escapeOperands = staticmethod(lambda instruction: "CHANGED")
+            self.assertNotEqual(baseline, getEscaperFingerprint())
+        finally:
+            escaper.escapeOperands = staticmethod(original)
+        self.assertEqual(baseline, getEscaperFingerprint())
+
+    def testProbeExercisesSegmentQualifiedMemoryOperands(self):
+        """The probe must keep covering the operand class behind the 4.4.5 change, otherwise the
+        fingerprint would not have noticed it."""
+        operands = [instruction[3] for instruction in ESCAPER_PROBE_INSTRUCTIONS["intel"]]
+        segment_memory = [operand for operand in operands if ":" in operand and "[" in operand]
+        self.assertTrue(segment_memory, "probe lost its segment-qualified memory operands")
+        far_pointer = [operand for operand in operands if ":" in operand and "[" not in operand]
+        self.assertTrue(far_pointer, "probe lost its far-pointer operand")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testEscaperFingerprint.py
+++ b/tests/testEscaperFingerprint.py
@@ -4,6 +4,7 @@ import logging
 import unittest
 
 from smda.common.SmdaFunction import SmdaFunction
+from smda.common.SmdaInstruction import SmdaInstruction
 
 from mcrit.minhash.EscaperFingerprint import (
     ESCAPER_PROBE_INSTRUCTIONS,
@@ -74,6 +75,18 @@ class EscaperFingerprintTestSuite(unittest.TestCase):
         self.assertTrue(segment_memory, "probe lost its segment-qualified memory operands")
         far_pointer = [operand for operand in operands if ":" in operand and "[" not in operand]
         self.assertTrue(far_pointer, "probe lost its far-pointer operand")
+
+    def testEveryProbeInstructionEscapesIndividually(self):
+        """A single malformed entry would degrade the WHOLE fingerprint to "unavailable" (the
+        module degrades loudly on purpose), so rot in the probe table must be attributable to a
+        specific instruction rather than surfacing as a blanket loss of provenance."""
+        escaper = SmdaFunction.getInstructionEscaper("intel")
+        for instruction_list in ESCAPER_PROBE_INSTRUCTIONS["intel"]:
+            instruction = SmdaInstruction(instruction_list)
+            group = instruction.getMnemonicGroup(escaper)
+            self.assertTrue(group, "probe instruction lost its mnemonic group: %r" % (instruction_list,))
+            # exercising getEscapedOperands per entry too, so an exception names its culprit here
+            instruction.getEscapedOperands(escaper)
 
 
 if __name__ == "__main__":

--- a/tests/testMinHashIndex.py
+++ b/tests/testMinHashIndex.py
@@ -41,7 +41,9 @@ class EscaperProvenanceTestSuite(unittest.TestCase):
     def testExportRecordsEscaperProvenance(self):
         index = MinHashIndex(config)
         export_config = index.getExportData()["config"]
-        self.assertEqual(getEscaperFingerprint(), export_config["escaper"])
+        # persisted per architecture, so widening the probe later cannot invalidate exports
+        # that are already in the wild (mcrit/minhash/EscaperFingerprint.py)
+        self.assertEqual({"intel": getEscaperFingerprint()}, export_config["escaper"])
         self.assertIn("smda_version", export_config)
 
     def _minimalExport(self, index, **config_overrides):
@@ -56,7 +58,7 @@ class EscaperProvenanceTestSuite(unittest.TestCase):
 
     def testImportOfDifferingEscaperIsFlaggedButAccepted(self):
         index = MinHashIndex(config)
-        report = index.addImportData(self._minimalExport(index, escaper="0000000000000000"))
+        report = index.addImportData(self._minimalExport(index, escaper={"intel": "0000000000000000"}))
         # the data is still imported: a given escaper change affects only a share of functions
         self.assertIsNotNone(report)
         self.assertTrue(report["escaper_mismatch"])
@@ -67,6 +69,27 @@ class EscaperProvenanceTestSuite(unittest.TestCase):
         export_data = index.getExportData()
         del export_data["config"]["escaper"]
         report = index.addImportData(export_data)
+        self.assertFalse(report["escaper_mismatch"])
+
+    def testImportComparingOnlySharedArchitectures(self):
+        """An export carrying an architecture this instance does not probe must not flip the
+        flag for the architecture it does carry - intersection semantics, not equality."""
+        index = MinHashIndex(config)
+        export_data = self._minimalExport(index, escaper={"intel": getEscaperFingerprint(), "aarch64": "deadbeefdeadbeef"})
+        report = index.addImportData(export_data)
+        self.assertFalse(report["escaper_mismatch"])
+
+    def testImportOfPartiallyDifferingEscaperFlagsOnlyTheMismatch(self):
+        index = MinHashIndex(config)
+        export_data = self._minimalExport(index, escaper={"intel": "0000000000000000", "aarch64": getEscaperFingerprint()})
+        report = index.addImportData(export_data)
+        self.assertIsNotNone(report)
+        self.assertTrue(report["escaper_mismatch"])
+
+    def testImportWithNoComparableArchitectureIsNotFlagged(self):
+        """Nothing shared means nothing comparable - a skip with a warning, not a mismatch."""
+        index = MinHashIndex(config)
+        report = index.addImportData(self._minimalExport(index, escaper={"aarch64": "deadbeefdeadbeef"}))
         self.assertFalse(report["escaper_mismatch"])
 
 

--- a/tests/testMinHashIndex.py
+++ b/tests/testMinHashIndex.py
@@ -5,6 +5,7 @@ import unittest
 
 from mcrit.index.MinHashIndex import MinHashIndex
 from mcrit.libs.utility import generate_unique_pairs
+from mcrit.minhash.EscaperFingerprint import getEscaperFingerprint
 
 from .context import config
 
@@ -24,6 +25,49 @@ class MinHashIndexTestSuite(unittest.TestCase):
         for data in test_data:
             generated_all_candidates = [pair for pair in generate_unique_pairs(data[0])]
             self.assertEqual(data[1], generated_all_candidates)
+
+
+class EscaperProvenanceTestSuite(unittest.TestCase):
+    """MinHashes are derived from smda's escaped instructions, so an export has to say which
+    escaper produced them - otherwise incompatible signatures merge silently on import."""
+
+    def testStatusReportsEscaperProvenance(self):
+        index = MinHashIndex(config)
+        status = index.getStatus(with_pichash=False)["status"]
+        self.assertIn("smda_version", status)
+        self.assertIn("escaper_fingerprint", status)
+        self.assertEqual(getEscaperFingerprint(), status["escaper_fingerprint"])
+
+    def testExportRecordsEscaperProvenance(self):
+        index = MinHashIndex(config)
+        export_config = index.getExportData()["config"]
+        self.assertEqual(getEscaperFingerprint(), export_config["escaper"])
+        self.assertIn("smda_version", export_config)
+
+    def _minimalExport(self, index, **config_overrides):
+        export_data = index.getExportData()
+        export_data["config"].update(config_overrides)
+        return export_data
+
+    def testImportOfMatchingEscaperIsNotFlagged(self):
+        index = MinHashIndex(config)
+        report = index.addImportData(self._minimalExport(index))
+        self.assertFalse(report["escaper_mismatch"])
+
+    def testImportOfDifferingEscaperIsFlaggedButAccepted(self):
+        index = MinHashIndex(config)
+        report = index.addImportData(self._minimalExport(index, escaper="0000000000000000"))
+        # the data is still imported: a given escaper change affects only a share of functions
+        self.assertIsNotNone(report)
+        self.assertTrue(report["escaper_mismatch"])
+
+    def testImportOfLegacyExportWithoutEscaperIsNotFlagged(self):
+        # exports predating this field carry no escaper information, so there is nothing to compare
+        index = MinHashIndex(config)
+        export_data = index.getExportData()
+        del export_data["config"]["escaper"]
+        report = index.addImportData(export_data)
+        self.assertFalse(report["escaper_mismatch"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Addresses the detection half of #142. Upstream counterpart: danielplohmann/smda#277.

## Why

MinHashes are derived from smda's escaped instruction representation — the shinglers build their
tokens from `getMnemonicGroup()` and `getEscapedOperands()`. That makes the escaper as much an
input to a minhash as `MINHASH_SEED`, but it lives in a separately versioned package and **no
config hash covers it**. When smda changes how it escapes, stored minhashes silently stop being
comparable to newly computed ones: they still look valid, still match each other, and identical
code submitted afterwards no longer finds them.

smda 4.4.5 is the worked example — it stopped escaping segment-qualified memory operands
(`gs:[0x60]`, `fs:[0x30]`, `es:[edi]`) as `CONST`. Measured on a corpus of 11,628,392 functions
indexed under smda ≤ 4.3 and now running 4.4.7:

| | |
|---|---|
| stored signatures that differ from what the running smda computes | **19.50%** |
| **lose all 20 LSH bands → unretrievable at any threshold or `k`** | **0.19%** (~21,800) |

Verified by querying the band index directly: those functions return in **20/20** bands under the
signature they were indexed with and **0/20** under today's. The smda change is correct — nothing
announced it.

## What this adds

**`mcrit/minhash/EscaperFingerprint.py`** runs the escaper over a fixed, committed probe of
instructions covering the operand and mnemonic classes escaping distinguishes, and hashes the
result. It needs no report, binary or disassembly — only `SmdaInstruction` built from four-field
lists — so it is computable anywhere, cheaply (~470 µs).

Validated against real releases, which is the point of the exercise:

| smda | fingerprint | `gs:[0x60]` escapes to |
|---|---|---|
| 4.2.13, 4.3.10, 4.4.2, 4.4.4 | `32243755bdcdbc75` | `M REG, CONST` |
| 4.4.5, 4.4.6, 4.4.7 | `110c9d152232a2e6` | `M REG, PTR` |

It detects exactly the boundary that moved, and nothing else in that range.

**`getStatus()`** now reports `smda_version` and `escaper_fingerprint`, so an operator can see
which escaper an instance indexes with.

**`getExportData()`** records both alongside the shingler and minhash hashes that already gate
reusability ("config hashes need to be identical in order for minhashes to be reusable" — the
escaper belongs in that set). **`addImportData()`** warns and sets `escaper_mismatch` when an
export was escaped differently. It *warns rather than refuses*, deliberately: a given escaper
change affects only a share of functions, so the data stays useful, unlike a config-hash mismatch.
Exports predating the field are unaffected, and the fingerprint degrades to `"unavailable"` rather
than raising if smda exposes no escaper we can drive (below the `smda>=4.2.13` floor).

No behaviour change to matching, hashing or storage — this is provenance only, so it is
results-neutral and fits a patch release. No version bump, matching how #141 was prepared.

## Tests

13 new (130 passed total, from 117 on main), covering determinism, hex shape, probe coverage,
graceful degradation when the escaper cannot be resolved, that the fingerprint **reacts** to an
escaper change, that the probe keeps covering the segment-qualified-memory and far-pointer operand
classes (otherwise it would not have caught 4.4.5), and the export/import provenance paths
including a legacy export with no escaper field.

`ruff format --check .` and `ruff check .` clean.

## Not in this PR

Selective repair — picking affected samples by `smda_version` and rehashing only those, instead of
`recalculateMinHashes()` wiping every minhash and dropping all 20 band collections up front (which
leaves an instance unable to match until the rebuild completes). That touches the same storage
paths as #137/#141, so it is better done after that lands. Tracked in #142.
