### PR TITLE
Answer a sample search for an unknown sha256 with no match, not a 500 (#158)

### DIFF
--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -715,11 +715,12 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
         except Exception:
             pass
 
+        sha_match = None
         if re.match("^[a-fA-F0-9]{64}$", search_term) is not None:
+            # both storages answer an unknown hash with None (#158)
             sample_entry = storage.getSampleBySha256(search_term)
-            sha_match = sample_entry.toDict()
-        else:
-            sha_match = None
+            if sample_entry is not None:
+                sha_match = sample_entry.toDict()
 
         if sort_by not in (
             None,

--- a/tests/testMinHashIndex.py
+++ b/tests/testMinHashIndex.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import json
 import logging
 import os
 import unittest
@@ -63,6 +64,36 @@ class MalformedSearchQueryTestSuite(unittest.TestCase):
         self.assertIn("search_results", index.getFamilySearchResults("foo"))
         self.assertIn("search_results", index.getSampleSearchResults("family:foo"))
         self.assertIn("search_results", index.getFunctionSearchResults("offset:>0x100"))
+
+
+class SearchByIdentifierTestSuite(unittest.TestCase):
+    """An identifier that looks valid but is not stored is an empty match, not a server fault (#158)"""
+
+    def testUnknownSha256IsNotAMatch(self):
+        index = MinHashIndex(config)
+        results = index.getSampleSearchResults("a" * 64)
+        self.assertIsNone(results["sha_match"])
+        self.assertIsNone(results["id_match"])
+        self.assertEqual({}, results["search_results"])
+
+    def testKnownSha256IsAMatch(self):
+        index = MinHashIndex(config)
+        this_file_path = str(os.path.abspath(__file__))
+        example_file_path = os.sep.join([os.path.dirname(this_file_path), "example_report.smda"])
+        with open(example_file_path) as fjson:
+            smda_report = SmdaReport.fromDict(json.load(fjson))
+        assert smda_report is not None
+        index.addReport(smda_report)
+        sample_entry = index.getStorage().getSampleBySha256(smda_report.sha256)
+        results = index.getSampleSearchResults(smda_report.sha256)
+        self.assertEqual(sample_entry.sample_id, results["sha_match"]["sample_id"])
+
+    def testUnknownIdsAreNotAMatch(self):
+        index = MinHashIndex(config)
+        self.assertIsNone(index.getFamilySearchResults("12345")["id_match"])
+        self.assertIsNone(index.getSampleSearchResults("12345")["id_match"])
+        self.assertIsNone(index.getFunctionSearchResults("12345")["id_match"])
+        self.assertIsNone(index.getFunctionSearchResults("0xffffffffff")["id_match"])
 
 
 class UniqueBlocksCoverTestSuite(unittest.TestCase):


### PR DESCRIPTION
Closes #158.

`getSampleSearchResults` called `.toDict()` on whatever `getSampleBySha256` returned for a 64-hex-digit term; both storages return `None` for a hash that is not stored, so searching for any sha256 outside the collection was a 500. The sha match is `None` in that case now.

Tests cover the unknown and the known hash, and unknown ids on all three searches (those were already guarded by the surrounding `try`). Verified on a running instance: `GET /search/samples?query=aaaa…` answers 200 with `sha_match: null` instead of a traceback.

`ruff`, `ty` and the full suite pass.

