### PR TITLE
Keep the match flags booleans so they survive the round trip (#155)

### DIFF
--- a/mcrit/storage/MatchedFunctionEntry.py
+++ b/mcrit/storage/MatchedFunctionEntry.py
@@ -35,9 +35,11 @@ class MatchedFunctionEntry:
         self.matched_sample_id = match_tuple[1]
         self.matched_function_id = match_tuple[2]
         self.matched_score = match_tuple[3]
-        self.match_is_minhash = match_tuple[4] & MatcherFlags.IS_MINHASH_FLAG
-        self.match_is_pichash = match_tuple[4] & MatcherFlags.IS_PICHASH_FLAG
-        self.match_is_library = match_tuple[4] & MatcherFlags.IS_LIBRARY_FLAG
+        # stored as booleans: getMatchTuple multiplies them with the flag values again, and a
+        # masked int there would square the flag and corrupt the round trip (#155)
+        self.match_is_minhash = bool(match_tuple[4] & MatcherFlags.IS_MINHASH_FLAG)
+        self.match_is_pichash = bool(match_tuple[4] & MatcherFlags.IS_PICHASH_FLAG)
+        self.match_is_library = bool(match_tuple[4] & MatcherFlags.IS_LIBRARY_FLAG)
         self.matched_family = None
         self.matched_link_score = 0
         self.matched_unique = None

--- a/tests/testDataObjects.py
+++ b/tests/testDataObjects.py
@@ -8,8 +8,10 @@ from copy import deepcopy
 
 from smda.common.SmdaReport import SmdaReport
 
+import mcrit.matchers.MatcherFlags as MatcherFlags
 from mcrit.minhash.MinHash import MinHash
 from mcrit.storage.FunctionEntry import FunctionEntry
+from mcrit.storage.MatchedFunctionEntry import MatchedFunctionEntry
 from mcrit.storage.MatchingResult import MatchingResult
 from mcrit.storage.SampleEntry import SampleEntry
 
@@ -57,6 +59,19 @@ class MinHashingTestSuite(unittest.TestCase):
         as_dict = sample_entry.toDict()
         as_entry = SampleEntry.fromDict(as_dict)
         self.assertEqual(as_entry.sample_id, sample_entry.sample_id)
+
+    def testMatchedFunctionEntryFlagsSurviveTheRoundTrip(self):
+        # #155: every combination of the three match flags must come back unchanged from
+        # toDict()/fromDict(), which is what a served match report goes through
+        all_flags = MatcherFlags.IS_MINHASH_FLAG | MatcherFlags.IS_PICHASH_FLAG | MatcherFlags.IS_LIBRARY_FLAG
+        for flags in range(all_flags + 1):
+            with self.subTest(flags=flags):
+                entry = MatchedFunctionEntry(1, 100, 0x1000, [2, 3, 4, 75.0, flags])
+                self.assertEqual(flags, entry.getMatchTuple()[4])
+                self.assertEqual(flags, MatchedFunctionEntry.fromDict(entry.toDict()).getMatchTuple()[4])
+                self.assertIs(bool(flags & MatcherFlags.IS_MINHASH_FLAG), entry.match_is_minhash)
+                self.assertIs(bool(flags & MatcherFlags.IS_PICHASH_FLAG), entry.match_is_pichash)
+                self.assertIs(bool(flags & MatcherFlags.IS_LIBRARY_FLAG), entry.match_is_library)
 
     def testMatchingResult(self):
         THIS_FILE_PATH = str(os.path.abspath(__file__))


### PR DESCRIPTION
Closes #155.

`MatchedFunctionEntry` stored `flags & IS_*_FLAG` — a masked int — under `match_is_minhash/pichash/library`, and `getMatchTuple()` multiplied each by its flag value again. A pichash-only match (2) came back as 4, a library match, and a library match (4) as 16; only 0 and 1 survived. That tuple is what `GET /matches/function/{a}/{b}` serves.

The attributes are now the booleans their names and annotations promise. The test round-trips all eight flag combinations through `toDict()`/`fromDict()` and checks the three attributes are real booleans; it fails on `main` for six of the eight.

`ruff`, `ty` and the full suite pass.

