### PR TITLE
Let a function be renamed, and record who named it (fkie-cad/mcritweb#72)

### DIFF
--- a/mcrit/client/McritClient.py
+++ b/mcrit/client/McritClient.py
@@ -348,6 +348,16 @@ class McritClient:
         if data is not None:
             return FunctionEntry.fromDict(data)
 
+    def modifyFunction(self, function_id: int, function_name: str):
+        """
+        Set the name of the function <function_id>; the name is also recorded as a label by this client's username.
+        Supported by mcritweb API pass-through
+        """
+        response = requests.put(f"{self.mcrit_server}/functions/{function_id}", {"function_name": function_name}, headers=self.headers)
+        if self.raw:
+            return response
+        return handle_response(response)
+
     ###########################################
     ### Matching
     ###########################################

--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -3,7 +3,7 @@ import json
 import logging
 import re
 from datetime import datetime, timedelta
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from smda.common.SmdaReport import SmdaReport
 from smda.SmdaConfig import SmdaConfig
@@ -387,6 +387,11 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
             report_json = json.load(fin)
         report = SmdaReport.fromDict(report_json)
         return self.addReport(report, calculate_hashes=calculate_hashes, calculate_matches=calculate_matches)
+
+    def modifyFunction(self, function_id: int, update_information: dict, username: Optional[str] = None) -> bool:
+        # unlike modifySample/modifyFamily this touches one document and no statistics, so it
+        # is answered synchronously instead of as a job (fkie-cad/mcritweb#72)
+        return self.getStorage().modifyFunction(function_id, update_information, username=username)
 
     def getMatchesCross(self, sample_ids: List[int], sample_group_only=False, force_recalculation=False, **params):
         sample_to_job_id = {}

--- a/mcrit/server/FunctionResource.py
+++ b/mcrit/server/FunctionResource.py
@@ -3,7 +3,7 @@ import re
 import falcon
 
 from mcrit.index.MinHashIndex import MinHashIndex
-from mcrit.server.utils import db_log_msg, jsonify, timing
+from mcrit.server.utils import db_log_msg, get_username, jsonify, timing
 
 
 class FunctionResource:
@@ -33,6 +33,36 @@ class FunctionResource:
             }
         )
         db_log_msg(self.index, req, f"FunctionResource.on_get - success - {function_id}.")
+
+    @timing
+    def on_put(self, req, resp, function_id=None):
+        resp.status = falcon.HTTP_400
+        if not req.content_length or not isinstance(req.media, dict):
+            resp.data = jsonify({"status": "failed", "data": {"message": "PUT request without body can't be processed."}})
+            db_log_msg(self.index, req, "FunctionResource.on_put - failed - no PUT body.")
+            return
+        information_update = req.media
+        if "function_name" not in information_update:
+            resp.data = jsonify({"status": "failed", "data": {"message": "Nothing to modify: function_name is the only modifiable field."}})
+            db_log_msg(self.index, req, "FunctionResource.on_put - failed - nothing to modify.")
+            return
+        if not isinstance(information_update["function_name"], str) or not re.match(r"^[ -~]{0,256}$", information_update["function_name"]):
+            resp.data = jsonify({"status": "failed", "data": {"message": "function_name may be 0-256 printable ASCII characters."}})
+            db_log_msg(self.index, req, "FunctionResource.on_put - failed - invalid function name.")
+            return
+        if function_id is None or function_id < 0 or not self.index.isFunctionId(function_id):
+            resp.data = jsonify({"status": "failed", "data": {"message": "We don't have a function with that id."}})
+            resp.status = falcon.HTTP_404
+            db_log_msg(self.index, req, f"FunctionResource.on_put - failed - {function_id} unknown.")
+            return
+        successful = self.index.modifyFunction(function_id, {"function_name": information_update["function_name"].strip()}, username=get_username(req))
+        if successful:
+            resp.data = jsonify({"status": "successful", "data": {"message": "Function modified."}})
+            resp.status = falcon.HTTP_200
+            db_log_msg(self.index, req, f"FunctionResource.on_put - success - modified function_id {function_id}.")
+        else:
+            resp.data = jsonify({"status": "failed", "data": {"message": "Failed to modify function."}})
+            db_log_msg(self.index, req, f"FunctionResource.on_put - failed - function_id {function_id} not modified.")
 
     @timing
     def on_post_collection(self, req, resp):

