### PR TITLE
getUnhashedFunctions: select in the database, and skip functions that can never be hashed

### DIFF
--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -751,18 +751,24 @@ class MemoryStorage(StorageInterface):
         return valid_candidates
 
     def getUnhashedFunctions(self, function_ids: Optional[List[int]] = None, only_function_ids=False) -> List[Union[int, "FunctionEntry"]]:
-        result: List[Union[int, FunctionEntry]] = []
+        # Same selection as the MongoDB backend: needs a MinHash, and is large enough to receive
+        # one. Functions below the size thresholds can never be hashed, so returning them only
+        # makes every caller rediscover that after loading their disassembly.
+        candidates = [
+            function_entry
+            for _, function_entry in self._functions.items()
+            if not function_entry.minhash and self.isHashableBySize(function_entry.num_instructions, function_entry.num_blocks)
+        ]
         if function_ids is None:
-            if only_function_ids:
-                result = [function_entry.function_id for _, function_entry in self._functions.items() if function_entry.xcfg and not function_entry.minhash]
-            else:
-                result = [function_entry for _, function_entry in self._functions.items() if function_entry.xcfg and not function_entry.minhash]
-            return result
-        if only_function_ids:
-            result = [function_entry.function_id for _, function_entry in self._functions.items() if (not function_entry.minhash and function_entry.function_id in function_ids)]
+            # the None case additionally requires disassembly to be present, since without it there
+            # is nothing to hash from
+            candidates = [function_entry for function_entry in candidates if function_entry.xcfg]
         else:
-            result = [function_entry for _, function_entry in self._functions.items() if (not function_entry.minhash and function_entry.function_id in function_ids)]
-        return result
+            wanted = set(function_ids)
+            candidates = [function_entry for function_entry in candidates if function_entry.function_id in wanted]
+        if only_function_ids:
+            return [function_entry.function_id for function_entry in candidates]
+        return list(candidates)
 
     def deleteXcfgData(self) -> None:
         for function_id, function_entry in self._functions.items():

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -1506,15 +1506,41 @@ class MongoDbStorage(StorageInterface):
             stats["num_functions"] += family_document["num_functions"]
         return stats
 
+    def _hashableSizeQuery(self) -> Optional[Dict]:
+        """Query fragment for "this function is large enough to receive a MinHash".
+
+        Mirrors StorageInterface.isHashableBySize. Returns None when no threshold is active, in
+        which case nothing is hashable and the caller should not query at all.
+        """
+        clauses = []
+        if self._minhash_config.MINHASH_FN_MIN_BLOCKS:
+            clauses.append({"num_blocks": {"$gt": self._minhash_config.MINHASH_FN_MIN_BLOCKS}})
+        if self._minhash_config.MINHASH_FN_MIN_INS:
+            clauses.append({"num_instructions": {"$gt": self._minhash_config.MINHASH_FN_MIN_INS}})
+        if not clauses:
+            return None
+        return clauses[0] if len(clauses) == 1 else {"$or": clauses}
+
     def getUnhashedFunctions(self, function_ids: Optional[List[int]] = None, only_function_ids=False) -> List[Union[int, "FunctionEntry"]]:
-        unhashed_functions = []
-        search_query = {}
+        # Select in the database rather than in Python. Both filters matter on a large corpus:
+        # "minhash is empty" is trivially indexable work the server should not ship to the client,
+        # and the size filter keeps functions that can never BE hashed out of the result. Without
+        # it, every caller re-fetches the disassembly of every sub-threshold function to rediscover
+        # it is too small - on an 11.6M-function corpus that was 4.16M of the 10.01M functions with
+        # an empty minhash, on every invocation, which is enough to stall a repair and exhaust the
+        # memory of the process pool that consumes the result.
+        hashable_query = self._hashableSizeQuery()
+        if hashable_query is None:
+            return []
+        search_query = {"minhash": "", **hashable_query}
         if function_ids is not None:
-            search_query = {"function_id": {"$in": list(function_ids)}}
+            search_query["function_id"] = {"$in": list(function_ids)}
+        # only_function_ids wants exactly one field; projecting it keeps the scan from dragging
+        # every other field of every matching document across the wire for nothing.
+        projection = {"function_id": 1, "_id": 0} if only_function_ids else {"_id": 0}
+        unhashed_functions = []
         pending_documents = []
