### PR TITLE
Record who asked for a job (fkie-cad/mcritweb#37)

### DIFF
--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -375,7 +375,7 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
         LOGGER.info("Added %d function entries.", len(function_entries))
         job_id = None
         if calculate_hashes:
-            job_id = self.updateMinHashesForSample(sample_entry.sample_id)
+            job_id = self.updateMinHashesForSample(sample_entry.sample_id, username=username)
         return {"existed": False, "sample_info": sample_entry.toDict(), "job_id": job_id}
 
     def addReportJson(self, report_json, calculate_hashes=True, calculate_matches=False, username=None):

--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -388,15 +388,15 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
         report = SmdaReport.fromDict(report_json)
         return self.addReport(report, calculate_hashes=calculate_hashes, calculate_matches=calculate_matches)
 
-    def getMatchesCross(self, sample_ids: List[int], sample_group_only=False, force_recalculation=False, **params):
+    def getMatchesCross(self, sample_ids: List[int], sample_group_only=False, force_recalculation=False, username=None, **params):
         sample_to_job_id = {}
         for id in sample_ids:
             if sample_group_only:
-                job_id = self.getMatchesForSampleVsGroup(id, [sid for sid in sample_ids if sid != id], force_recalculation=force_recalculation, **params)
+                job_id = self.getMatchesForSampleVsGroup(id, [sid for sid in sample_ids if sid != id], force_recalculation=force_recalculation, username=username, **params)
             else:
-                job_id = self.getMatchesForSample(id, force_recalculation=force_recalculation, **params)
+                job_id = self.getMatchesForSample(id, force_recalculation=force_recalculation, username=username, **params)
             sample_to_job_id[id] = job_id
-        return self.combineMatchesToCross(sample_to_job_id, await_jobs=[*sample_to_job_id.values()], force_recalculation=force_recalculation)
+        return self.combineMatchesToCross(sample_to_job_id, await_jobs=[*sample_to_job_id.values()], force_recalculation=force_recalculation, username=username)
 
     def getMatchesForSmdaFunction(self, smda_report_with_function: SmdaReport, minhash_threshold=None, pichash_size=None, band_matches_required=None, exclude_self_matches=False):
         # convert function to FunctionEntry

--- a/mcrit/libs/mongoqueue.py
+++ b/mcrit/libs/mongoqueue.py
@@ -249,13 +249,14 @@ class MongoQueue:
         """ """
         self._getCollection().find_one_and_update({"attempts_left": {"$lte": 0}}, remove=True)
 
-    def put(self, payload, priority=0, await_jobs: List[str] = []):
-        """Place a job into the queue"""
+    def put(self, payload, priority=0, await_jobs: List[str] = [], username=None):
+        """Place a job into the queue; username records who asked for it (fkie-cad/mcritweb#37)"""
         job = dict(self._default_insert)
         job["number"] = _useCounter(self._getCollection().database, "job")
         job["created_at"] = datetime.now()
         job["priority"] = priority
         job["payload"] = payload
+        job["username"] = username
         await_jobs_set = set(await_jobs)
         job["unfinished_dependencies"] = list(await_jobs_set)
         job["all_dependencies"] = list(await_jobs_set)
@@ -609,6 +610,11 @@ class Job:
     @property
     def priority(self):
         return self._data["priority"]
+
+    @property
+    def username(self):
+        # absent on jobs created before the field existed
+        return self._data.get("username")
 
     @property
     def attempts_left(self):

--- a/mcrit/queue/LocalQueue.py
+++ b/mcrit/queue/LocalQueue.py
@@ -246,6 +246,11 @@ class Job:
         return self._data["priority"]
 
     @property
+    def username(self):
+        # who asked for the job (fkie-cad/mcritweb#37); None on jobs from a backend that did not record it
+        return self._data.get("username")
+
+    @property
     def attempts_left(self):
         return self._data["attempts_left"]
 
@@ -484,13 +489,14 @@ class LocalQueue:
         del self._files[grid]
         del self._files_meta[grid]
 
-    def put(self, payload, await_jobs=[]):
+    def put(self, payload, await_jobs=[], username=None):
         id = str(uuid.uuid4())
         job_data: Dict[str, Any] = defaultdict(lambda: None)
         job_data["_id"] = id
         job_data["number"] = self._job_counter
         self._job_counter += 1
         job_data["payload"] = payload
+        job_data["username"] = username
         job_data["unfinished_dependencies"] = await_jobs
         job_data["all_dependencies"] = await_jobs
         job_data["attempts_left"] = self.max_attempts

--- a/mcrit/queue/QueueRemoteCalls.py
+++ b/mcrit/queue/QueueRemoteCalls.py
@@ -127,11 +127,13 @@ def QueueRemoteCaller(clsCallee):
 
 # Wrapper that creates a remote call proxy for a given method
 def RemotifyFunctionWrapper(function):
-    def submitPayloadQueue(self, payload, await_jobs):
-        return str(self.queue.put(payload, await_jobs=await_jobs))
+    def submitPayloadQueue(self, payload, await_jobs, username):
+        return str(self.queue.put(payload, await_jobs=await_jobs, username=username))
 
     # remote call proxy
-    def remote_call_function(self, *params, await_jobs=None, force_recalculation=False, **kwparams):
+    # username is who asked for the job (fkie-cad/mcritweb#37): it is recorded on the job document and is not
+    # part of the descriptor, so a request by another user is still served from the cache
+    def remote_call_function(self, *params, await_jobs=None, force_recalculation=False, username=None, **kwparams):
         name = function.__name__
 
         # join file locations:
@@ -158,7 +160,7 @@ def RemotifyFunctionWrapper(function):
         payload = _createJobPayload(name, params, grid_params, descriptor)
         if await_jobs is None:
             await_jobs = []
-        job_id = submitPayloadQueue(self, payload, await_jobs)
+        job_id = submitPayloadQueue(self, payload, await_jobs, username)
 
         # Add job ids to parameters
         add_job_id_to_files(self, job_id, grid_params)

--- a/mcrit/server/BlocksResource.py
+++ b/mcrit/server/BlocksResource.py
@@ -1,7 +1,7 @@
 import re
 
 from mcrit.index.MinHashIndex import MinHashIndex
-from mcrit.server.utils import db_log_msg, getUniqueBlocksParams, jsonify, timing
+from mcrit.server.utils import db_log_msg, get_username, getUniqueBlocksParams, jsonify, timing
 
 
 class BlocksResource:
@@ -15,7 +15,7 @@ class BlocksResource:
         blocks_result = {}
         samples = self.index.getSamplesByFamilyId(family_id)
         target_sample_ids = [sample.sample_id for sample in samples]
-        blocks_result = self.index.getUniqueBlocks(target_sample_ids, family_id=family_id, **parameters)
+        blocks_result = self.index.getUniqueBlocks(target_sample_ids, family_id=family_id, username=get_username(req), **parameters)
         resp.data = jsonify({"status": "successful", "data": blocks_result})
 
     @timing
@@ -25,5 +25,5 @@ class BlocksResource:
         blocks_result = {}
         if comma_separated_sample_ids is not None and re.match(r"^\d+(?:[\s]*,[\s]*\d+)*$", comma_separated_sample_ids):
             target_sample_ids = [int(sample_id) for sample_id in comma_separated_sample_ids.split(",")]
-            blocks_result = self.index.getUniqueBlocks(target_sample_ids, **parameters)
+            blocks_result = self.index.getUniqueBlocks(target_sample_ids, username=get_username(req), **parameters)
         resp.data = jsonify({"status": "successful", "data": blocks_result})

--- a/mcrit/server/FamilyResource.py
+++ b/mcrit/server/FamilyResource.py
@@ -3,7 +3,7 @@ import re
 import falcon
 
 from mcrit.index.MinHashIndex import MinHashIndex
-from mcrit.server.utils import db_log_msg, jsonify, timing
+from mcrit.server.utils import db_log_msg, get_username, jsonify, timing
 
 
 class FamilyResource:
@@ -58,7 +58,7 @@ class FamilyResource:
                 information_update["is_library"] = True
             elif information_update["is_library"] in ["False", "false", "0", 0]:
                 information_update["is_library"] = False
-        successful = self.index.modifyFamily(family_id, information_update, force_recalculation=True)
+        successful = self.index.modifyFamily(family_id, information_update, force_recalculation=True, username=get_username(req))
         if successful:
             resp.data = jsonify({"status": "successful", "data": {"message": "Family modified."}})
             resp.status = falcon.HTTP_202
@@ -83,7 +83,7 @@ class FamilyResource:
         keep_samples = False
         if "keep_samples" in req.params:
             keep_samples = req.params["keep_samples"].lower().strip() == "true"
-        successful = self.index.deleteFamily(family_id, keep_samples=keep_samples, force_recalculation=True)
+        successful = self.index.deleteFamily(family_id, keep_samples=keep_samples, force_recalculation=True, username=get_username(req))
         if successful:
             db_log_msg(self.index, req, f"FamilyResource.on_delete - success - family_id: {family_id}, keep_samples={keep_samples}")
             resp.data = jsonify({"status": "successful", "data": successful})

--- a/mcrit/server/MatchResource.py
+++ b/mcrit/server/MatchResource.py
@@ -1,7 +1,7 @@
 import falcon
 
 from mcrit.index.MinHashIndex import MinHashIndex
-from mcrit.server.utils import db_log_msg, getMatchingParams, jsonify, timing
+from mcrit.server.utils import db_log_msg, get_username, getMatchingParams, jsonify, timing
 
 
 class MatchResource:
@@ -22,7 +22,7 @@ class MatchResource:
             db_log_msg(self.index, req, "MatchResource.on_get_sample - failed - unknown sample_id.")
             return
 
-        sample_matches = self.index.getMatchesForSample(sample_id, **parameters)
+        sample_matches = self.index.getMatchesForSample(sample_id, username=get_username(req), **parameters)
         resp.data = jsonify({"status": "successful", "data": sample_matches})
         db_log_msg(self.index, req, "MatchResource.on_get_sample - success.")
         # resp.status = falcon.HTTP_202
@@ -38,7 +38,7 @@ class MatchResource:
             db_log_msg(self.index, req, "MatchResource.on_get_sample_cross - failed - no sample_ids.")
             return
         sample_ids_list = [int(id) for id in sample_ids.split(",")]
-        cross_matches = self.index.getMatchesCross(sample_ids_list, **parameters)
+        cross_matches = self.index.getMatchesCross(sample_ids_list, username=get_username(req), **parameters)
         resp.data = jsonify({"status": "successful", "data": cross_matches})
         db_log_msg(self.index, req, "MatchResource.on_get_sample_cross - success.")
 
@@ -56,7 +56,7 @@ class MatchResource:
             resp.status = falcon.HTTP_404
             db_log_msg(self.index, req, "MatchResource.on_get_sample_vs - failed - unknown sample_id.")
             return
-        sample_matches = self.index.getMatchesForSampleVs(sample_id, sample_id_b, **parameters)
+        sample_matches = self.index.getMatchesForSampleVs(sample_id, sample_id_b, username=get_username(req), **parameters)
         resp.data = jsonify({"status": "successful", "data": sample_matches})
         db_log_msg(self.index, req, "MatchResource.on_get_sample_vs - success.")
 

--- a/mcrit/server/QueryResource.py
+++ b/mcrit/server/QueryResource.py
@@ -3,7 +3,7 @@ import re
 import falcon
 
 from mcrit.index.MinHashIndex import MinHashIndex
-from mcrit.server.utils import db_log_msg, getMatchingParams, jsonify, timing
+from mcrit.server.utils import db_log_msg, get_username, getMatchingParams, jsonify, timing
 
 
 class QueryResource:
@@ -25,7 +25,7 @@ class QueryResource:
             db_log_msg(self.index, req, "QueryResource.on_post_query_smda - failed - no POST body.")
             return
         smda_report = req.media
-        summary = self.index.getMatchesForSmdaReport(smda_report, **parameters)
+        summary = self.index.getMatchesForSmdaReport(smda_report, username=get_username(req), **parameters)
         resp.data = jsonify({"status": "successful", "data": summary})
         db_log_msg(self.index, req, "QueryResource.on_post_query_smda - success.")
 
@@ -43,7 +43,7 @@ class QueryResource:
             db_log_msg(self.index, req, "QueryResource.on_post_query_binary - failed - no POST body.")
             return
         binary = req.stream.read()
-        summary = self.index.getMatchesForUnmappedBinary(binary, **parameters)
+        summary = self.index.getMatchesForUnmappedBinary(binary, username=get_username(req), **parameters)
         resp.data = jsonify({"status": "successful", "data": summary})
         db_log_msg(self.index, req, "QueryResource.on_post_query_binary - success.")
 
@@ -63,7 +63,7 @@ class QueryResource:
         # convert string to int. 0 means figure out base automatically.
         base_address = int(base_address, 0) if base_address is not None else 0
         binary = req.stream.read()
-        summary = self.index.getMatchesForMappedBinary(binary, base_address, **parameters)
+        summary = self.index.getMatchesForMappedBinary(binary, base_address, username=get_username(req), **parameters)
         resp.data = jsonify({"status": "successful", "data": summary})
         db_log_msg(self.index, req, "QueryResource.on_post_query_binary_mapped - success.")
 

--- a/mcrit/server/SampleResource.py
+++ b/mcrit/server/SampleResource.py
@@ -4,7 +4,7 @@ import re
 import falcon
 
 from mcrit.index.MinHashIndex import MinHashIndex
-from mcrit.server.utils import db_log_msg, jsonify, timing
+from mcrit.server.utils import db_log_msg, get_username, jsonify, timing
 
 
 class SampleResource:
@@ -57,7 +57,7 @@ class SampleResource:
 
     @timing
     def on_delete(self, req, resp, sample_id=None):
-        successful = self.index.deleteSample(sample_id, force_recalculation=True)
+        successful = self.index.deleteSample(sample_id, force_recalculation=True, username=get_username(req))
         if successful:
             resp.data = jsonify({"status": "successful", "data": successful})
             resp.status = falcon.HTTP_202
@@ -98,7 +98,7 @@ class SampleResource:
                 information_update["is_library"] = True
             elif information_update["is_library"] in ["False", "false", "0", 0]:
                 information_update["is_library"] = False
-        successful = self.index.modifySample(sample_id, information_update, force_recalculation=True)
+        successful = self.index.modifySample(sample_id, information_update, force_recalculation=True, username=get_username(req))
         if successful:
             resp.data = jsonify({"status": "successful", "data": {"message": "Sample modified."}})
             resp.status = falcon.HTTP_202
@@ -158,7 +158,7 @@ class SampleResource:
         binary_sha256 = hashlib.sha256(binary).hexdigest()
         sample_entry = self.index.getSampleBySha256(binary_sha256)
         if sample_entry is None:
-            job_id = self.index.addBinarySample(binary, filename, family, version, is_dump, base_address, bitness, force_recalculation=True)
+            job_id = self.index.addBinarySample(binary, filename, family, version, is_dump, base_address, bitness, force_recalculation=True, username=get_username(req))
             resp.data = jsonify({"status": "successful", "data": job_id})
             resp.status = falcon.HTTP_202
             db_log_msg(self.index, req, f"SampleResource.on_post_submit_binary - success - with job_id: {job_id}.")

--- a/mcrit/server/StatusResource.py
+++ b/mcrit/server/StatusResource.py
@@ -4,7 +4,7 @@ import re
 import falcon
 
 from mcrit.index.MinHashIndex import MinHashIndex
-from mcrit.server.utils import db_log_msg, jsonify, timing
+from mcrit.server.utils import db_log_msg, get_username, jsonify, timing
 
 
 class StatusResource:
@@ -82,28 +82,28 @@ class StatusResource:
 
     @timing
     def on_get_complete_minhashes(self, req, resp):
-        minhash_report = self.index.updateMinHashes(None, force_recalculation=True)
+        minhash_report = self.index.updateMinHashes(None, force_recalculation=True, username=get_username(req))
         resp.data = jsonify({"status": "successful", "data": minhash_report})
         db_log_msg(self.index, req, "StatusResource.on_get_complete_minhashes - success.")
         return
 
     @timing
     def on_get_rebuild_index(self, req, resp):
-        index_report = self.index.rebuildIndex(force_recalculation=True)
+        index_report = self.index.rebuildIndex(force_recalculation=True, username=get_username(req))
         resp.data = jsonify({"status": "successful", "data": index_report})
         db_log_msg(self.index, req, "StatusResource.on_get_rebuild_index - success.")
         return
 
     @timing
     def on_get_recalculate_pichashes(self, req, resp):
-        index_report = self.index.recalculatePicHashes(force_recalculation=True)
+        index_report = self.index.recalculatePicHashes(force_recalculation=True, username=get_username(req))
         resp.data = jsonify({"status": "successful", "data": index_report})
         db_log_msg(self.index, req, "StatusResource.on_get_recalculate_pichashes - success.")
         return
 
     @timing
     def on_get_recalculate_minhashes(self, req, resp):
-        index_report = self.index.recalculateMinHashes(force_recalculation=True)
+        index_report = self.index.recalculateMinHashes(force_recalculation=True, username=get_username(req))
         resp.data = jsonify({"status": "successful", "data": index_report})
         db_log_msg(self.index, req, "StatusResource.on_get_recalculate_minhashes - success.")
         return

--- a/mcrit/server/utils.py
+++ b/mcrit/server/utils.py
@@ -6,8 +6,13 @@ from bson import json_util
 LOGGER = logging.getLogger(__name__)
 
 
+def get_username(req):
+    """The user a request was made for, as MCRITweb and McritClient send it, or None."""
+    return req.get_header("username", default=None)
+
+
 def db_log_msg(index, req, message, level=None):
-    username = req.get_header("username", default="anonymous")
+    username = get_username(req) or "anonymous"
     if level is None:
         LOGGER.info(f"{username} - {message}")
     index._storage.dbLogEvent(message, username=username)

--- a/tests/testBlocksResource.py
+++ b/tests/testBlocksResource.py
@@ -26,19 +26,19 @@ class TestBlocksResource(unittest.TestCase):
         index, resource = self._resource()
         resp = falcon.Response()
         resource.on_get_unique_blocks_for_samples(self._request("/uniqueblocks/samples/1,2", "covers_required=3&min_instructions=5"), resp, "1,2")
-        index.getUniqueBlocks.assert_called_once_with([1, 2], covers_required=3, min_instructions=5)
+        index.getUniqueBlocks.assert_called_once_with([1, 2], username=None, covers_required=3, min_instructions=5)
         assert resp.data is not None
         self.assertEqual("successful", json.loads(resp.data)["status"])
 
     def test_family_route_passes_the_parameters(self):
         index, resource = self._resource()
         resource.on_get_unique_blocks_for_family(self._request("/uniqueblocks/family/4", "covers_required=2"), falcon.Response(), 4)
-        index.getUniqueBlocks.assert_called_once_with([7, 8], family_id=4, covers_required=2)
+        index.getUniqueBlocks.assert_called_once_with([7, 8], family_id=4, username=None, covers_required=2)
 
     def test_omitted_parameters_leave_the_defaults_to_the_worker(self):
         index, resource = self._resource()
         resource.on_get_unique_blocks_for_samples(self._request("/uniqueblocks/samples/1"), falcon.Response(), "1")
-        index.getUniqueBlocks.assert_called_once_with([1])
+        index.getUniqueBlocks.assert_called_once_with([1], username=None)
 
     def test_malformed_sample_ids_are_not_queried(self):
         index, resource = self._resource()

--- a/tests/testJobOwner.py
+++ b/tests/testJobOwner.py
@@ -66,5 +66,29 @@ class JobOwnerTest(unittest.TestCase):
         self._assert_called_with_username(index, "rebuildIndex", "alice")
 
 
+class ReportSubmissionOwnerTest(unittest.TestCase):
+    """The minhash job a submitted report queues is the submitter's too (POST /samples)"""
+
+    def test_add_report_forwards_the_user_to_the_minhash_job(self):
+        import json
+        import os
+
+        from smda.common.SmdaReport import SmdaReport
+
+        from mcrit.index.MinHashIndex import MinHashIndex
+
+        from .context import config
+
+        index = MinHashIndex(config)
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "example_report.smda")) as fjson:
+            report = SmdaReport.fromDict(json.load(fjson))
+        assert report is not None
+        summary = index.addReport(report, username="alice")
+        assert summary is not None
+        job = index.queue.get_job(summary["job_id"])
+        assert job is not None
+        self.assertEqual("alice", job.username)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testJobOwner.py
+++ b/tests/testJobOwner.py
@@ -1,0 +1,70 @@
+import unittest
+from unittest.mock import MagicMock
+
+import falcon
+import falcon.testing
+
+from mcrit.server.BlocksResource import BlocksResource
+from mcrit.server.FamilyResource import FamilyResource
+from mcrit.server.MatchResource import MatchResource
+from mcrit.server.QueryResource import QueryResource
+from mcrit.server.SampleResource import SampleResource
+from mcrit.server.StatusResource import StatusResource
+from mcrit.server.utils import get_username
+
+
+def _request(path, headers=None, query_string="", body=None, method="GET"):
+    environ = falcon.testing.create_environ(path=path, headers=headers or {}, query_string=query_string, body=body or "", method=method)
+    return falcon.Request(environ)
+
+
+class JobOwnerTest(unittest.TestCase):
+    """Every job-creating route hands the requesting user on to the queue (fkie-cad/mcritweb#37)"""
+
+    def test_get_username_reads_the_header_mcritweb_sends(self):
+        self.assertEqual("alice", get_username(_request("/", headers={"username": "alice"})))
+        self.assertIsNone(get_username(_request("/")))
+
+    def _assert_called_with_username(self, index, method, expected):
+        self.assertTrue(getattr(index, method).called, method)
+        self.assertEqual(expected, getattr(index, method).call_args.kwargs.get("username"), method)
+
+    def test_match_routes_forward_the_user(self):
+        for expected, headers in (("alice", {"username": "alice"}), (None, {})):
+            with self.subTest(user=expected):
+                index = MagicMock()
+                index.isSampleId.return_value = True
+                resource = MatchResource(index)
+                resource.on_get_sample(_request("/matches/sample/1", headers), falcon.Response(), sample_id=1)
+                self._assert_called_with_username(index, "getMatchesForSample", expected)
+                resource.on_get_sample_vs(_request("/matches/sample/1/2", headers), falcon.Response(), sample_id=1, sample_id_b=2)
+                self._assert_called_with_username(index, "getMatchesForSampleVs", expected)
+                resource.on_get_sample_cross(_request("/matches/sample/cross/1,2", headers), falcon.Response(), sample_ids="1,2")
+                self._assert_called_with_username(index, "getMatchesCross", expected)
+
+    def test_query_and_blocks_routes_forward_the_user(self):
+        headers = {"username": "alice"}
+        index = MagicMock()
+        QueryResource(index).on_post_query_binary(_request("/query/binary", headers, body="MZ", method="POST"), falcon.Response())
+        self._assert_called_with_username(index, "getMatchesForUnmappedBinary", "alice")
+        QueryResource(index).on_post_query_binary_mapped(_request("/query/binary/mapped/4096", headers, body="MZ", method="POST"), falcon.Response(), base_address="4096")
+        self._assert_called_with_username(index, "getMatchesForMappedBinary", "alice")
+        BlocksResource(index).on_get_unique_blocks_for_samples(_request("/uniqueblocks/samples/1", headers), falcon.Response(), comma_separated_sample_ids="1")
+        self._assert_called_with_username(index, "getUniqueBlocks", "alice")
+
+    def test_collection_and_maintenance_routes_forward_the_user(self):
+        headers = {"username": "alice"}
+        index = MagicMock()
+        SampleResource(index).on_delete(_request("/samples/1", headers, method="DELETE"), falcon.Response(), sample_id=1)
+        self._assert_called_with_username(index, "deleteSample", "alice")
+        FamilyResource(index).on_delete(_request("/families/1", headers, method="DELETE"), falcon.Response(), family_id=1)
+        self._assert_called_with_username(index, "deleteFamily", "alice")
+        status = StatusResource(index)
+        status.on_get_complete_minhashes(_request("/complete_minhashes", headers), falcon.Response())
+        self._assert_called_with_username(index, "updateMinHashes", "alice")
+        status.on_get_rebuild_index(_request("/rebuild_index", headers), falcon.Response())
+        self._assert_called_with_username(index, "rebuildIndex", "alice")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testMongoQueue.py
+++ b/tests/testMongoQueue.py
@@ -176,6 +176,15 @@ class MongoQueueTest(TestCase):
         self.assertEqual(1, len(jobs_in_progress))
         self.assertEqual(job.job_id, jobs_in_progress[0]["_id"])
 
