### PR TITLE
Select jobs before paging them, and count what a listing would show (fkie-cad/mcritweb#57, fkie-cad/mcritweb#51)

### DIFF
--- a/mcrit/client/McritClient.py
+++ b/mcrit/client/McritClient.py
@@ -580,43 +580,49 @@ class McritClient:
             return response
         return handle_response(response)
 
-    def getQueueData(self, start=0, limit=0, method=None, filter=None, state=None, ascending=False):
+    @staticmethod
+    def _job_selection_query(method=None, filter=None, state=None, username=None, **more):
+        """The query string of the parameters that select jobs, URL-encoded (a filter is free text)."""
+        params = {"method": method, "filter": filter, "state": state, "username": username, **more}
+        present = {key: value for key, value in params.items() if value is not None and value is not False and value != 0}
+        return "?" + urllib.parse.urlencode(present) if present else ""
+
+    def getQueueData(self, start=0, limit=0, method=None, filter=None, state=None, ascending=False, username=None):
         """
-        Get queue data, optionally from <start> and <limit> many
+        Get queue data, optionally from <start> and <limit> many, narrowed to a <method>, a
+        <state>, jobs whose parameters contain <filter> (case-insensitive) and/or jobs requested
+        by <username>. The narrowing is applied before paging, so a page is a page of the matches.
         Supported by mcritweb API pass-through
         """
-        query_string = "?ascending=True" if ascending else ""
-        if isinstance(start, int) and start > 0:
-            if len(query_string) == 0:
-                query_string = f"?start={start}"
-            else:
-                query_string += f"&start={start}"
-        if isinstance(limit, int) and limit > 0:
-            if len(query_string) == 0:
-                query_string = f"?limit={limit}"
-            else:
-                query_string += f"&limit={limit}"
-        if isinstance(method, str) and method is not None:
-            if len(query_string) == 0:
-                query_string = f"?method={method}"
-            else:
-                query_string += f"&method={method}"
-        if isinstance(filter, str) and filter is not None:
-            if len(query_string) == 0:
-                query_string = f"?filter={filter}"
-            else:
-                query_string += f"&filter={filter}"
-        if isinstance(state, str) and state is not None:
-            if len(query_string) == 0:
-                query_string = f"?state={state}"
-            else:
-                query_string += f"&state={state}"
+        query_string = self._job_selection_query(
+            method=method,
+            filter=filter,
+            state=state,
+            username=username,
+            start=start if isinstance(start, int) else 0,
+            limit=limit if isinstance(limit, int) else 0,
+            ascending="True" if ascending else None,
+        )
         response = requests.get(f"{self.mcrit_server}/jobs/{query_string}", headers=self.headers)
         if self.raw:
             return response
         data = handle_response(response)
         if data is not None:
             return [Job(job_data, None) for job_data in data]
+
+    def getQueueCount(self, method=None, filter=None, state=None, username=None):
+        """
+        How many jobs getQueueData would list for the same selection - what a paginated listing
+        needs to size itself.
+        Supported by mcritweb API pass-through
+        """
+        query_string = self._job_selection_query(method=method, filter=filter, state=state, username=username)
+        response = requests.get(f"{self.mcrit_server}/jobs/count{query_string}", headers=self.headers)
+        if self.raw:
+            return response
+        data = handle_response(response)
+        if data is not None:
+            return data["count"]
 
     def deleteQueueData(self, method=None, created_before=None, finished_before=None):
         """

--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -375,7 +375,7 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
         LOGGER.info("Added %d function entries.", len(function_entries))
         job_id = None
         if calculate_hashes:
-            job_id = self.updateMinHashesForSample(sample_entry.sample_id)
+            job_id = self.updateMinHashesForSample(sample_entry.sample_id, username=username)
         return {"existed": False, "sample_info": sample_entry.toDict(), "job_id": job_id}
 
     def addReportJson(self, report_json, calculate_hashes=True, calculate_matches=False, username=None):

--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -388,15 +388,15 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
         report = SmdaReport.fromDict(report_json)
         return self.addReport(report, calculate_hashes=calculate_hashes, calculate_matches=calculate_matches)
 
-    def getMatchesCross(self, sample_ids: List[int], sample_group_only=False, force_recalculation=False, **params):
+    def getMatchesCross(self, sample_ids: List[int], sample_group_only=False, force_recalculation=False, username=None, **params):
         sample_to_job_id = {}
         for id in sample_ids:
             if sample_group_only:
-                job_id = self.getMatchesForSampleVsGroup(id, [sid for sid in sample_ids if sid != id], force_recalculation=force_recalculation, **params)
+                job_id = self.getMatchesForSampleVsGroup(id, [sid for sid in sample_ids if sid != id], force_recalculation=force_recalculation, username=username, **params)
             else:
-                job_id = self.getMatchesForSample(id, force_recalculation=force_recalculation, **params)
+                job_id = self.getMatchesForSample(id, force_recalculation=force_recalculation, username=username, **params)
             sample_to_job_id[id] = job_id
-        return self.combineMatchesToCross(sample_to_job_id, await_jobs=[*sample_to_job_id.values()], force_recalculation=force_recalculation)
+        return self.combineMatchesToCross(sample_to_job_id, await_jobs=[*sample_to_job_id.values()], force_recalculation=force_recalculation, username=username)
 
     def getMatchesForSmdaFunction(self, smda_report_with_function: SmdaReport, minhash_threshold=None, pichash_size=None, band_matches_required=None, exclude_self_matches=False):
         # convert function to FunctionEntry

--- a/mcrit/libs/mongoqueue.py
+++ b/mcrit/libs/mongoqueue.py
@@ -14,9 +14,10 @@
 
 
 import json
+import re
 import traceback
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import gridfs
 import pymongo
@@ -359,34 +360,46 @@ class MongoQueue:
 
         return dict(zip(["available", "locked", "errors", "total"], counts))
 
-    def get_jobs(self, start_index: int, limit: int, method=None, state=None, ascending=False) -> Optional[List["Job"]]:
-        jobs = []
-        query_filter = {} if method is None else {"payload.method": method}
-        if state is None:
-            if ascending:
-                for job_document in self._getCollection().find(query_filter).skip(start_index).limit(limit):
-                    jobs.append(self._wrap_one(job_document))
-            else:
-                for job_document in self._getCollection().find(query_filter, sort=[("_id", -1)]).skip(start_index).limit(limit):
-                    jobs.append(self._wrap_one(job_document))
-        else:
-            # we go with an inefficient implementation for now to see if this is a desired feature and revise the query in case we deem this useful.
-            # TODO improve performance of these queries, we probably want to find a query_filter for the different possible states to allow use of skip/limit
-            all_jobs = []
-            if ascending:
-                for job_document in self._getCollection().find(query_filter):
-                    if self._identifyJobState(job_document) == state:
-                        all_jobs.append(self._wrap_one(job_document))
-            else:
-                for job_document in self._getCollection().find(query_filter, sort=[("_id", -1)]):
-                    if self._identifyJobState(job_document) == state:
-                        all_jobs.append(self._wrap_one(job_document))
-            # apply skip/limit as slice on the result
-            if limit:
-                jobs = all_jobs[start_index : start_index + limit]
-            else:
-                jobs = all_jobs[start_index:]
-        return jobs
+    # The states of _identifyJobState as queries, in the same order of precedence: each query
+    # excludes what an earlier branch would have claimed, so a document lands in exactly one.
+    _STATE_QUERIES = {
+        "in_progress": {"started_at": {"$ne": None}, "locked_by": {"$ne": None}, "finished_at": None, "terminated": False},
+        "failed": {"attempts_left": 0, "finished_at": None, "terminated": False, "$or": [{"started_at": None}, {"locked_by": None}]},
+        "queued": {"attempts_left": {"$ne": 0}, "finished_at": None, "locked_by": None, "terminated": False},
+        "finished": {"finished_at": {"$ne": None}, "terminated": False},
+        "terminated": {"terminated": True},
+    }
+
+    @classmethod
+    def _job_query(cls, method=None, state=None, filter=None, username=None) -> dict:
+        """The query behind get_jobs and get_job_count, so that paging, filtering and counting
+        all see the same set of documents (fkie-cad/mcritweb#57): a text filter used to be applied to a page
+        after it had been cut, which answered "the matches among jobs 0-24" instead of "the
+        first 25 matches", and a state used to be decided in Python per document."""
+        conditions: List[dict] = []
+        if method is not None:
+            conditions.append({"payload.method": method})
+        if state is not None:
+            # an unknown state names no job, as it never did
+            conditions.append(dict(cls._STATE_QUERIES.get(state, {"_id": {"$exists": False}})))
+        if filter:
+            # what the job's parameters rendering is made of: the method name and the
+            # serialized parameters
+            pattern = re.compile(re.escape(filter), re.IGNORECASE)
+            conditions.append({"$or": [{"payload.method": pattern}, {"payload.params": pattern}]})
+        if username is not None:
+            conditions.append({"username": username})
+        if not conditions:
+            return {}
+        return {"$and": conditions}
+
+    def get_jobs(self, start_index: int, limit: int, method=None, state=None, ascending=False, filter=None, username=None) -> List["Job"]:
+        query = self._job_query(method=method, state=state, filter=filter, username=username)
+        cursor = self._getCollection().find(query, sort=[("_id", 1 if ascending else -1)]).skip(start_index).limit(limit)
+        return [self._wrap_one(job_document) for job_document in cursor]
+
+    def get_job_count(self, method=None, state=None, filter=None, username=None) -> int:
+        return self._getCollection().count_documents(self._job_query(method=method, state=state, filter=filter, username=username))
 
     def get_job(self, job_id):
         job_id = ObjectId(job_id)

--- a/mcrit/libs/mongoqueue.py
+++ b/mcrit/libs/mongoqueue.py
@@ -249,13 +249,14 @@ class MongoQueue:
         """ """
         self._getCollection().find_one_and_update({"attempts_left": {"$lte": 0}}, remove=True)
 
-    def put(self, payload, priority=0, await_jobs: List[str] = []):
-        """Place a job into the queue"""
+    def put(self, payload, priority=0, await_jobs: List[str] = [], username=None):
+        """Place a job into the queue; username records who asked for it (fkie-cad/mcritweb#37)"""
         job = dict(self._default_insert)
         job["number"] = _useCounter(self._getCollection().database, "job")
         job["created_at"] = datetime.now()
         job["priority"] = priority
         job["payload"] = payload
+        job["username"] = username
         await_jobs_set = set(await_jobs)
         job["unfinished_dependencies"] = list(await_jobs_set)
         job["all_dependencies"] = list(await_jobs_set)
@@ -609,6 +610,11 @@ class Job:
     @property
     def priority(self):
         return self._data["priority"]
+
+    @property
+    def username(self):
+        # absent on jobs created before the field existed
+        return self._data.get("username")
 
     @property
     def attempts_left(self):

--- a/mcrit/queue/LocalQueue.py
+++ b/mcrit/queue/LocalQueue.py
@@ -399,14 +399,48 @@ class LocalQueue:
         data = self._jobs[job_id]
         return data and Job(data, self)
 
-    def get_jobs(self, start_index: int, limit: int, method=None, state=None, filter=None, ascencing=False):
-        # TODO implement all the filtering methods properly
+    @staticmethod
+    def _identifyJobState(doc) -> str:
+        # the same rule as MongoQueue._identifyJobState, on a job dict whose absent fields read
+        # as None
+        if doc["started_at"] and doc["locked_by"] and not (doc["finished_at"] or doc["terminated"]):
+            return "in_progress"
+        if doc["attempts_left"] == 0 and not doc["finished_at"] and not doc["terminated"]:
+            return "failed"
+        if not doc["finished_at"] and not doc["locked_by"] and not doc["terminated"]:
+            return "queued"
+        if doc["finished_at"] and not doc["terminated"]:
+            return "finished"
+        if doc["terminated"]:
+            return "terminated"
+        return "unknown"
+
+    def _matching_jobs(self, method=None, state=None, filter=None, username=None, ascending=False):
+        # the same selection MongoQueue._job_query makes (fkie-cad/mcritweb#57), in submission order
         jobs = []
-        for job_id, job_document in self._jobs.items():
+        for job_document in self._jobs.values():
             if method is not None and job_document["payload"]["method"] != method:
                 continue
-            jobs.append(Job(job_document, self))
-        return jobs[start_index : start_index + limit]
+            if state is not None and self._identifyJobState(job_document) != state:
+                continue
+            if username is not None and job_document["username"] != username:
+                continue
+            if filter:
+                haystack = (job_document["payload"].get("method") or "") + " " + (job_document["payload"].get("params") or "")
+                if filter.lower() not in haystack.lower():
+                    continue
+            jobs.append(job_document)
+        jobs.sort(key=lambda job_document: job_document["number"], reverse=not ascending)
+        return jobs
+
+    def get_jobs(self, start_index: int, limit: int, method=None, state=None, ascending=False, filter=None, username=None):
+        jobs = [Job(job_document, self) for job_document in self._matching_jobs(method=method, state=state, filter=filter, username=username, ascending=ascending)]
+        if limit:
+            return jobs[start_index : start_index + limit]
+        return jobs[start_index:]
+
+    def get_job_count(self, method=None, state=None, filter=None, username=None) -> int:
+        return len(self._matching_jobs(method=method, state=state, filter=filter, username=username))
 
     def get_cached_job_id(self, payload):
         return self._descriptor_to_job[payload["descriptor"]]

--- a/mcrit/queue/LocalQueue.py
+++ b/mcrit/queue/LocalQueue.py
@@ -246,6 +246,11 @@ class Job:
         return self._data["priority"]
 
     @property
+    def username(self):
+        # who asked for the job (fkie-cad/mcritweb#37); None on jobs from a backend that did not record it
+        return self._data.get("username")
+
+    @property
     def attempts_left(self):
         return self._data["attempts_left"]
 
@@ -484,13 +489,14 @@ class LocalQueue:
         del self._files[grid]
         del self._files_meta[grid]
 
-    def put(self, payload, await_jobs=[]):
+    def put(self, payload, await_jobs=[], username=None):
         id = str(uuid.uuid4())
         job_data: Dict[str, Any] = defaultdict(lambda: None)
         job_data["_id"] = id
         job_data["number"] = self._job_counter
         self._job_counter += 1
         job_data["payload"] = payload
+        job_data["username"] = username
         job_data["unfinished_dependencies"] = await_jobs
         job_data["all_dependencies"] = await_jobs
         job_data["attempts_left"] = self.max_attempts

--- a/mcrit/queue/QueueRemoteCalls.py
+++ b/mcrit/queue/QueueRemoteCalls.py
@@ -127,11 +127,13 @@ def QueueRemoteCaller(clsCallee):
 
 # Wrapper that creates a remote call proxy for a given method
 def RemotifyFunctionWrapper(function):
-    def submitPayloadQueue(self, payload, await_jobs):
-        return str(self.queue.put(payload, await_jobs=await_jobs))
+    def submitPayloadQueue(self, payload, await_jobs, username):
+        return str(self.queue.put(payload, await_jobs=await_jobs, username=username))
 
     # remote call proxy
-    def remote_call_function(self, *params, await_jobs=None, force_recalculation=False, **kwparams):
+    # username is who asked for the job (fkie-cad/mcritweb#37): it is recorded on the job document and is not
+    # part of the descriptor, so a request by another user is still served from the cache
+    def remote_call_function(self, *params, await_jobs=None, force_recalculation=False, username=None, **kwparams):
         name = function.__name__
 
         # join file locations:
@@ -158,7 +160,7 @@ def RemotifyFunctionWrapper(function):
         payload = _createJobPayload(name, params, grid_params, descriptor)
         if await_jobs is None:
             await_jobs = []
-        job_id = submitPayloadQueue(self, payload, await_jobs)
+        job_id = submitPayloadQueue(self, payload, await_jobs, username)
 
         # Add job ids to parameters
         add_job_id_to_files(self, job_id, grid_params)

--- a/mcrit/queue/QueueRemoteCalls.py
+++ b/mcrit/queue/QueueRemoteCalls.py
@@ -253,7 +253,10 @@ def add_job_id_to_files(self, job_id, grid_params):
 def _createJobPayload(method_name, params, grid_params, descriptor):
     payload = {
         "method": method_name,
-        "params": json.dumps(params),
+        # not ASCII-escaped: the serialized parameters are what the job listing's text
+        # filter matches against, and a filter typed as "Müller" must find a job whose
+        # parameter reads "Müller" in the listing (fkie-cad/mcritweb#57)
+        "params": json.dumps(params, ensure_ascii=False),
         "file_params": json.dumps(grid_params),
         "descriptor": descriptor,
     }

--- a/mcrit/queue/QueueRemoteCalls.py
+++ b/mcrit/queue/QueueRemoteCalls.py
@@ -34,12 +34,14 @@ class BaseRemoteCallerClass:
         LOGGER.debug("called getQueueStats()")
         return self.queue.getQueueStatistics(refresh=refresh)
 
-    def getQueueData(self, start_index: int, limit: int, method=None, state=None, filter=None, ascending=False) -> List[dict]:
-        LOGGER.debug(f"called getQueueData(start_index={start_index}, limit={method}, method={method}, state={state}, filter={filter}, ascending={ascending}):")
-        if filter is not None:
-            # TODO apply filter to more fields
-            return [job._data for job in self.queue.get_jobs(start_index, limit, method, state, ascending) if filter in job.parameters]
-        return [job._data for job in self.queue.get_jobs(start_index, limit, method, state, ascending)]
+    def getQueueData(self, start_index: int, limit: int, method=None, state=None, filter=None, ascending=False, username=None) -> List[dict]:
+        LOGGER.debug(f"called getQueueData(start_index={start_index}, limit={limit}, method={method}, state={state}, filter={filter}, ascending={ascending}, username={username}):")
+        # the filter is part of the query, so a page is a page of the matches (fkie-cad/mcritweb#57)
+        return [job._data for job in self.queue.get_jobs(start_index, limit, method=method, state=state, ascending=ascending, filter=filter, username=username)]
+
+    def getQueueCount(self, method=None, state=None, filter=None, username=None) -> int:
+        LOGGER.debug(f"called getQueueCount(method={method}, state={state}, filter={filter}, username={username}):")
+        return self.queue.get_job_count(method=method, state=state, filter=filter, username=username)
 
     def deleteQueueData(self, method=None, created_before=None, finished_before=None):
         LOGGER.debug(f"called getQueueData(filter={method}, filter={filter}, created_before={created_before}, finished_before={finished_before}):")

--- a/mcrit/server/BlocksResource.py
+++ b/mcrit/server/BlocksResource.py
@@ -1,7 +1,7 @@
 import re
 
 from mcrit.index.MinHashIndex import MinHashIndex
-from mcrit.server.utils import db_log_msg, getUniqueBlocksParams, jsonify, timing
+from mcrit.server.utils import db_log_msg, get_username, getUniqueBlocksParams, jsonify, timing
 
 
 class BlocksResource:
@@ -15,7 +15,7 @@ class BlocksResource:
         blocks_result = {}
         samples = self.index.getSamplesByFamilyId(family_id)
         target_sample_ids = [sample.sample_id for sample in samples]
-        blocks_result = self.index.getUniqueBlocks(target_sample_ids, family_id=family_id, **parameters)
+        blocks_result = self.index.getUniqueBlocks(target_sample_ids, family_id=family_id, username=get_username(req), **parameters)
         resp.data = jsonify({"status": "successful", "data": blocks_result})
 
     @timing
@@ -25,5 +25,5 @@ class BlocksResource:
         blocks_result = {}
         if comma_separated_sample_ids is not None and re.match(r"^\d+(?:[\s]*,[\s]*\d+)*$", comma_separated_sample_ids):
             target_sample_ids = [int(sample_id) for sample_id in comma_separated_sample_ids.split(",")]
-            blocks_result = self.index.getUniqueBlocks(target_sample_ids, **parameters)
+            blocks_result = self.index.getUniqueBlocks(target_sample_ids, username=get_username(req), **parameters)
         resp.data = jsonify({"status": "successful", "data": blocks_result})

--- a/mcrit/server/FamilyResource.py
+++ b/mcrit/server/FamilyResource.py
@@ -3,7 +3,7 @@ import re
 import falcon
 
 from mcrit.index.MinHashIndex import MinHashIndex
-from mcrit.server.utils import db_log_msg, jsonify, timing
+from mcrit.server.utils import db_log_msg, get_username, jsonify, timing
 
 
 class FamilyResource:
@@ -58,7 +58,7 @@ class FamilyResource:
                 information_update["is_library"] = True
             elif information_update["is_library"] in ["False", "false", "0", 0]:
                 information_update["is_library"] = False
-        successful = self.index.modifyFamily(family_id, information_update, force_recalculation=True)
+        successful = self.index.modifyFamily(family_id, information_update, force_recalculation=True, username=get_username(req))
         if successful:
             resp.data = jsonify({"status": "successful", "data": {"message": "Family modified."}})
             resp.status = falcon.HTTP_202
@@ -83,7 +83,7 @@ class FamilyResource:
         keep_samples = False
         if "keep_samples" in req.params:
             keep_samples = req.params["keep_samples"].lower().strip() == "true"
-        successful = self.index.deleteFamily(family_id, keep_samples=keep_samples, force_recalculation=True)
+        successful = self.index.deleteFamily(family_id, keep_samples=keep_samples, force_recalculation=True, username=get_username(req))
         if successful:
             db_log_msg(self.index, req, f"FamilyResource.on_delete - success - family_id: {family_id}, keep_samples={keep_samples}")
             resp.data = jsonify({"status": "successful", "data": successful})

--- a/mcrit/server/JobResource.py
+++ b/mcrit/server/JobResource.py
@@ -14,21 +14,29 @@ class JobResource:
     def __init__(self, index: MinHashIndex):
         self.index = index
 
+    @staticmethod
+    def _selection(req):
+        """The parameters that select jobs, shared by the listing and its count."""
+        return {
+            "method": req.params.get("method", None),
+            "state": req.params.get("state", None),
+            "filter": req.params.get("filter", None),
+            "username": req.params.get("username", None),
+        }
+
+    @timing
+    def on_get_count(self, req, resp):
+        count = self.index.getQueueCount(**self._selection(req))
+        resp.data = jsonify({"status": "successful", "data": {"count": count}})
+        db_log_msg(self.index, req, "JobResource.on_get_count - success.")
+
     @timing
     def on_get_collection(self, req, resp):
         # parse optional request parameters
         ascending = False
         if "ascending" in req.params:
             ascending = req.params["ascending"].lower().strip() == "true"
-        method_filter = None
-        if "method" in req.params:
-            method_filter = req.params["method"]
-        state_filter = None
-        if "state" in req.params:
-            state_filter = req.params["state"]
-        query_filter = None
-        if "filter" in req.params:
-            query_filter = req.params["filter"]
+        selection = self._selection(req)
         start_job_id = 0
         if "start" in req.params:
             try:
@@ -41,7 +49,7 @@ class JobResource:
                 limit_job_count = int(req.params["limit"])
             except ValueError:
                 pass
-        queue_data = self.index.getQueueData(start_index=start_job_id, limit=limit_job_count, method=method_filter, state=state_filter, filter=query_filter, ascending=ascending)
+        queue_data = self.index.getQueueData(start_index=start_job_id, limit=limit_job_count, ascending=ascending, **selection)
         resp.data = jsonify({"status": "successful", "data": queue_data})
         db_log_msg(self.index, req, "JobResource.on_get_collection - success.")
 

--- a/mcrit/server/JobResource.py
+++ b/mcrit/server/JobResource.py
@@ -26,6 +26,7 @@ class JobResource:
 
     @timing
     def on_get_count(self, req, resp):
+        """How many jobs match the same ``method``, ``state``, ``filter`` and ``username`` selection ``GET /jobs`` takes, without paging through them. Answers ``count``."""
         count = self.index.getQueueCount(**self._selection(req))
         resp.data = jsonify({"status": "successful", "data": {"count": count}})
         db_log_msg(self.index, req, "JobResource.on_get_count - success.")

--- a/mcrit/server/MatchResource.py
+++ b/mcrit/server/MatchResource.py
@@ -1,7 +1,7 @@
 import falcon
 
 from mcrit.index.MinHashIndex import MinHashIndex
-from mcrit.server.utils import db_log_msg, getMatchingParams, jsonify, timing
+from mcrit.server.utils import db_log_msg, get_username, getMatchingParams, jsonify, timing
 
 
 class MatchResource:
@@ -22,7 +22,7 @@ class MatchResource:
             db_log_msg(self.index, req, "MatchResource.on_get_sample - failed - unknown sample_id.")
             return
 
-        sample_matches = self.index.getMatchesForSample(sample_id, **parameters)
+        sample_matches = self.index.getMatchesForSample(sample_id, username=get_username(req), **parameters)
         resp.data = jsonify({"status": "successful", "data": sample_matches})
         db_log_msg(self.index, req, "MatchResource.on_get_sample - success.")
         # resp.status = falcon.HTTP_202
@@ -38,7 +38,7 @@ class MatchResource:
             db_log_msg(self.index, req, "MatchResource.on_get_sample_cross - failed - no sample_ids.")
             return
         sample_ids_list = [int(id) for id in sample_ids.split(",")]
-        cross_matches = self.index.getMatchesCross(sample_ids_list, **parameters)
+        cross_matches = self.index.getMatchesCross(sample_ids_list, username=get_username(req), **parameters)
         resp.data = jsonify({"status": "successful", "data": cross_matches})
         db_log_msg(self.index, req, "MatchResource.on_get_sample_cross - success.")
 
@@ -56,7 +56,7 @@ class MatchResource:
             resp.status = falcon.HTTP_404
             db_log_msg(self.index, req, "MatchResource.on_get_sample_vs - failed - unknown sample_id.")
             return
-        sample_matches = self.index.getMatchesForSampleVs(sample_id, sample_id_b, **parameters)
+        sample_matches = self.index.getMatchesForSampleVs(sample_id, sample_id_b, username=get_username(req), **parameters)
         resp.data = jsonify({"status": "successful", "data": sample_matches})
         db_log_msg(self.index, req, "MatchResource.on_get_sample_vs - success.")
 

--- a/mcrit/server/QueryResource.py
+++ b/mcrit/server/QueryResource.py
@@ -3,7 +3,7 @@ import re
 import falcon
 
 from mcrit.index.MinHashIndex import MinHashIndex
-from mcrit.server.utils import db_log_msg, getMatchingParams, jsonify, timing
+from mcrit.server.utils import db_log_msg, get_username, getMatchingParams, jsonify, timing
 
 
 class QueryResource:
@@ -25,7 +25,7 @@ class QueryResource:
             db_log_msg(self.index, req, "QueryResource.on_post_query_smda - failed - no POST body.")
             return
         smda_report = req.media
-        summary = self.index.getMatchesForSmdaReport(smda_report, **parameters)
+        summary = self.index.getMatchesForSmdaReport(smda_report, username=get_username(req), **parameters)
         resp.data = jsonify({"status": "successful", "data": summary})
         db_log_msg(self.index, req, "QueryResource.on_post_query_smda - success.")
 
@@ -43,7 +43,7 @@ class QueryResource:
             db_log_msg(self.index, req, "QueryResource.on_post_query_binary - failed - no POST body.")
             return
         binary = req.stream.read()
-        summary = self.index.getMatchesForUnmappedBinary(binary, **parameters)
+        summary = self.index.getMatchesForUnmappedBinary(binary, username=get_username(req), **parameters)
         resp.data = jsonify({"status": "successful", "data": summary})
         db_log_msg(self.index, req, "QueryResource.on_post_query_binary - success.")
 
@@ -63,7 +63,7 @@ class QueryResource:
         # convert string to int. 0 means figure out base automatically.
         base_address = int(base_address, 0) if base_address is not None else 0
         binary = req.stream.read()
-        summary = self.index.getMatchesForMappedBinary(binary, base_address, **parameters)
+        summary = self.index.getMatchesForMappedBinary(binary, base_address, username=get_username(req), **parameters)
         resp.data = jsonify({"status": "successful", "data": summary})
         db_log_msg(self.index, req, "QueryResource.on_post_query_binary_mapped - success.")
 

--- a/mcrit/server/SampleResource.py
+++ b/mcrit/server/SampleResource.py
@@ -4,7 +4,7 @@ import re
 import falcon
 
 from mcrit.index.MinHashIndex import MinHashIndex
-from mcrit.server.utils import db_log_msg, jsonify, timing
+from mcrit.server.utils import db_log_msg, get_username, jsonify, timing
 
 
 class SampleResource:
@@ -57,7 +57,7 @@ class SampleResource:
 
     @timing
     def on_delete(self, req, resp, sample_id=None):
-        successful = self.index.deleteSample(sample_id, force_recalculation=True)
+        successful = self.index.deleteSample(sample_id, force_recalculation=True, username=get_username(req))
         if successful:
             resp.data = jsonify({"status": "successful", "data": successful})
             resp.status = falcon.HTTP_202
@@ -98,7 +98,7 @@ class SampleResource:
                 information_update["is_library"] = True
             elif information_update["is_library"] in ["False", "false", "0", 0]:
                 information_update["is_library"] = False
-        successful = self.index.modifySample(sample_id, information_update, force_recalculation=True)
+        successful = self.index.modifySample(sample_id, information_update, force_recalculation=True, username=get_username(req))
         if successful:
             resp.data = jsonify({"status": "successful", "data": {"message": "Sample modified."}})
             resp.status = falcon.HTTP_202
@@ -158,7 +158,7 @@ class SampleResource:
         binary_sha256 = hashlib.sha256(binary).hexdigest()
         sample_entry = self.index.getSampleBySha256(binary_sha256)
         if sample_entry is None:
-            job_id = self.index.addBinarySample(binary, filename, family, version, is_dump, base_address, bitness, force_recalculation=True)
+            job_id = self.index.addBinarySample(binary, filename, family, version, is_dump, base_address, bitness, force_recalculation=True, username=get_username(req))
             resp.data = jsonify({"status": "successful", "data": job_id})
             resp.status = falcon.HTTP_202
             db_log_msg(self.index, req, f"SampleResource.on_post_submit_binary - success - with job_id: {job_id}.")

--- a/mcrit/server/StatusResource.py
+++ b/mcrit/server/StatusResource.py
@@ -4,7 +4,7 @@ import re
 import falcon
 
 from mcrit.index.MinHashIndex import MinHashIndex
-from mcrit.server.utils import db_log_msg, jsonify, timing
+from mcrit.server.utils import db_log_msg, get_username, jsonify, timing
 
 
 class StatusResource:
@@ -82,28 +82,28 @@ class StatusResource:
 
     @timing
     def on_get_complete_minhashes(self, req, resp):
-        minhash_report = self.index.updateMinHashes(None, force_recalculation=True)
+        minhash_report = self.index.updateMinHashes(None, force_recalculation=True, username=get_username(req))
         resp.data = jsonify({"status": "successful", "data": minhash_report})
         db_log_msg(self.index, req, "StatusResource.on_get_complete_minhashes - success.")
         return
 
     @timing
     def on_get_rebuild_index(self, req, resp):
-        index_report = self.index.rebuildIndex(force_recalculation=True)
+        index_report = self.index.rebuildIndex(force_recalculation=True, username=get_username(req))
         resp.data = jsonify({"status": "successful", "data": index_report})
         db_log_msg(self.index, req, "StatusResource.on_get_rebuild_index - success.")
         return
 
     @timing
     def on_get_recalculate_pichashes(self, req, resp):
-        index_report = self.index.recalculatePicHashes(force_recalculation=True)
+        index_report = self.index.recalculatePicHashes(force_recalculation=True, username=get_username(req))
         resp.data = jsonify({"status": "successful", "data": index_report})
         db_log_msg(self.index, req, "StatusResource.on_get_recalculate_pichashes - success.")
         return
 
     @timing
     def on_get_recalculate_minhashes(self, req, resp):
-        index_report = self.index.recalculateMinHashes(force_recalculation=True)
+        index_report = self.index.recalculateMinHashes(force_recalculation=True, username=get_username(req))
         resp.data = jsonify({"status": "successful", "data": index_report})
         db_log_msg(self.index, req, "StatusResource.on_get_recalculate_minhashes - success.")
         return

--- a/mcrit/server/application_routes.py
+++ b/mcrit/server/application_routes.py
@@ -159,6 +159,7 @@ def get_app():
 
     _app.add_route("/jobs", job_resource, suffix="collection")
     _app.add_route("/jobs/stats", job_resource, suffix="stats")
+    _app.add_route("/jobs/count", job_resource, suffix="count")
     _app.add_route("/jobs/{job_id}", job_resource)
     _app.add_route("/jobs/{job_id}/result", job_resource, suffix="job_result")
     _app.add_route("/results/{result_id}", job_resource, suffix="results")

--- a/mcrit/server/utils.py
+++ b/mcrit/server/utils.py
@@ -6,8 +6,13 @@ from bson import json_util
 LOGGER = logging.getLogger(__name__)
 
 
+def get_username(req):
+    """The user a request was made for, as MCRITweb and McritClient send it, or None."""
+    return req.get_header("username", default=None)
+
+
 def db_log_msg(index, req, message, level=None):
-    username = req.get_header("username", default="anonymous")
+    username = get_username(req) or "anonymous"
     if level is None:
         LOGGER.info(f"{username} - {message}")
     index._storage.dbLogEvent(message, username=username)

--- a/tests/testBlocksResource.py
+++ b/tests/testBlocksResource.py
@@ -26,19 +26,19 @@ class TestBlocksResource(unittest.TestCase):
         index, resource = self._resource()
         resp = falcon.Response()
         resource.on_get_unique_blocks_for_samples(self._request("/uniqueblocks/samples/1,2", "covers_required=3&min_instructions=5"), resp, "1,2")
-        index.getUniqueBlocks.assert_called_once_with([1, 2], covers_required=3, min_instructions=5)
+        index.getUniqueBlocks.assert_called_once_with([1, 2], username=None, covers_required=3, min_instructions=5)
         assert resp.data is not None
         self.assertEqual("successful", json.loads(resp.data)["status"])
 
     def test_family_route_passes_the_parameters(self):
         index, resource = self._resource()
         resource.on_get_unique_blocks_for_family(self._request("/uniqueblocks/family/4", "covers_required=2"), falcon.Response(), 4)
-        index.getUniqueBlocks.assert_called_once_with([7, 8], family_id=4, covers_required=2)
+        index.getUniqueBlocks.assert_called_once_with([7, 8], family_id=4, username=None, covers_required=2)
 
     def test_omitted_parameters_leave_the_defaults_to_the_worker(self):
         index, resource = self._resource()
         resource.on_get_unique_blocks_for_samples(self._request("/uniqueblocks/samples/1"), falcon.Response(), "1")
-        index.getUniqueBlocks.assert_called_once_with([1])
+        index.getUniqueBlocks.assert_called_once_with([1], username=None)
 
     def test_malformed_sample_ids_are_not_queried(self):
         index, resource = self._resource()

--- a/tests/testJobOwner.py
+++ b/tests/testJobOwner.py
@@ -66,5 +66,29 @@ class JobOwnerTest(unittest.TestCase):
         self._assert_called_with_username(index, "rebuildIndex", "alice")
 
 
+class ReportSubmissionOwnerTest(unittest.TestCase):
+    """The minhash job a submitted report queues is the submitter's too (POST /samples)"""
+
+    def test_add_report_forwards_the_user_to_the_minhash_job(self):
+        import json
+        import os
+
+        from smda.common.SmdaReport import SmdaReport
+
+        from mcrit.index.MinHashIndex import MinHashIndex
+
+        from .context import config
+
+        index = MinHashIndex(config)
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "example_report.smda")) as fjson:
+            report = SmdaReport.fromDict(json.load(fjson))
+        assert report is not None
+        summary = index.addReport(report, username="alice")
+        assert summary is not None
+        job = index.queue.get_job(summary["job_id"])
+        assert job is not None
+        self.assertEqual("alice", job.username)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testJobOwner.py
+++ b/tests/testJobOwner.py
@@ -1,0 +1,70 @@
+import unittest
+from unittest.mock import MagicMock
+
+import falcon
+import falcon.testing
+
+from mcrit.server.BlocksResource import BlocksResource
+from mcrit.server.FamilyResource import FamilyResource
+from mcrit.server.MatchResource import MatchResource
+from mcrit.server.QueryResource import QueryResource
+from mcrit.server.SampleResource import SampleResource
+from mcrit.server.StatusResource import StatusResource
+from mcrit.server.utils import get_username
+
+
+def _request(path, headers=None, query_string="", body=None, method="GET"):
+    environ = falcon.testing.create_environ(path=path, headers=headers or {}, query_string=query_string, body=body or "", method=method)
+    return falcon.Request(environ)
+
+
+class JobOwnerTest(unittest.TestCase):
+    """Every job-creating route hands the requesting user on to the queue (fkie-cad/mcritweb#37)"""
+
+    def test_get_username_reads_the_header_mcritweb_sends(self):
+        self.assertEqual("alice", get_username(_request("/", headers={"username": "alice"})))
+        self.assertIsNone(get_username(_request("/")))
+
+    def _assert_called_with_username(self, index, method, expected):
+        self.assertTrue(getattr(index, method).called, method)
+        self.assertEqual(expected, getattr(index, method).call_args.kwargs.get("username"), method)
+
+    def test_match_routes_forward_the_user(self):
+        for expected, headers in (("alice", {"username": "alice"}), (None, {})):
+            with self.subTest(user=expected):
+                index = MagicMock()
+                index.isSampleId.return_value = True
+                resource = MatchResource(index)
+                resource.on_get_sample(_request("/matches/sample/1", headers), falcon.Response(), sample_id=1)
+                self._assert_called_with_username(index, "getMatchesForSample", expected)
+                resource.on_get_sample_vs(_request("/matches/sample/1/2", headers), falcon.Response(), sample_id=1, sample_id_b=2)
+                self._assert_called_with_username(index, "getMatchesForSampleVs", expected)
+                resource.on_get_sample_cross(_request("/matches/sample/cross/1,2", headers), falcon.Response(), sample_ids="1,2")
+                self._assert_called_with_username(index, "getMatchesCross", expected)
+
+    def test_query_and_blocks_routes_forward_the_user(self):
+        headers = {"username": "alice"}
+        index = MagicMock()
+        QueryResource(index).on_post_query_binary(_request("/query/binary", headers, body="MZ", method="POST"), falcon.Response())
+        self._assert_called_with_username(index, "getMatchesForUnmappedBinary", "alice")
+        QueryResource(index).on_post_query_binary_mapped(_request("/query/binary/mapped/4096", headers, body="MZ", method="POST"), falcon.Response(), base_address="4096")
+        self._assert_called_with_username(index, "getMatchesForMappedBinary", "alice")
+        BlocksResource(index).on_get_unique_blocks_for_samples(_request("/uniqueblocks/samples/1", headers), falcon.Response(), comma_separated_sample_ids="1")
+        self._assert_called_with_username(index, "getUniqueBlocks", "alice")
+
+    def test_collection_and_maintenance_routes_forward_the_user(self):
+        headers = {"username": "alice"}
+        index = MagicMock()
+        SampleResource(index).on_delete(_request("/samples/1", headers, method="DELETE"), falcon.Response(), sample_id=1)
+        self._assert_called_with_username(index, "deleteSample", "alice")
+        FamilyResource(index).on_delete(_request("/families/1", headers, method="DELETE"), falcon.Response(), family_id=1)
+        self._assert_called_with_username(index, "deleteFamily", "alice")
+        status = StatusResource(index)
+        status.on_get_complete_minhashes(_request("/complete_minhashes", headers), falcon.Response())
+        self._assert_called_with_username(index, "updateMinHashes", "alice")
+        status.on_get_rebuild_index(_request("/rebuild_index", headers), falcon.Response())
+        self._assert_called_with_username(index, "rebuildIndex", "alice")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testMongoQueue.py
+++ b/tests/testMongoQueue.py
@@ -176,6 +176,15 @@ class MongoQueueTest(TestCase):
         self.assertEqual(1, len(jobs_in_progress))
         self.assertEqual(job.job_id, jobs_in_progress[0]["_id"])
 