-        for function_document in self._getDb().functions.find(search_query, {"_id": 0}):
-            if function_document["minhash"] != "":
-                continue
+        for function_document in self._getDb().functions.find(search_query, projection):
             if only_function_ids:
                 unhashed_functions.append(function_document["function_id"])
             else:

--- a/mcrit/storage/StorageInterface.py
+++ b/mcrit/storage/StorageInterface.py
@@ -637,6 +637,22 @@ class StorageInterface:
         """
         return None
 
+    def isHashableBySize(self, num_instructions: int, num_blocks: int) -> bool:
+        """Whether a function of this size can receive a MinHash at all.
+
+        Mirrors MinHasher.isMinHashableFunction, but from the counts stored on a function document,
+        so a caller can decide before paying to load and parse the disassembly. Note that a
+        threshold of 0 is falsy and therefore disables its clause rather than meaning "no minimum" -
+        with both thresholds at 0 nothing is hashable, which is what isMinHashableFunction does too.
+        """
+        min_blocks = self._minhash_config.MINHASH_FN_MIN_BLOCKS
+        min_instructions = self._minhash_config.MINHASH_FN_MIN_INS
+        if min_blocks and num_blocks > min_blocks:
+            return True
+        if min_instructions and num_instructions > min_instructions:
+            return True
+        return False
+
     def getUnhashedFunctions(self, function_ids: Optional[List[int]] = None, only_function_ids=False) -> List[Union[int, "FunctionEntry"]]:
         """Given a list of function_ids, return all FunctionEntry objects corresponding to these IDs if they do not have a minhash yet.
         Otherwise, return all FunctionEntry objects that do not have a minhash.

