### PR TITLE
Size the percentage denominator by what the request can match (#156)

### DIFF
--- a/mcrit/matchers/MatcherInterface.py
+++ b/mcrit/matchers/MatcherInterface.py
@@ -568,6 +568,24 @@ class MatcherInterface:
 
         return matches_function_list, match_function_mapping, aggregation, num_library_match_bytes
 
+    def _isMatchableFunction(self, function_entry) -> bool:
+        """Whether this request can match the function at all, i.e. whether it belongs in the
+        denominator of the percentages: by PicHash when it reaches the request's pichash_size,
+        or by MinHash when the minhasher produces a signature for it (#156).
+
+        Both thresholds are the ones the numerator uses - pichash_size is per request, the
+        MinHash limits are the configured ones - so a request with a small pichash_size
+        widens the denominator along with the matches instead of exceeding 100 %.
+        """
+        if function_entry.num_instructions >= self._pichash_size:
+            return True
+        minhash_config = self._worker._minhash_config
+        if minhash_config.MINHASH_FN_MIN_INS and function_entry.num_instructions > minhash_config.MINHASH_FN_MIN_INS:
+            return True
+        if minhash_config.MINHASH_FN_MIN_BLOCKS and function_entry.num_blocks > minhash_config.MINHASH_FN_MIN_BLOCKS:
+            return True
+        return False
+
     def _get_family_adjustment(self, match_report) -> Dict[int, float]:
         adjustments: Dict[int, float] = {}
         for fid, function_data in match_report.items():
@@ -585,7 +603,7 @@ class MatcherInterface:
         else:
             own_sample_function_entries = self._storage.getFunctionsBySampleId(own_sample_info["sample_id"])
         for function_entry in own_sample_function_entries:
-            if function_entry.num_instructions >= self._worker._minhash_config.MINHASH_FN_MIN_INS:
+            if self._isMatchableFunction(function_entry):
                 own_sample_num_matchable_bytes += function_entry.binweight
         own_sample_num_nonlibrary_bytes = own_sample_num_matchable_bytes - num_library_bytes
         # aggregate sample byte sizes

--- a/tests/testMatcher.py
+++ b/tests/testMatcher.py
@@ -648,6 +648,39 @@ class MatcherTestSuite(unittest.TestCase):
             ],
         )
 
+    def testPercentagesUseTheRequestsOwnThresholds(self):
+        # #156: with pichash_size below MINHASH_FN_MIN_INS the small functions match by
+        # PicHash but used to be missing from the denominator, so a sample matched against
+        # an identical copy of itself scored above 100 %
+        index = MinHashIndex(config=config)
+        worker = index.queue._worker
+        # the pristine report: the suite's copy has its 2-instruction function swapped out
+        # for a self match, and that tiny function is exactly what this test is about
+        this_file_path = str(os.path.abspath(__file__))
+        report = SmdaReport.fromFile(os.sep.join([os.path.dirname(this_file_path), "example_report.smda"]))
+        assert report is not None
+        entry_a = index._storage.addSmdaReport(report)
+        twin = SmdaReport.fromDict(report.toDict())
+        assert twin is not None
+        twin.sha256 = "ff" * 32
+        twin.family = "twin_family"
+        entry_b = index._storage.addSmdaReport(twin)
+        worker.updateMinHashesForSample(entry_a.sample_id)
+        worker.updateMinHashesForSample(entry_b.sample_id)
+        small_functions = [f for f in index._storage.getFunctionsBySampleId(entry_a.sample_id) if f.num_instructions < config.MINHASH_CONFIG.MINHASH_FN_MIN_INS]
+        self.assertGreater(len(small_functions), 0, "the fixture needs functions below MINHASH_FN_MIN_INS to be meaningful")
+        for pichash_size in (1, config.MINHASH_CONFIG.PICHASH_SIZE):
+            with self.subTest(pichash_size=pichash_size):
+                matcher = MatcherVs(worker, pichash_size=pichash_size)
+                result = matcher.getMatchesForSample(entry_a.sample_id, entry_b.sample_id)
+                summary = [s for s in result["matches"]["samples"] if s["sample_id"] == entry_b.sample_id][0]
+                matchable = [f for f in index._storage.getFunctionsBySampleId(entry_a.sample_id) if f.num_instructions >= pichash_size]
+                expected_bytes = sum(f.binweight for f in matchable)
+                self.assertEqual(expected_bytes, summary["matched"]["bytes"]["unweighted"])
+                self.assertAlmostEqual(100.0, summary["matched"]["percent"]["unweighted"])
+                for kind, value in summary["matched"]["percent"].items():
+                    self.assertLessEqual(value, 100.0 + 1e-9, kind)
+
     def testMatcherQuery(self):
         index = MinHashIndex(config=config)
         worker = index.queue._worker


### PR DESCRIPTION
Closes #156.

The matchable bytes of a sample — the denominator of every percentage in a sample summary — counted the functions with at least `MINHASH_FN_MIN_INS` instructions, a configuration constant, while the PicHash numerator counted every function of at least the request's `pichash_size`. A request with a smaller `pichash_size` matched functions the denominator did not contain, so a sample matched against an identical copy of itself scored above 100 %.

## What changed

`MatcherInterface._isMatchableFunction` decides the denominator with the request's own thresholds: a function counts when it reaches `pichash_size`, or when the minhasher produces a signature for it (`MINHASH_FN_MIN_INS` / `MINHASH_FN_MIN_BLOCKS`, with the same strict comparison `MinHasher.isMinHashableFunction` uses). This is the issue's first option; it keeps small-`pichash_size` requests meaningful rather than refusing them.

With the default configuration (`PICHASH_SIZE = MINHASH_FN_MIN_INS = 10`) both rules select the same functions, so existing reports are unchanged — the existing matcher expectations still pass. The new test matches a sample against an identical copy and pins `pichash_size=1` and the default to exactly 100 %; on `main` the `pichash_size=1` case reports 100.096 %.

`ruff`, `ty` and the full suite pass.