+    def test_put_records_username(self):
+        with_user = self.queue.put({"method": "test_method"}, username="alice")
+        without_user = self.queue.put({"method": "test_method"})
+        self.assertEqual("alice", self.queue.get_job(with_user).username)
+        self.assertIsNone(self.queue.get_job(without_user).username)
+        # a document from before the field existed
+        self.queue._getCollection().update_one({"_id": without_user}, {"$unset": {"username": ""}})
+        self.assertIsNone(self.queue.get_job(without_user).username)
+
     def test_context_manager_error(self):
         self.queue.put({"method": "test_method", "context_id": "alpha", "data": [1, 2, 3], "more-data": time.time()})
         job = self.queue.next()

--- a/tests/testRemoteCalls.py
+++ b/tests/testRemoteCalls.py
@@ -232,6 +232,22 @@ class LocalQueueRemoteCallTest(TestCase):
         with self.assertRaises(AttributeError):
             self.caller.function_that_doesnt_exist(1, 2, 3)
 
+    def test_job_records_who_asked(self):
+        # fkie-cad/mcritweb#37: the user a job was requested for is stored on the job, is not part of the
+        # descriptor (another user's identical request is still served from the cache), and
+        # is None when nobody was named
+        kwparams = {"test_job_owner": True}
+        job_id = self.caller.test(username="alice", **kwparams)
+        self.assertEqual("alice", self.queue.get_job(job_id).username)
+        self.assertEqual("alice", self.queue.get_job(job_id)._data["username"])
+        self.assertEqual(job_id, self.caller.test(username="bob", **kwparams))
+        self.assertEqual("alice", self.queue.get_job(job_id).username)
+        forced_job_id = self.caller.test(username="bob", force_recalculation=True, **kwparams)
+        self.assertEqual("bob", self.queue.get_job(forced_job_id).username)
+        anonymous_job_id = self.caller.test(test_job_owner_anonymous=True)
+        self.assertIsNone(self.queue.get_job(anonymous_job_id).username)
+        self.queue.clear()
+
     def test_file_access(self):
         params = []
         kwparams = {"foo": {"test_file_access": True}}