+    def test_put_records_username(self):
+        with_user = self.queue.put({"method": "test_method"}, username="alice")
+        without_user = self.queue.put({"method": "test_method"})
+        self.assertEqual("alice", self.queue.get_job(with_user).username)
+        self.assertIsNone(self.queue.get_job(without_user).username)
+        # a document from before the field existed
+        self.queue._getCollection().update_one({"_id": without_user}, {"$unset": {"username": ""}})
+        self.assertIsNone(self.queue.get_job(without_user).username)
+
     def test_context_manager_error(self):
         self.queue.put({"method": "test_method", "context_id": "alpha", "data": [1, 2, 3], "more-data": time.time()})
         job = self.queue.next()

--- a/tests/testMongoQueue.py
+++ b/tests/testMongoQueue.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import time
@@ -184,6 +185,59 @@ class MongoQueueTest(TestCase):
         # a document from before the field existed
         self.queue._getCollection().update_one({"_id": without_user}, {"$unset": {"username": ""}})
         self.assertIsNone(self.queue.get_job(without_user).username)
+
+    def test_state_queries_agree_with_identify_job_state(self):
+        # fkie-cad/mcritweb#57: the per-state queries replace a per-document classification in Python; over
+        # every combination of the fields that classification reads, each document must be
+        # selected by exactly the query of its state
+        from itertools import product
+
+        now = datetime.now()
+        documents = []
+        for started_at, locked_by, finished_at, terminated, attempts_left in product((None, now), (None, "worker"), (None, now), (False, True), (0, 1)):
+            document = dict(self.queue._default_insert)
+            document.update(
+                {
+                    "payload": {"method": "test_method", "params": "{}", "descriptor": "d"},
+                    "created_at": now,
+                    "started_at": started_at,
+                    "locked_by": locked_by,
+                    "finished_at": finished_at,
+                    "terminated": terminated,
+                    "attempts_left": attempts_left,
+                }
+            )
+            documents.append(document)
+        self.queue._getCollection().insert_many(documents)
+        self.assertEqual(32, self.queue.get_job_count())
+        # a document no branch claims (e.g. locked but never started) is "unknown" in Python
+        # and is selected by no state query either
+        unknown = {doc["_id"] for doc in documents if self.queue._identifyJobState(doc) == "unknown"}
+        seen = set()
+        for state in ("in_progress", "failed", "queued", "finished", "terminated"):
+            expected = {doc["_id"] for doc in documents if self.queue._identifyJobState(doc) == state}
+            selected = {job.job_id for job in self.queue.get_jobs(0, 0, state=state)}
+            self.assertEqual(expected, selected, state)
+            self.assertEqual(len(expected), self.queue.get_job_count(state=state), state)
+            self.assertTrue(seen.isdisjoint(selected), state)
+            seen |= selected
+        self.assertEqual(32 - len(unknown), len(seen))
+        self.assertTrue(seen.isdisjoint(unknown))
+
+    def test_filter_and_username_select_before_paging(self):
+        for i in range(5):
+            self.queue.put({"method": "test_method", "params": '{"0": "apple %d"}' % i, "descriptor": "a%d" % i}, username="alice")
+            self.queue.put({"method": "other_method", "params": '{"0": "pear %d"}' % i, "descriptor": "p%d" % i}, username="bob")
+        self.assertEqual(5, self.queue.get_job_count(filter="Apple"))
+        self.assertEqual(5, self.queue.get_job_count(filter="other_"))
+        self.assertEqual(5, self.queue.get_job_count(username="bob"))
+        self.assertEqual(0, self.queue.get_job_count(filter="apple", username="bob"))
+        self.assertEqual(10, self.queue.get_job_count(state="queued"))
+        self.assertEqual(["apple 4", "apple 3", "apple 2"], [json.loads(job.payload["params"])["0"] for job in self.queue.get_jobs(0, 3, filter="apple")])
+        self.assertEqual(["apple 1", "apple 0"], [json.loads(job.payload["params"])["0"] for job in self.queue.get_jobs(3, 3, filter="apple")])
+        self.assertEqual(["apple 0", "apple 1"], [json.loads(job.payload["params"])["0"] for job in self.queue.get_jobs(0, 2, filter="apple", ascending=True)])
+        # a regex special character in the filter is literal
+        self.assertEqual(0, self.queue.get_job_count(filter="apple.*"))
 
     def test_context_manager_error(self):
         self.queue.put({"method": "test_method", "context_id": "alpha", "data": [1, 2, 3], "more-data": time.time()})

