### PR TITLE
Weight a unique function by its best match, not its last (#157)

### DIFF
--- a/mcrit/storage/MatchingResult.py
+++ b/mcrit/storage/MatchingResult.py
@@ -369,8 +369,11 @@ class MatchingResult:
                     weighted_bytes_per_function_id[function_match_summary.function_id] = 0
                 families_matched_by_function_id[function_match_summary.function_id].add(function_match_summary.matched_family_id)
                 samples_matched_by_function_id[function_match_summary.function_id].add(function_match_summary.matched_sample_id)
-                # matches should be weighted by match score
-                weighted_bytes_per_function_id[function_match_summary.function_id] = function_match_summary.num_bytes * function_match_summary.matched_score / 100.0
+                # matches should be weighted by match score - the best one a function has, not
+                # whichever match happened to be iterated last (#157)
+                weighted_bytes_per_function_id[function_match_summary.function_id] = max(
+                    weighted_bytes_per_function_id[function_match_summary.function_id], function_match_summary.num_bytes * function_match_summary.matched_score / 100.0
+                )
             for function_id in families_matched_by_function_id:
                 if len(families_matched_by_function_id[function_id]) == 1:
                     for sid in samples_matched_by_function_id[function_id]:

--- a/mcrit/storage/MatchingResult.py
+++ b/mcrit/storage/MatchingResult.py
@@ -361,24 +361,24 @@ class MatchingResult:
             self.unique_family_scores_per_sample = {entry.sample_id: {"functions_matched": 0, "bytes_matched": 0, "unique_score": 0} for entry in self.sample_matches}
             families_matched_by_function_id = {}
             samples_matched_by_function_id = {}
-            weighted_bytes_per_function_id = {}
+            weighted_bytes_per_function_and_sample = {}
             for function_match_summary in self.function_matches:
                 if function_match_summary.function_id not in families_matched_by_function_id:
                     families_matched_by_function_id[function_match_summary.function_id] = set()
                     samples_matched_by_function_id[function_match_summary.function_id] = set()
-                    weighted_bytes_per_function_id[function_match_summary.function_id] = 0
                 families_matched_by_function_id[function_match_summary.function_id].add(function_match_summary.matched_family_id)
                 samples_matched_by_function_id[function_match_summary.function_id].add(function_match_summary.matched_sample_id)
-                # matches should be weighted by match score - the best one a function has, not
-                # whichever match happened to be iterated last (#157)
-                weighted_bytes_per_function_id[function_match_summary.function_id] = max(
-                    weighted_bytes_per_function_id[function_match_summary.function_id], function_match_summary.num_bytes * function_match_summary.matched_score / 100.0
+                # matches should be weighted by match score - the best one the function has in
+                # that sample, not whichever match happened to be iterated last (#157)
+                key = (function_match_summary.function_id, function_match_summary.matched_sample_id)
+                weighted_bytes_per_function_and_sample[key] = max(
+                    weighted_bytes_per_function_and_sample.get(key, 0), function_match_summary.num_bytes * function_match_summary.matched_score / 100.0
                 )
             for function_id in families_matched_by_function_id:
                 if len(families_matched_by_function_id[function_id]) == 1:
                     for sid in samples_matched_by_function_id[function_id]:
                         self.unique_family_scores_per_sample[sid]["functions_matched"] += 1
-                        self.unique_family_scores_per_sample[sid]["bytes_matched"] += weighted_bytes_per_function_id[function_id]
+                        self.unique_family_scores_per_sample[sid]["bytes_matched"] += weighted_bytes_per_function_and_sample[(function_id, sid)]
             for sid in self.unique_family_scores_per_sample:
                 self.unique_family_scores_per_sample[sid]["unique_score"] = (
                     100.0 * self.unique_family_scores_per_sample[sid]["bytes_matched"] / self.reference_sample_entry.binweight

--- a/tests/testDataObjects.py
+++ b/tests/testDataObjects.py
@@ -91,6 +91,54 @@ class MinHashingTestSuite(unittest.TestCase):
         assert len(filtered_result.getFunctionMatches()) == 715
         assert len(set([match.function_id for match in filtered_result.getFunctionMatches()])) == 513
 
+    def testUniqueFamilyScoreUsesTheBestMatchOfAFunction(self):
+        # #157: a function matched twice within one family (two samples, two scores) must
+        # contribute its best score to the unique family score, regardless of match order
+        THIS_FILE_PATH = str(os.path.abspath(__file__))
+        PROJECT_ROOT = str(os.path.abspath(os.sep.join([THIS_FILE_PATH, "..", ".."])))
+        example_file_path = os.sep.join([PROJECT_ROOT, "tests", "example_matching_report.json"])
+        with open(example_file_path) as fjson:
+            match_json = json.load(fjson)
+        matching_result = MatchingResult.fromDict(match_json)
+        # the fixture scores every match of a function alike; spread them so that the order
+        # of iteration would show if only the last one were kept
+        matches_by_function = {}
+        for match in matching_result.function_matches:
+            matches_by_function.setdefault(match.function_id, []).append(match)
+        for matches in matches_by_function.values():
+            for rank, match in enumerate(matches):
+                match.matched_score = max(10.0, match.matched_score - 15.0 * rank)
+        # a function is unique to a family when all its matches are in that one family; the
+        # expected bytes are then the best-scored match of the function, summed per sample
+        expected_bytes = {entry.sample_id: 0 for entry in matching_result.sample_matches}
+        best_per_function = {}
+        samples_per_function = {}
+        families_per_function = {}
+        for match in matching_result.function_matches:
+            weighted = match.num_bytes * match.matched_score / 100.0
+            best_per_function[match.function_id] = max(best_per_function.get(match.function_id, 0), weighted)
+            samples_per_function.setdefault(match.function_id, set()).add(match.matched_sample_id)
+            families_per_function.setdefault(match.function_id, set()).add(match.matched_family_id)
+        for function_id, weighted in best_per_function.items():
+            if len(families_per_function[function_id]) != 1:
+                continue
+            for sample_id in samples_per_function[function_id]:
+                expected_bytes[sample_id] += weighted
+        differing = [
+            fid
+            for fid in best_per_function
+            if len(families_per_function[fid]) == 1 and len({m.matched_score for m in matching_result.function_matches if m.function_id == fid}) > 1
+        ]
+        self.assertGreater(len(differing), 0, "the fixture needs functions matched with differing scores to be meaningful")
+        for sample_id, bytes_expected in expected_bytes.items():
+            info = matching_result.getUniqueFamilyMatchInfoForSample(sample_id)
+            self.assertAlmostEqual(bytes_expected, info["bytes_matched"], places=6)
+        # and the same numbers when the matches arrive in reverse order
+        reversed_result = MatchingResult.fromDict(match_json)
+        reversed_result.function_matches = list(reversed(matching_result.function_matches))
+        for sample_id, bytes_expected in expected_bytes.items():
+            self.assertAlmostEqual(bytes_expected, reversed_result.getUniqueFamilyMatchInfoForSample(sample_id)["bytes_matched"], places=6)
+
     def testMatchingResultLazyFiltering(self):
         """The filtered_* lists are derived lazily and can be reset, so that a MatchingResult
         may be reused across several independent filter runs (e.g. from a cache)."""

--- a/tests/testDataObjects.py
+++ b/tests/testDataObjects.py
@@ -108,25 +108,31 @@ class MinHashingTestSuite(unittest.TestCase):
         for matches in matches_by_function.values():
             for rank, match in enumerate(matches):
                 match.matched_score = max(10.0, match.matched_score - 15.0 * rank)
+        # and give one function two differently scored matches in two samples of the same
+        # family, so that a per-function maximum would credit the weaker sample too much
+        sample_ids = [entry.sample_id for entry in matching_result.sample_matches]
+        self.assertEqual(2, len(sample_ids))
+        twin_matches = next(matches for matches in matches_by_function.values() if len(matches) >= 2)
+        for match, sample_id in zip(twin_matches[:2], sample_ids):
+            match.matched_family_id = twin_matches[0].matched_family_id
+            match.matched_sample_id = sample_id
+        twin_matches[0].matched_score, twin_matches[1].matched_score = 90.0, 30.0
         # a function is unique to a family when all its matches are in that one family; the
         # expected bytes are then the best-scored match of the function, summed per sample
         expected_bytes = {entry.sample_id: 0 for entry in matching_result.sample_matches}
-        best_per_function = {}
-        samples_per_function = {}
+        best_per_function_and_sample = {}
         families_per_function = {}
         for match in matching_result.function_matches:
             weighted = match.num_bytes * match.matched_score / 100.0
-            best_per_function[match.function_id] = max(best_per_function.get(match.function_id, 0), weighted)
-            samples_per_function.setdefault(match.function_id, set()).add(match.matched_sample_id)
+            key = (match.function_id, match.matched_sample_id)
+            best_per_function_and_sample[key] = max(best_per_function_and_sample.get(key, 0), weighted)
             families_per_function.setdefault(match.function_id, set()).add(match.matched_family_id)
-        for function_id, weighted in best_per_function.items():
-            if len(families_per_function[function_id]) != 1:
-                continue
-            for sample_id in samples_per_function[function_id]:
+        for (function_id, sample_id), weighted in best_per_function_and_sample.items():
+            if len(families_per_function[function_id]) == 1:
                 expected_bytes[sample_id] += weighted
         differing = [
             fid
-            for fid in best_per_function
+            for fid in families_per_function
             if len(families_per_function[fid]) == 1 and len({m.matched_score for m in matching_result.function_matches if m.function_id == fid}) > 1
         ]
         self.assertGreater(len(differing), 0, "the fixture needs functions matched with differing scores to be meaningful")


### PR DESCRIPTION
Closes #157.

`getUniqueFamilyMatchInfoForSample` assigned the score-weighted bytes of a function on every match, so the value that survived was whichever match was iterated last, while the family and sample sets beside it were accumulated. The "unique" percentage on the 1-vs-N page was order-dependent. The assignment is `max()` now.

The test spreads the fixture's matches over different scores (the captured report scores every match of a function alike, which is why this went unnoticed), computes the expected best-per-function bytes for functions unique to one family, and checks the result in both iteration orders; it fails on `main`.

`ruff`, `ty` and the full suite pass.