--- a/mcrit/server/FunctionResource.py
+++ b/mcrit/server/FunctionResource.py
@@ -36,6 +36,7 @@ class FunctionResource:
 
     @timing
     def on_put(self, req, resp, function_id=None):
+        """Rename a function; JSON body with ``function_name`` (up to 256 printable chars). The name is recorded as a label by the requesting user. Answers 202 on success, 400 for a malformed body, 404 for an unknown id."""
         resp.status = falcon.HTTP_400
         if not req.content_length or not isinstance(req.media, dict):
             resp.data = jsonify({"status": "failed", "data": {"message": "PUT request without body can't be processed."}})

--- a/mcrit/server/utils.py
+++ b/mcrit/server/utils.py
@@ -6,8 +6,13 @@ from bson import json_util
 LOGGER = logging.getLogger(__name__)
 
 
+def get_username(req):
+    """The user a request was made for, as MCRITweb and McritClient send it, or None."""
+    return req.get_header("username", default=None)
+
+
 def db_log_msg(index, req, message, level=None):
-    username = req.get_header("username", default="anonymous")
+    username = get_username(req) or "anonymous"
     if level is None:
         LOGGER.info(f"{username} - {message}")
     index._storage.dbLogEvent(message, username=username)

--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -267,6 +267,20 @@ class MemoryStorage(StorageInterface):
             self._samples[sample_id].component = update_information["component"]
         return True
 
+    def modifyFunction(self, function_id: int, update_information: dict, username: Optional[str] = None) -> bool:
+        if function_id < 0 or not self.isFunctionId(function_id):
+            return False
+        function_entry = self._functions[function_id]
+        if "function_name" in update_information:
+            function_name = update_information["function_name"]
+            function_entry.function_name = function_name
+            if function_name:
+                label_username = username or "anonymous"
+                is_known_label = any(label.username == label_username and label.function_label == function_name for label in function_entry.function_labels)
+                if not is_known_label:
+                    function_entry.function_labels.append(FunctionLabelEntry(function_name, label_username))
+        return True
+
     def modifyFamily(self, family_id: int, update_information: dict) -> bool:
         if not self.isFamilyId(family_id):
             return False

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -690,6 +690,22 @@ class MongoDbStorage(StorageInterface):
             self._getDb().samples.update_one({"sample_id": sample_id}, {"$set": {"component": update_information["component"]}})
         return True
 
+    def modifyFunction(self, function_id: int, update_information: dict, username: Optional[str] = None) -> bool:
+        if function_id < 0 or not self.isFunctionId(function_id):
+            return False
+        if "function_name" in update_information:
+            function_name = update_information["function_name"]
+            update: Dict[str, Any] = {"$set": {"function_name": function_name}}
+            if function_name:
+                function_entry = self.getFunctionById(function_id)
+                assert function_entry is not None
+                label_username = username or "anonymous"
+                is_known_label = any(label.username == label_username and label.function_label == function_name for label in function_entry.function_labels)
+                if not is_known_label:
+                    update["$push"] = {"function_labels": FunctionLabelEntry(function_name, label_username).toDict()}
+            self._getDb().functions.update_one({"function_id": function_id}, update)
+        return True
+
     def modifyFamily(self, family_id: int, update_information: dict) -> bool:
         if not self.isFamilyId(family_id):
             return False

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -695,15 +695,13 @@ class MongoDbStorage(StorageInterface):
             return False
         if "function_name" in update_information:
             function_name = update_information["function_name"]
-            update: Dict[str, Any] = {"$set": {"function_name": function_name}}
+            self._getDb().functions.update_one({"function_id": function_id}, {"$set": {"function_name": function_name}})
             if function_name:
-                function_entry = self.getFunctionById(function_id)
-                assert function_entry is not None
+                # the "not yet labelled so by this user" check is part of the update's filter,
+                # so two concurrent identical requests cannot both push the label
                 label_username = username or "anonymous"
-                is_known_label = any(label.username == label_username and label.function_label == function_name for label in function_entry.function_labels)
-                if not is_known_label:
-                    update["$push"] = {"function_labels": FunctionLabelEntry(function_name, label_username).toDict()}
-            self._getDb().functions.update_one({"function_id": function_id}, update)
+                not_yet_labelled = {"function_id": function_id, "function_labels": {"$not": {"$elemMatch": {"username": label_username, "function_label": function_name}}}}
+                self._getDb().functions.update_one(not_yet_labelled, {"$push": {"function_labels": FunctionLabelEntry(function_name, label_username).toDict()}})
         return True
 
     def modifyFamily(self, family_id: int, update_information: dict) -> bool:

--- a/mcrit/storage/StorageInterface.py
+++ b/mcrit/storage/StorageInterface.py
@@ -224,6 +224,19 @@ class StorageInterface:
         """
         raise NotImplementedError
 
+    def modifyFunction(self, function_id: int, update_information: dict, username: Optional[str] = None) -> bool:
+        """Update a function in the storage (fkie-cad/mcritweb#72)
+
+        Args:
+            function_id: the id of the function to modify; query functions (negative ids) cannot be modified
+            update_information: a dictionary with update information for fields (function_name)
+            username: who submits the change; a new function_name is also recorded as a FunctionLabelEntry by this user
+
+        Returns:
+            True if function_id was contained in the storage and updated successfully, False otherwise
+        """
+        raise NotImplementedError
+
     def deleteSample(self, sample_id: int) -> bool:
         """Remove a sample from the storage, also removes all functions of the sample.
         All minhashes will be removed from the bands.

--- a/tests/testFunctionResourcePut.py
+++ b/tests/testFunctionResourcePut.py
@@ -1,0 +1,61 @@
+import json
+import unittest
+from unittest.mock import MagicMock
+
+import falcon
+import falcon.testing
+
+from mcrit.server.FunctionResource import FunctionResource
+
+
+def _put(path, body, headers=None):
+    environ = falcon.testing.create_environ(path=path, method="PUT", body=json.dumps(body), headers={"Content-Type": "application/json", **(headers or {})})
+    return falcon.Request(environ)
+
+
+class FunctionResourcePutTest(unittest.TestCase):
+    """PUT /functions/{id} sets a function's name for the requesting user (fkie-cad/mcritweb#72)"""
+
+    def test_modifies_the_function_for_the_requesting_user(self):
+        index = MagicMock()
+        index.isFunctionId.return_value = True
+        index.modifyFunction.return_value = True
+        resp = falcon.Response()
+        FunctionResource(index).on_put(_put("/functions/7", {"function_name": "  decrypt_config "}, {"username": "alice"}), resp, function_id=7)
+        self.assertEqual(falcon.HTTP_200, resp.status)
+        index.modifyFunction.assert_called_once_with(7, {"function_name": "decrypt_config"}, username="alice")
+        assert resp.data is not None
+        self.assertEqual("successful", json.loads(resp.data)["status"])
+
+    def test_refuses_bad_input(self):
+        for body, headers, status, fragment in (
+            (None, {}, falcon.HTTP_400, "without body"),
+            ({"is_library": True}, {}, falcon.HTTP_400, "function_name"),
+            ({"function_name": "x" * 257}, {}, falcon.HTTP_400, "printable"),
+            ({"function_name": "d\u00e9crypt"}, {}, falcon.HTTP_400, "printable"),
+            ({"function_name": 7}, {}, falcon.HTTP_400, "printable"),
+        ):
+            with self.subTest(body=body):
+                index = MagicMock()
+                index.isFunctionId.return_value = True
+                resp = falcon.Response()
+                request = _put("/functions/7", body) if body is not None else falcon.Request(falcon.testing.create_environ(path="/functions/7", method="PUT"))
+                FunctionResource(index).on_put(request, resp, function_id=7)
+                self.assertEqual(status, resp.status)
+                index.modifyFunction.assert_not_called()
+                assert resp.data is not None
+                self.assertIn(fragment, json.loads(resp.data)["data"]["message"])
+
+    def test_unknown_and_query_functions_are_404(self):
+        for function_id, known in ((99, False), (-3, True)):
+            with self.subTest(function_id=function_id):
+                index = MagicMock()
+                index.isFunctionId.return_value = known
+                resp = falcon.Response()
+                FunctionResource(index).on_put(_put(f"/functions/{function_id}", {"function_name": "x"}), resp, function_id=function_id)
+                self.assertEqual(falcon.HTTP_404, resp.status)
+                index.modifyFunction.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -72,6 +72,48 @@ class MemoryStorageTest(TestCase):
         self.assertEqual(10, stats_without_pichash["num_functions"])
         self.assertIsNone(stats_without_pichash["num_pichashes"])
 
+    def testModifyFunction(self):
+        # fkie-cad/mcritweb#72: a function's name can be set; the name is recorded as a label
+        # by the user who set it, once per (user, name); query functions and unknown ids are refused
+        self.storage.clearStorage()
+        smda_report = SmdaReport.fromFile(self.example_file_path)
+        assert smda_report is not None
+        sample_entry = self.storage.addSmdaReport(smda_report)
+        assert sample_entry is not None
+        function_entry = (self.storage.getFunctionsBySampleId(sample_entry.sample_id) or [])[0]
+        function_id = function_entry.function_id
+        labels_before = len(function_entry.function_labels)
+        self.assertTrue(self.storage.modifyFunction(function_id, {"function_name": "decrypt_config"}, username="alice"))
+        modified = self.storage.getFunctionById(function_id)
+        assert modified is not None
+        self.assertEqual("decrypt_config", modified.function_name)
+        self.assertEqual(labels_before + 1, len(modified.function_labels))
+        self.assertEqual(("decrypt_config", "alice"), (modified.function_labels[-1].function_label, modified.function_labels[-1].username))
+        # the same label by the same user is not recorded twice, by another user it is
+        self.assertTrue(self.storage.modifyFunction(function_id, {"function_name": "decrypt_config"}, username="alice"))
+        self.assertTrue(self.storage.modifyFunction(function_id, {"function_name": "decrypt_config"}, username="bob"))
+        modified = self.storage.getFunctionById(function_id)
+        assert modified is not None
+        self.assertEqual(labels_before + 2, len(modified.function_labels))
+        self.assertEqual("bob", modified.function_labels[-1].username)
+        # without a user the label is anonymous; an empty name clears the name and records nothing
+        self.assertTrue(self.storage.modifyFunction(function_id, {"function_name": "sub_1234"}))
+        modified = self.storage.getFunctionById(function_id)
+        assert modified is not None
+        self.assertEqual("anonymous", modified.function_labels[-1].username)
+        self.assertTrue(self.storage.modifyFunction(function_id, {"function_name": ""}, username="alice"))
+        modified = self.storage.getFunctionById(function_id)
+        assert modified is not None
+        self.assertEqual("", modified.function_name)
+        self.assertEqual(labels_before + 3, len(modified.function_labels))
+        # the other functions of the sample are untouched, the entry round-trips through toDict
+        untouched = (self.storage.getFunctionsBySampleId(sample_entry.sample_id) or [])[1]
+        self.assertEqual(labels_before, len(untouched.function_labels))
+        self.assertEqual(modified.toDict()["function_labels"], [label.toDict() for label in modified.function_labels])
+        self.assertFalse(self.storage.modifyFunction(function_id + 100000, {"function_name": "x"}, username="alice"))
+        self.assertFalse(self.storage.modifyFunction(-1, {"function_name": "x"}, username="alice"))
+        self.assertTrue(self.storage.modifyFunction(function_id, {}, username="alice"))
+
     def testStatusAnswersInlineXcfgOnMemoryStorage(self):
         # the interface default is None ("not applicable"), so /status must keep working on
         # backends without the pre-split shape - a raise here broke every memory-backed call.


### PR DESCRIPTION
Closes fkie-cad/mcritweb#72 (modify functions), together with its MCRITweb half, fkie-cad/mcritweb#173.

## What changed

Families and samples could be modified through the API, functions could not: no route, no client call, no storage operation.

- `PUT /functions/{id}` with `function_name` sets the name on both storage backends and records it as a `FunctionLabelEntry` by the requesting user (the `username` header), unless that user already submitted that label — the same shape `updateFunctionLabels` writes for labels arriving with a submitted report, so a function's label history is one list whichever way a name got there. An empty name clears the name and records nothing. Query functions (negative ids) answer 404, as do unknown ids; a non-printable or over-long name answers 400.
- `MinHashIndex.modifyFunction` is synchronous: unlike `modifySample`/`modifyFamily` it touches one document and no statistics, so there is nothing a job would keep consistent.
- `McritClient.modifyFunction(function_id, function_name)`.

## Tests

Storage tests on both backends (name set, label recorded once per user, anonymous without a user, empty name clears, unknown/query ids refused, other functions untouched), resource tests for the validation and the pass-through of the user.

## Verified against a running instance

`modifyFunction(273, "decrypt_config_v2")` as `alice` → `GET /functions/273` shows the name and a label `('decrypt_config_v2', 'alice')`; a non-ASCII name answers 400 and an unknown id 404. The MCRITweb side renames from the function page and shows the label history.

`ruff`, `ty` and the full suite pass.

## In MCRITweb (fkie-cad/mcritweb#173)

![the rename modal](https://raw.githubusercontent.com/r0ny123/mcritweb/feat/72-edit-function-name/docs/manual/images/function_rename.png)