--- a/tests/testRemoteCalls.py
+++ b/tests/testRemoteCalls.py
@@ -276,6 +276,12 @@ class LocalQueueRemoteCallTest(TestCase):
         self.assertEqual(sorted(numbers), numbers)
         self.assertEqual(3, len(self.caller.getQueueData(0, 0, filter="apple", username="alice")))
         self.assertEqual(12, len(self.caller.getQueueData(0, 0, state="finished")))
+        # a parameter is matched as the listing shows it, not as an ASCII escape
+        umlaut_job = self.caller.test(needle="Müller", index=99)
+        self.caller.awaitResult(umlaut_job)
+        self.assertEqual(1, self.caller.getQueueCount(filter="müller"))
+        self.assertEqual(1, self.caller.getQueueCount(filter="Müller"))
+        self.assertEqual(0, self.caller.getQueueCount(filter="u00fc"))
         self.queue.clear()
 
     def test_file_access(self):

--- a/tests/testRemoteCalls.py
+++ b/tests/testRemoteCalls.py
@@ -232,6 +232,22 @@ class LocalQueueRemoteCallTest(TestCase):
         with self.assertRaises(AttributeError):
             self.caller.function_that_doesnt_exist(1, 2, 3)
 
+    def test_job_records_who_asked(self):
+        # fkie-cad/mcritweb#37: the user a job was requested for is stored on the job, is not part of the
+        # descriptor (another user's identical request is still served from the cache), and
+        # is None when nobody was named
+        kwparams = {"test_job_owner": True}
+        job_id = self.caller.test(username="alice", **kwparams)
+        self.assertEqual("alice", self.queue.get_job(job_id).username)
+        self.assertEqual("alice", self.queue.get_job(job_id)._data["username"])
+        self.assertEqual(job_id, self.caller.test(username="bob", **kwparams))
+        self.assertEqual("alice", self.queue.get_job(job_id).username)
+        forced_job_id = self.caller.test(username="bob", force_recalculation=True, **kwparams)
+        self.assertEqual("bob", self.queue.get_job(forced_job_id).username)
+        anonymous_job_id = self.caller.test(test_job_owner_anonymous=True)
+        self.assertIsNone(self.queue.get_job(anonymous_job_id).username)
+        self.queue.clear()
+
     def test_file_access(self):
         params = []
         kwparams = {"foo": {"test_file_access": True}}