### PR DESCRIPTION
Closes fkie-cad/mcritweb#37 (annotate jobs with who asked for them), together with its MCRITweb half, fkie-cad/mcritweb#172.

## What changed

Every request already carries the user MCRITweb or `McritClient` acts for, in the `username` header, but the server only wrote it to the log; jobs had no owner field at all.

- The job-creating routes (matching, cross, queries, unique blocks, sample/family modification and deletion, binary submission, the maintenance jobs) pass the header on as a `username` keyword. `server.utils.get_username()` is the one place the header is read; `db_log_msg` uses it too.
- The remote-call wrapper stores it on the **job document**, not in the payload, so it is not part of the descriptor: another user's identical request is still served from the cache.
- `Job.username` on both queue implementations (`None` on jobs from before the field existed or queued without a user). `getQueueData` returns the field with the rest of the job.

Why the username and not a uuid: the username is what is already on the wire, and MCRITweb has no user uuid to send. If a deployment renames users, the recorded name is the name at request time; that is the same trade-off the existing `FunctionLabelEntry.username` makes.

## Tests

Queue level (`put(username=)`, absent field on old documents), remote-call level (stored, not in the descriptor, `None` when absent) on both queues, and resource level (every job-creating route forwards the header, `None` without it).

## Verified against a running instance

A job requested with `username: alice` lists as alice's in `GET /jobs`, and a plain request by `bob` for the same parameters is served from alice's finished job.

`ruff`, `ty` and the full suite pass.

## In MCRITweb (fkie-cad/mcritweb#172)

![the jobs list with the User column](https://raw.githubusercontent.com/r0ny123/mcritweb/fix/37-show-job-owner/docs/manual/images/jobs_owner.png)

