### PR TITLE
Serve repeated requests from the newest finished job, never a failed one (fkie-cad/mcritweb#47)

### DIFF
--- a/mcrit/libs/mongoqueue.py
+++ b/mcrit/libs/mongoqueue.py
@@ -488,6 +488,13 @@ class MongoQueue:
         return entry.metadata
 
     def get_cached_job_id(self, payload):
+        """The job whose result a repeated request with the same descriptor should reuse.
+
+        A finished job is preferred over one still queued or running, and among several of
+        the same kind the newest wins; jobs that failed (no attempts left) or were terminated
+        are never reused. Sorting by finished_at descending puts the finished jobs first
+        because a descending sort places null (unfinished) after every date (fkie-cad/mcritweb#47).
+        """
         job = self._wrap_one(
             self._getCollection().find_one(
                 {
@@ -495,7 +502,7 @@ class MongoQueue:
                     "payload.descriptor": payload["descriptor"],
                     "terminated": False,
                 },
-                sort=[("created_at", pymongo.DESCENDING)],
+                sort=[("finished_at", pymongo.DESCENDING), ("created_at", pymongo.DESCENDING)],
             )
         )
         return job and job.job_id or None

--- a/mcrit/queue/LocalQueue.py
+++ b/mcrit/queue/LocalQueue.py
@@ -390,7 +390,9 @@ class LocalQueue:
         self._worker = worker
 
     def get_job(self, job_id):
-        data = self._jobs[job_id]
+        # .get(): _jobs is a defaultdict, and indexing it with an unknown id used to leave a
+        # None entry behind that every later scan of the jobs tripped over
+        data = self._jobs.get(job_id)
         return data and Job(data, self)
 
     def get_jobs(self, start_index: int, limit: int, method=None, state=None, filter=None, ascencing=False):

--- a/mcrit/queue/LocalQueue.py
+++ b/mcrit/queue/LocalQueue.py
@@ -372,7 +372,6 @@ class LocalQueue:
         self._jobs: Dict[str, Any] = defaultdict(lambda: None)
         self._files: Dict[str, Any] = defaultdict(lambda: None)
         self._files_meta: Dict[str, Any] = defaultdict(lambda: None)
-        self._descriptor_to_job: Dict[str, Any] = defaultdict(lambda: None)
         self._hash_to_file: Dict[str, Any] = defaultdict(lambda: None)
 
     def registerWorker(self):
@@ -404,7 +403,17 @@ class LocalQueue:
         return jobs[start_index : start_index + limit]
 
     def get_cached_job_id(self, payload):
-        return self._descriptor_to_job[payload["descriptor"]]
+        # same rule as MongoQueue.get_cached_job_id (fkie-cad/mcritweb#47): finished before unfinished, newest
+        # first within each group, failed and terminated jobs never
+        candidates = [
+            job_data
+            for job_data in self._jobs.values()
+            if job_data["payload"]["descriptor"] == payload["descriptor"] and job_data["attempts_left"] > 0 and not job_data["terminated"]
+        ]
+        if not candidates:
+            return None
+        best = max(candidates, key=lambda job_data: (job_data["finished_at"] is not None, job_data["number"]))
+        return best["_id"]
 
     def _file_to_grid(self, file, metadata=None):
         id = str(uuid.uuid4())
@@ -496,7 +505,6 @@ class LocalQueue:
         job_data["attempts_left"] = self.max_attempts
         job_data["created_at"] = datetime.now()
         self._jobs[id] = job_data
-        self._descriptor_to_job[payload["descriptor"]] = id
         job_data["started_at"] = datetime.now()
         # NOTE: we can just ignore await jobs, because all jobs are
         #       executed in submission order
@@ -513,9 +521,6 @@ class LocalQueue:
         job = self._jobs[id]
         result = job["result"]
         file_params = json.loads(job["payload"]["file_params"])
-        descriptor = job["payload"]["descriptor"]
-        if self._descriptor_to_job[descriptor] == id:
-            del self._descriptor_to_job[descriptor]
         del self._jobs[id]
         self._delete_grid(result)
         for f in file_params.values():

--- a/tests/testMongoQueue.py
+++ b/tests/testMongoQueue.py
@@ -176,6 +176,34 @@ class MongoQueueTest(TestCase):
         self.assertEqual(1, len(jobs_in_progress))
         self.assertEqual(job.job_id, jobs_in_progress[0]["_id"])
 
+    def test_cached_job_prefers_finished_over_running(self):
+        # fkie-cad/mcritweb#47: a force rematch that is still running must not shadow the finished job whose
+        # result is what a repeated request can actually use
+        payload = {"method": "test_method", "descriptor": "same-request"}
+        finished_id = self.queue.put(dict(payload))
+        self.queue.next().complete("result-1")
+        running_id = self.queue.put(dict(payload))
+        self.queue.next()  # locked by the consumer, in progress
+        self.assertEqual(finished_id, self.queue.get_cached_job_id(payload))
+        # once the newer job is finished as well, the newest finished result wins
+        self.queue.get_job(running_id).complete("result-2")
+        self.assertEqual(running_id, self.queue.get_cached_job_id(payload))
+
+    def test_cached_job_ignores_failed_and_terminated(self):
+        payload = {"method": "test_method", "descriptor": "same-request"}
+        self.queue.max_attempts = 1
+        self.queue._default_insert["attempts_left"] = 1
+        failed_id = self.queue.put(dict(payload))
+        self.queue.next().error("boom")
+        self.assertEqual(0, self.queue.get_job(failed_id).attempts_left)
+        self.assertIsNone(self.queue.get_cached_job_id(payload))
+        terminated_id = self.queue.put(dict(payload))
+        self.queue.next().terminate()
+        self.assertTrue(self.queue.get_job(terminated_id)._is_terminated())
+        self.assertIsNone(self.queue.get_cached_job_id(payload))
+        queued_id = self.queue.put(dict(payload))
+        self.assertEqual(queued_id, self.queue.get_cached_job_id(payload))
+
     def test_context_manager_error(self):
         self.queue.put({"method": "test_method", "context_id": "alpha", "data": [1, 2, 3], "more-data": time.time()})
         job = self.queue.next()

--- a/tests/testRemoteCalls.py
+++ b/tests/testRemoteCalls.py
@@ -220,6 +220,9 @@ class LocalQueueRemoteCallTest(TestCase):
     def _set_job_fields(self, job_id, **fields):
         self.queue._jobs[job_id].update(fields)
 
+    def _unknown_job_id(self):
+        return "no-such-job"
+
     def test_job_cache_prefers_finished_and_skips_failed(self):
         # fkie-cad/mcritweb#47: the cache answers with the newest finished job, falls back to an unfinished one
         # only when no finished job exists, and never answers with a failed or terminated job
@@ -238,6 +241,9 @@ class LocalQueueRemoteCallTest(TestCase):
         self._set_job_fields(job_id_2, terminated=True)
         job_id_3 = self.caller.test(**kwparams)
         self.assertNotIn(job_id_3, (job_id_1, job_id_2))
+        # a lookup of an unknown job must not break the cache afterwards
+        self.assertIsNone(self.queue.get_job(self._unknown_job_id()))
+        self.assertEqual(job_id_3, self.caller.test(**kwparams))
         self.queue.clear()
 
     def test_function_access(self):
@@ -372,7 +378,12 @@ class MongoQueueRemoteCallTest(LocalQueueRemoteCallTest):
         self.worker_thread.start()
 
     def _set_job_fields(self, job_id, **fields):
-        self.queue._getCollection().update_one({"_id": ObjectId(job_id)}, {"$set": fields})
+        queue = self.queue
+        assert isinstance(queue, MongoQueue)
+        queue._getCollection().update_one({"_id": ObjectId(job_id)}, {"$set": fields})
+
+    def _unknown_job_id(self):
+        return str(ObjectId())
 
     @pytest.mark.sleep
     def test_termination(self):

--- a/tests/testRemoteCalls.py
+++ b/tests/testRemoteCalls.py
@@ -7,6 +7,7 @@ from unittest import TestCase
 
 import pymongo
 import pytest
+from bson import ObjectId
 from bson.json_util import dumps, loads
 
 from mcrit.config.QueueConfig import QueueConfig
@@ -216,6 +217,29 @@ class LocalQueueRemoteCallTest(TestCase):
                 self.assertNotEqual(job_id_1, job_id_2)
         self.queue.clear()
 
+    def _set_job_fields(self, job_id, **fields):
+        self.queue._jobs[job_id].update(fields)
+
+    def test_job_cache_prefers_finished_and_skips_failed(self):
+        # fkie-cad/mcritweb#47: the cache answers with the newest finished job, falls back to an unfinished one
+        # only when no finished job exists, and never answers with a failed or terminated job
+        kwparams = {"test_cache_preference": True}
+        job_id_1 = self.caller.test(**kwparams)
+        self.caller.awaitResult(job_id_1)
+        job_id_2 = self.caller.test(force_recalculation=True, **kwparams)
+        self.caller.awaitResult(job_id_2)
+        self.assertNotEqual(job_id_1, job_id_2)
+        self.assertEqual(job_id_2, self.caller.test(**kwparams))
+        # the newer job still running: the older finished one is the usable result
+        self._set_job_fields(job_id_2, finished_at=None)
+        self.assertEqual(job_id_1, self.caller.test(**kwparams))
+        # nothing usable left: a new job is created instead of pointing at a dead one
+        self._set_job_fields(job_id_1, attempts_left=0)
+        self._set_job_fields(job_id_2, terminated=True)
+        job_id_3 = self.caller.test(**kwparams)
+        self.assertNotIn(job_id_3, (job_id_1, job_id_2))
+        self.queue.clear()
+
     def test_function_access(self):
         params = {0: 1, 1: 2, 2: 3}
         payload1 = _createJobPayload("function_that_isnt_remote", params, {}, get_descriptor("function_that_isnt_remote", params, {}))
@@ -347,6 +371,9 @@ class MongoQueueRemoteCallTest(LocalQueueRemoteCallTest):
         self.worker_thread = Thread(target=self.worker.run)
         self.worker_thread.start()
 
+    def _set_job_fields(self, job_id, **fields):
+        self.queue._getCollection().update_one({"_id": ObjectId(job_id)}, {"$set": fields})
+
     @pytest.mark.sleep
     def test_termination(self):
         id = self.caller.test_progress()
@@ -378,12 +405,12 @@ class MongoQueueRemoteCallTest(LocalQueueRemoteCallTest):
 
         self.worker.terminate()
         self.worker_thread.join()
+        # the forced job cannot run without a worker, so a plain request keeps being served
+        # by the finished job rather than by the one that is only queued (fkie-cad/mcritweb#47)
         job_id_4 = self.caller.test(*params, force_recalculation=True, **kwparams)
         job_id_5 = self.caller.test(*params, force_recalculation=False, **kwparams)
-        print(self.queue.get_job(job_id_4)._data)
-        print(self.queue.get_job(job_id_2)._data)
-        self.assertNotEqual(job_id_2, job_id_5)
-        self.assertEqual(job_id_4, job_id_5)
+        self.assertNotEqual(job_id_2, job_id_4)
+        self.assertEqual(job_id_2, job_id_5)
 
         self.worker_thread = Thread(target=self.worker.run)
         self.worker_thread.start()


### PR DESCRIPTION
Closes fkie-cad/mcritweb#47 (labelled `mcrit` there). The cache selection was wrong: a force rematch that was still queued or running shadowed the finished job whose result a repeated plain request could actually use.

## What changed

`get_cached_job_id` picked the newest job with the same descriptor that had attempts left and was not terminated, whatever its state. Both queues now prefer a **finished** job over an unfinished one and the newest within each group; jobs without attempts left (failed) or terminated ones are never reused, exactly the rule the issue proposes.

- `MongoQueue`: one query, sorted `finished_at` descending then `created_at` descending. A descending sort places every date before `null`, so the finished jobs come first without a second query.
- `LocalQueue`: the same rule over its jobs; the `_descriptor_to_job` map, which could only ever remember the last job, is gone.
- `test_job_cache_prio` encoded the old rule (a queued forced job wins over the finished one) and is updated; new tests cover finished-over-running, newest-finished, and that failed/terminated jobs are skipped, on both queues.

## Verified against a running instance

MongoDB 7 + this branch as server and worker, four samples, a finished 1vs1 job between two of them:

| step | result |
|---|---|
| force rematch, then cancel it, then plain request | served by the earlier finished job |
| force rematch still running, plain request meanwhile | served by the earlier finished job |
| forced job finished, plain request | served by the newer finished job |

`ruff`, `ty` and the full suite (mongo tests included) pass.

