### PR TITLE
Serve sorted searches from an index, and page past an id of 0 (fkie-cad/mcritweb#59)

### DIFF
--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -577,7 +577,9 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
             last_element_key = None
 
         forward_cursor_str = None
-        if last_element_key:
+        # `is not None`, not truthiness: the key is an id, and a page whose last entry is
+        # id 0 (function 0, sample 0, the unknown family 0) used to end the listing there
+        if last_element_key is not None:
             last_result = search_results_objects[last_element_key]
             forward_cursor = MinimalSearchCursor()
             forward_cursor.is_forward_search = True ^ is_backward_search  # switch for backward search, because of swap
@@ -613,9 +615,12 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
                 (standard_sort, is_ascending),
             ]
         else:
+            # the tie-break follows the direction of the sort field: the order stays total and
+            # deterministic, and a single compound index on (field, id) then serves the
+            # descending order as well, walked backwards (fkie-cad/mcritweb#59)
             sort_by_list = [
                 (sort_by, is_ascending),
-                (standard_sort, True),
+                (standard_sort, is_ascending),
             ]
         return sort_by_list
 

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -206,6 +206,17 @@ class MongoDbStorage(StorageInterface):
         self._getDb()["functions"].create_index("_pichash")
         self._getDb()["functions"].create_index("_picblockhashes.hash")
         self._getDb()["functions"].create_index("_picblockhashes.offset")
+        # Searches sorted by a field other than the id (fkie-cad/mcritweb#59): the search cursor sorts by that
+        # field and breaks ties by the id, in the same direction, so one compound index per
+        # sortable field serves both directions by being walked backwards. Without it the
+        # server sorts every filtered document in memory, which is where the reported 10x
+        # goes. The fields are the ones the search results can be sorted by in MCRITweb.
+        for field in ("family_name", "num_samples", "num_library_samples", "num_functions"):
+            self._getDb()["families"].create_index([(field, 1), ("family_id", 1)])
+        for field in ("family_id", "family", "filename", "version", "bitness", "sha256", "statistics.num_functions"):
+            self._getDb()["samples"].create_index([(field, 1), ("sample_id", 1)])
+        for field in ("family_id", "sample_id", "function_name", "offset", "num_instructions", "num_blocks"):
+            self._getDb()["functions"].create_index([(field, 1), ("function_id", 1)])
         # stored without guarantee of existence
         self._getDb()["query_samples"].create_index("sample_id")
         self._getDb()["query_samples"].create_index("sha256")

--- a/tests/testMinHashIndex.py
+++ b/tests/testMinHashIndex.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import json
 import logging
 import os
 import unittest
@@ -63,6 +64,41 @@ class MalformedSearchQueryTestSuite(unittest.TestCase):
         self.assertIn("search_results", index.getFamilySearchResults("foo"))
         self.assertIn("search_results", index.getSampleSearchResults("family:foo"))
         self.assertIn("search_results", index.getFunctionSearchResults("offset:>0x100"))
+
+
+class SortedSearchPagingTestSuite(unittest.TestCase):
+    """Sorting by a field breaks ties by the id in the same direction (fkie-cad/mcritweb#59): the order is total,
+    and paging through it by cursor neither skips nor repeats an entry, in either direction"""
+
+    def testTieBreakFollowsTheSortDirection(self):
+        index = MinHashIndex(config)
+        self.assertEqual([("function_id", True)], index._get_sort_data("function_id", None, True))
+        self.assertEqual([("function_id", False)], index._get_sort_data("function_id", "function_id", False))
+        self.assertEqual([("num_blocks", True), ("function_id", True)], index._get_sort_data("function_id", "num_blocks", True))
+        self.assertEqual([("num_blocks", False), ("function_id", False)], index._get_sort_data("function_id", "num_blocks", False))
+
+    def testCursorPagingIsCompleteInBothDirections(self):
+        index = MinHashIndex(config)
+        this_file_path = str(os.path.abspath(__file__))
+        for name in ("example_report.smda", "example_report_2.smda", "library_report.smda"):
+            with open(os.sep.join([os.path.dirname(this_file_path), name])) as fjson:
+                index.addReport(SmdaReport.fromDict(json.load(fjson)))
+        all_functions = index.getFunctionSearchResults("offset:>=0", limit=1000)["search_results"]
+        self.assertGreater(len(all_functions), 5)
+        for is_ascending in (True, False):
+            with self.subTest(ascending=is_ascending):
+                seen = []
+                cursor = None
+                while True:
+                    page = index.getFunctionSearchResults("offset:>=0", sort_by="num_instructions", is_ascending=is_ascending, cursor=cursor, limit=4)
+                    seen.extend(page["search_results"].values())
+                    cursor = page["cursor"]["forward"]
+                    if cursor is None or not page["search_results"]:
+                        break
+                keys = [(entry["num_instructions"], entry["function_id"]) for entry in seen]
+                self.assertEqual(sorted(keys, reverse=not is_ascending), keys)
+                self.assertEqual(len(all_functions), len(seen))
+                self.assertEqual(len(all_functions), len(set(keys)))
 
 
 class UniqueBlocksCoverTestSuite(unittest.TestCase):