--- a/tests/testUnhashedFunctions.py
+++ b/tests/testUnhashedFunctions.py
@@ -1,0 +1,134 @@
+#!/usr/bin/python
+
+import json
+import logging
+import os
+import unittest
+
+from smda.common.BinaryInfo import BinaryInfo
+from smda.common.SmdaFunction import SmdaFunction
+from smda.common.SmdaReport import SmdaReport
+
+from mcrit.config.McritConfig import McritConfig
+from mcrit.config.MinHashConfig import MinHashConfig
+from mcrit.config.QueueConfig import QueueConfig
+from mcrit.config.ShinglerConfig import ShinglerConfig
+from mcrit.config.StorageConfig import StorageConfig
+from mcrit.minhash.MinHasher import MinHasher
+from mcrit.storage.StorageFactory import StorageFactory
+
+LOG = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)-15s %(message)s")
+logging.disable(logging.CRITICAL)
+
+THIS_FILE_PATH = str(os.path.abspath(__file__))
+PROJECT_ROOT = str(os.path.abspath(os.sep.join([THIS_FILE_PATH, "..", ".."])))
+EXAMPLE_REPORT = os.sep.join([PROJECT_ROOT, "tests", "example_report.smda"])
+
+
+def loadExampleReport():
+    with open(EXAMPLE_REPORT) as handle:
+        report = SmdaReport.fromDict(json.load(handle))
+    assert report is not None, "example report failed to parse"
+    return report
+
+
+def buildMemoryStorage(min_instructions=10, min_blocks=0):
+    config = McritConfig()
+    config.STORAGE_CONFIG = StorageConfig(STORAGE_METHOD=StorageFactory.STORAGE_METHOD_MEMORY)
+    config.MINHASH_CONFIG = MinHashConfig()
+    config.MINHASH_CONFIG.MINHASH_FN_MIN_INS = min_instructions
+    config.MINHASH_CONFIG.MINHASH_FN_MIN_BLOCKS = min_blocks
+    config.SHINGLER_CONFIG = ShinglerConfig()
+    config.QUEUE_CONFIG = QueueConfig()
+    return StorageFactory.getStorage(config), config
+
+
+class HashableBySizeTestSuite(unittest.TestCase):
+    """isHashableBySize has to agree with MinHasher.isMinHashableFunction, because it exists to let
+    a caller skip work the hasher would discard anyway."""
+
+    def testAgreesWithTheHasherOnRealFunctions(self):
+        storage, config = buildMemoryStorage()
+        hasher = MinHasher(config.MINHASH_CONFIG, config.SHINGLER_CONFIG)
+        report = loadExampleReport()
+        checked = 0
+        for function in report.getFunctions():
+            checked += 1
+            self.assertEqual(
+                hasher.isMinHashableFunction(function),
+                storage.isHashableBySize(function.num_instructions, function.num_blocks),
+                "disagreement on a function with %d instructions / %d blocks" % (function.num_instructions, function.num_blocks),
+            )
+        self.assertGreater(checked, 0)
+
+    def testThresholdOfZeroDisablesItsClause(self):
+        """A threshold of 0 is falsy and switches its clause off rather than meaning "no minimum" -
+        the same quirk isMinHashableFunction has. With both at 0 nothing is hashable."""
+        storage, _ = buildMemoryStorage(min_instructions=0, min_blocks=0)
+        self.assertFalse(storage.isHashableBySize(1000, 1000))
+        storage, _ = buildMemoryStorage(min_instructions=0, min_blocks=5)
+        self.assertTrue(storage.isHashableBySize(1, 6))
+        self.assertFalse(storage.isHashableBySize(1000, 5))
+
+    def testEitherThresholdSuffices(self):
+        storage, _ = buildMemoryStorage(min_instructions=10, min_blocks=5)
+        self.assertTrue(storage.isHashableBySize(11, 1))
+        self.assertTrue(storage.isHashableBySize(1, 6))
+        self.assertFalse(storage.isHashableBySize(10, 5))
+
+
+class UnhashedFunctionSelectionTestSuite(unittest.TestCase):
+    """getUnhashedFunctions feeds minhash generation, so returning functions that can never be
+    hashed makes every caller load their disassembly to rediscover that."""
+
+    def setUp(self):
+        self.storage, self.config = buildMemoryStorage()
+        self.storage.addSmdaReport(loadExampleReport())
+
+    def testSubThresholdFunctionsAreNotReturned(self):
+        unhashed = self.storage.getUnhashedFunctions()
+        self.assertTrue(unhashed)
+        for entry in unhashed:
+            self.assertTrue(
+                self.storage.isHashableBySize(entry.num_instructions, entry.num_blocks),
+                "returned a function of %d instructions, which can never be hashed" % entry.num_instructions,
+            )
+
+    def testTheCorpusActuallyContainsSubThresholdFunctions(self):
+        """Otherwise the test above proves nothing."""
+        every = [entry for _, entry in self.storage._functions.items()]
+        too_small = [entry for entry in every if not self.storage.isHashableBySize(entry.num_instructions, entry.num_blocks)]
+        self.assertTrue(too_small, "example report has no sub-threshold functions to exclude")
+        returned_ids = {entry.function_id for entry in self.storage.getUnhashedFunctions()}
+        for entry in too_small:
+            self.assertNotIn(entry.function_id, returned_ids)
+
+    def testOnlyFunctionIdsAgreesWithTheFullForm(self):
+        ids = self.storage.getUnhashedFunctions(None, only_function_ids=True)
+        entries = self.storage.getUnhashedFunctions()
+        self.assertEqual(sorted(ids), sorted(entry.function_id for entry in entries))
+        self.assertTrue(all(isinstance(function_id, int) for function_id in ids))
+
+    def testFilteringByFunctionIdsStillAppliesTheSizeFilter(self):
+        every_id = [entry.function_id for _, entry in self.storage._functions.items()]
+        selected = self.storage.getUnhashedFunctions(every_id)
+        for entry in selected:
+            self.assertTrue(self.storage.isHashableBySize(entry.num_instructions, entry.num_blocks))
+
+    def testHashedFunctionsAreNotReturned(self):
+        hasher = MinHasher(self.config.MINHASH_CONFIG, self.config.SHINGLER_CONFIG)
+        unhashed = self.storage.getUnhashedFunctions()
+        self.assertTrue(unhashed)
+        minhashes = []
+        for entry in unhashed:
+            binary_info = BinaryInfo(b"")
+            binary_info.architecture = entry.architecture
+            smda_function = SmdaFunction.fromDict(entry.xcfg, binary_info=binary_info)
+            minhashes.append(hasher.calculateMinHashFromStorage((entry.function_id, smda_function)))
+        self.storage.addMinHashes(minhashes)
+        self.assertEqual([], self.storage.getUnhashedFunctions())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The problem