--- a/tests/testRemoteCalls.py
+++ b/tests/testRemoteCalls.py
@@ -246,6 +246,36 @@ class LocalQueueRemoteCallTest(TestCase):
         self.assertEqual("bob", self.queue.get_job(forced_job_id).username)
         anonymous_job_id = self.caller.test(test_job_owner_anonymous=True)
         self.assertIsNone(self.queue.get_job(anonymous_job_id).username)
+
+    def test_queue_listing_filters_before_paging(self):
+        # fkie-cad/mcritweb#57: a text filter, a user and a state select the jobs first, and only then is the
+        # page cut; the count is the count of that same selection
+        for i in range(6):
+            self.caller.test(needle="apple", index=i, username="alice" if i % 2 else "bob")
+            self.caller.test(needle="pear", index=i, username="alice")
+        for job in self.queue.get_jobs(0, 0):
+            self.caller.awaitResult(str(job.job_id))
+        self.assertEqual(12, self.caller.getQueueCount())
+        self.assertEqual(6, self.caller.getQueueCount(filter="APPLE"))
+        self.assertEqual(9, self.caller.getQueueCount(username="alice"))
+        self.assertEqual(3, self.caller.getQueueCount(filter="apple", username="alice"))
+        self.assertEqual(0, self.caller.getQueueCount(filter="banana"))
+        self.assertEqual(12, self.caller.getQueueCount(state="finished"))
+        self.assertEqual(0, self.caller.getQueueCount(state="queued"))
+        self.assertEqual(0, self.caller.getQueueCount(state="no-such-state"))
+        page_1 = self.caller.getQueueData(0, 4, filter="apple")
+        page_2 = self.caller.getQueueData(4, 4, filter="apple")
+        self.assertEqual(4, len(page_1))
+        self.assertEqual(2, len(page_2))
+        self.assertTrue(all("apple" in job["payload"]["params"] for job in page_1 + page_2))
+        self.assertEqual(6, len({str(job["_id"]) for job in page_1 + page_2}))
+        # newest first by default, oldest first when ascending
+        numbers = [job["number"] for job in self.caller.getQueueData(0, 0, filter="apple")]
+        self.assertEqual(sorted(numbers, reverse=True), numbers)
+        numbers = [job["number"] for job in self.caller.getQueueData(0, 0, filter="apple", ascending=True)]
+        self.assertEqual(sorted(numbers), numbers)
+        self.assertEqual(3, len(self.caller.getQueueData(0, 0, filter="apple", username="alice")))
+        self.assertEqual(12, len(self.caller.getQueueData(0, 0, state="finished")))
         self.queue.clear()
 
     def test_file_access(self):