--- a/tests/testMongoDbStorageInit.py
+++ b/tests/testMongoDbStorageInit.py
@@ -113,6 +113,25 @@ class MongoDbStorageInitTest(TestCase):
         # the families counter must be past 0, so the next family can never collide with id 0
         self.assertEqual(1, self.storage.addFamily("another_family"))
 
+    def testSortableSearchFieldsHaveCompoundIndexes(self):
+        # fkie-cad/mcritweb#59: every field a search can be sorted by carries a (field, id) index, so a sort by
+        # it is served in index order instead of by an in-memory sort of every filtered document
+        database = self.storage._getDb()
+        self.storage._ensureIndexAndUnknownFamily()
+        expected = {
+            "families": [("family_name", "family_id"), ("num_samples", "family_id"), ("num_library_samples", "family_id"), ("num_functions", "family_id")],
+            "samples": [(field, "sample_id") for field in ("family_id", "family", "filename", "version", "bitness", "sha256", "statistics.num_functions")],
+            "functions": [(field, "function_id") for field in ("family_id", "sample_id", "function_name", "offset", "num_instructions", "num_blocks")],
+        }
+        for collection, pairs in expected.items():
+            keys = [tuple(key for key, _ in info["key"]) for info in database[collection].index_information().values()]
+            for pair in pairs:
+                self.assertIn(pair, keys, f"{collection} {pair}")
+        # and a sorted search plans no blocking sort, in either direction
+        for direction in (1, -1):
+            plan = database["functions"].find({"function_name": {"$regex": "sub"}}, sort=[("num_blocks", direction), ("function_id", direction)], limit=10).explain()
+            self.assertNotIn("SORT", str(plan["queryPlanner"]["winningPlan"]))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Closes fkie-cad/mcritweb#59 (labelled `mcrit`): searches sorted by anything but the id had no index to be served from.

## What changed

- `_ensureIndexAndUnknownFamily` creates a compound `(field, id)` index for every field the search results can be sorted by in MCRITweb: families `family_name`, `num_samples`, `num_library_samples`, `num_functions`; samples `family_id`, `family`, `filename`, `version`, `bitness`, `sha256`, `statistics.num_functions`; functions `family_id`, `sample_id`, `function_name`, `offset`, `num_instructions`, `num_blocks`. As with the v1.6.2 indexes, the first start after upgrading builds them.
- The search cursor's tie-break now follows the direction of the sort field (`_get_sort_data`). The order stays total and deterministic, and one index serves the descending order by being walked backwards; with `(field asc, id asc)` and a `(field desc, id asc)` sort no single index could.
- Found on the way, fixed here because the paging test needed it: **paging stopped early whenever a page ended on id 0**. The forward cursor was built behind `if last_element_key:`, which is False for function 0, sample 0 and the unknown family 0. It is `is not None` now. The details are in the commit message and the test.

## Measured

`explain()` on a real database, filter `function_name` regex, sort `num_blocks`/`offset`/`function_name` (functions), `family` (samples), `num_samples` (families), both directions:

| | before | after |
|---|---|---|
| winning plan | `SORT → FETCH → IXSCAN` (blocking in-memory sort of every filtered document) | `LIMIT → FETCH → IXSCAN` (index order, stops at the limit) |

A mongo-backed test asserts the indexes exist and that the plan for a sorted search has no `SORT` stage; another pages a listing to the end in both directions on the memory backend.

`ruff`, `ty` and the full suite pass.