`getUnhashedFunctions` defines its work as "minhash is empty". That set includes every function below `MINHASH_FN_MIN_INS` / `MINHASH_FN_MIN_BLOCKS` - functions that can never receive a MinHash at all. So callers load and parse the disassembly of all of them on every invocation, only for `calculateMinHashes` to discard them by the same criterion a moment later:

```python
smda_functions = [(fid, fn) for fid, fn in smda_functions if self.minhasher.isMinHashableFunction(fn)]
```

This is cheap on a small corpus and gets expensive in proportion to how many short functions accumulate.

## What it cost in practice

Measured while repairing an 11.6M-function instance after the SMDA 4.4.5 escaper change (the situation #142 describes):

* **10,013,479** functions had an empty minhash
* of those, only **5,853,524** could ever receive one
* the remaining **4,160,000** were re-fetched from the `xcfg` collection on every invocation

A full re-hash appeared to hang - the hashed count stood still while the log repeated `Calculating MinHashes: 0 function entries are indexable` batch after batch - and the process pool consuming the result was **OOM-killed twice**, at `MINHASH_GENERATION_WORKPACK_SIZE` 10000 and again at 2000. The batch size was never what drove it; it only changed how long it took to get there.

With the size criterion pushed into the query, the same repair completed in 204 minutes at 477 functions/s.

## The change

Three parts, all in the selection:

* **`StorageInterface.isHashableBySize(num_instructions, num_blocks)`** mirrors `MinHasher.isMinHashableFunction` from the counts already stored on a function document, so a caller can decide *before* paying to load and parse disassembly. A test asserts the two agree on every function in `example_report.smda`, which is what makes filtering early safe.
* **The MongoDB query now carries both filters** - `{"minhash": "", <size clause>}` - instead of `find({}, {"_id": 0})` followed by a Python `continue`.
* **`only_function_ids=True` projects just `function_id`**, rather than dragging every field of every matching document across the wire to read one of them.

`MemoryStorage` gets the same selection. That also settles a divergence between the backends: it required `xcfg` to be present in the `function_ids is None` branch but not in the explicit-ids one.

## Behaviour

Unchanged for callers. All three call sites are in `Worker.updateMinHashes`, and everything now excluded was already being discarded by `calculateMinHashes` immediately afterwards - so the outcome is identical and the cost is not.

**One quirk is mirrored rather than fixed.** A threshold of `0` is falsy, so it *disables* its clause rather than meaning "no minimum"; with both thresholds at 0, nothing is hashable. That is what `isMinHashableFunction` already does, so the new query returns nothing in that case where it previously returned everything (which the hasher then dropped). I have pinned the current semantics with a test rather than quietly changing them - if `0` should mean "no minimum", that seems worth deciding on its own.

## Not included: version bump or changelog

Deliberately, so this does not conflict with #147 - both would otherwise touch `pyproject.toml`, `McritConfig.py` and `CHANGELOG.md`. This branch is off current `main` and carries only the fix and its tests, so it can be folded into whichever release suits without a rebase fight.

## Tests

8 new tests in `tests/testUnhashedFunctions.py`: agreement with `isMinHashableFunction` across a real report, the falsy-threshold semantics, either-threshold-suffices, exclusion of sub-threshold functions (with a companion test asserting the fixture *contains* some, so the first one cannot pass vacuously), `only_function_ids` agreeing with the full form, the size filter still applying when explicit ids are passed, and hashed functions dropping out of the result.

Full suite passes against a real MongoDB (211 passed, 34 subtests), `ruff format`, `ruff check` and `ty` all clean.

## Related

Same corpus and repair that motivated #142. This is the "why the global repair path is impractical at scale" half; the selective-repair half of #142 is still open, and would benefit from the same predicate.