### PR DESCRIPTION
**Stacked on #161** (base branch `fix/37-record-job-owner`); only the last two commits are this PR.

Closes fkie-cad/mcritweb#51 and closes fkie-cad/mcritweb#57 (the Jobs tracker) on the backend side: `getQueueData` applied its text filter to a page *after* the page had been cut, so `start=0, limit=25, filter=x` answered "the matches among jobs 0–24" instead of "the first 25 matches", and nothing could say how many jobs matched at all. A state was decided in Python per document, i.e. the whole queue was loaded for a filtered page.

## What changed

- `MongoQueue._job_query` builds one query from method, state, text filter and requesting user, and `get_jobs` pages *that*. Each state is a query of its own, in the precedence order of `_identifyJobState`; a test inserts every combination of the fields that classification reads (32 documents) and asserts each state query selects exactly the documents the Python classification does.
- The text filter is a literal, case-insensitive match on the method name and the serialized parameters (what `Job.parameters` renders from), regex characters escaped.
- `get_job_count` answers the same selection, exposed as `GET /jobs/count` and `McritClient.getQueueCount()`; `GET /jobs` accepts `filter` and `username`, and `getQueueData` gains `username`. The client URL-encodes the free-text filter (it did not before).
- `LocalQueue.get_jobs` used to receive `ascending` in its `filter` parameter, by position; it has the same selection now.

## Verified against a running instance

`getQueueCount()`, `getQueueCount(username="alice")`, `getQueueCount(filter="SampleVs")`, `getQueueCount(state="finished")` and a filtered, user-narrowed page all answer the expected subsets; `GET /jobs/count?username=alice` returns `{"count": 1}`.

`ruff`, `ty` and the full suite pass.

