### PR TITLE
Stop indexing _picblockhashes.offset, which no query can use

### DIFF
--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -205,7 +205,6 @@ class MongoDbStorage(StorageInterface):
         self._getDb()["functions"].create_index("function_name")
         self._getDb()["functions"].create_index("_pichash")
         self._getDb()["functions"].create_index("_picblockhashes.hash")
-        self._getDb()["functions"].create_index("_picblockhashes.offset")
         # stored without guarantee of existence
         self._getDb()["query_samples"].create_index("sample_id")
         self._getDb()["query_samples"].create_index("sha256")

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -567,13 +567,21 @@ class MongoDbStorageTest(MemoryStorageTest):
         expected_indexed_fields = {
             "samples": {"sample_id", "sha256", "family_id"},
             "families": {"family_id", "family_name"},
-            "functions": {"function_id", "sample_id", "family_id", "function_name", "_pichash", "_picblockhashes.hash", "_picblockhashes.offset"},
+            "functions": {"function_id", "sample_id", "family_id", "function_name", "_pichash", "_picblockhashes.hash"},
             "query_samples": {"sample_id", "sha256"},
         }
         for collection, expected_fields in expected_indexed_fields.items():
             index_information = self.storage._getDb()[collection].index_information()
             indexed_fields = set(key for index in index_information.values() for key, _direction in index["key"])
             self.assertTrue(expected_fields.issubset(indexed_fields), f"missing indexes on {collection}: {expected_fields - indexed_fields}")
+
+    def testStorageDoesNotIndexPicBlockHashOffset(self):
+        # No query filters or sorts on "_picblockhashes.offset" - getMatchesForPicBlockHash only
+        # projects it, which an index cannot serve. Pinned so the index is not reintroduced by
+        # symmetry with "_picblockhashes.hash", which is filtered on and does need one.
+        index_information = self.storage._getDb()["functions"].index_information()
+        indexed_fields = set(key for index in index_information.values() for key, _direction in index["key"])
+        self.assertNotIn("_picblockhashes.offset", indexed_fields)
 
     def testGetSampleBySha256ForQuerySamples(self):
         self.storage.clearStorage()


### PR DESCRIPTION
`_picblockhashes.offset` is indexed at `MongoDbStorage._ensureIndexAndUnknownFamily`, next to `_picblockhashes.hash`. Nothing can use it.

### Why no query can use it

`.hash` is filtered on and needs its index — `getMatchesForPicBlockHash` matches `{"_picblockhashes.hash": hex(picblockhash)}`. `.offset` appears exactly once more in the codebase, in the `$project` of that same aggregation:

```python
{"$project": {"_id": 0, "function_id": 1, "family_id": 1, "sample_id": 1, "offset": "$_picblockhashes.offset"}},
```

A projection is not a predicate, so no index serves it. The only other reader, `getUniqueBlocks`, takes the array out of documents it has already fetched.

### Measured

`$indexStats` on a production instance (8,691 samples / 11,669,208 functions), 6 days of uptime:

```
function_id_1              ops=9583714
sample_id_1                ops=9696
_pichash_1                 ops=328
_picblockhashes.hash_1     ops=62
_picblockhashes.offset_1   ops=0        <- 0.678 GB
```

Index sizes on `functions` for that instance:

| index | size |
|---|---|
| `_picblockhashes.hash_1` | 1.119 GB |
| **`_picblockhashes.offset_1`** | **0.678 GB** |
| `_pichash_1` | 0.271 GB |
| `_id_` | 0.145 GB |
| `function_id_1` | 0.123 GB |
| others | 0.183 GB |
| **total** | **2.519 GB** |

So it is **27% of the collection's index footprint**, and being multikey it also costs one index entry per block per function on every insert — writes that are never read back.

### What this does and does not do

Removing the `create_index` stops *new* deployments building it. An existing instance keeps its copy until dropped:

```js
db.functions.dropIndex("_picblockhashes.offset_1")
```

**I deliberately did not put that drop in `_ensureIndexAndUnknownFamily`.** That method runs on every `MongoDbStorage` construction, and having it silently drop an index on startup seemed like the wrong kind of surprise — dropping is fast and non-destructive to data, but it is still an operation an admin should choose. If you would rather it self-heal, it is a one-liner to add and I am happy to.

### Tests

`testStorageInitializationCreatesIndexes` asserts `issubset`, so it would have passed either way; `.offset` is removed from its expected set, and `testStorageDoesNotIndexPicBlockHashOffset` is added to pin the absence, so the index is not reintroduced by symmetry with `.hash`.

```
204 passed, 34 subtests passed in 82.04s
All checks passed!            # ruff check
136 files already formatted   # ruff format --check
```

### Evidence strength

The code reading and the index sizes are **measured**; the `ops=0` is measured **on one instance over 6 days**, so it shows this deployment's traffic never used it, and the code reading is what shows nothing *could*. Note that `family_id_1` and `function_name_1` also report 0 ops there — those have plausible consumers that instance simply did not exercise, which is exactly why I am not proposing to touch them.

No version bump or changelog entry, to avoid conflicting with the open PRs; fold into whichever release suits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwSfzAD1ZwEoWY3eWvbYvX
