### PR TITLE
Answer searches as SearchResult objects from McritClient

### DIFF
--- a/mcrit/client/McritClient.py
+++ b/mcrit/client/McritClient.py
@@ -13,6 +13,7 @@ from mcrit.queue.LocalQueue import Job
 from mcrit.storage.FamilyEntry import FamilyEntry
 from mcrit.storage.FunctionEntry import FunctionEntry
 from mcrit.storage.SampleEntry import SampleEntry
+from mcrit.storage.SearchResult import SearchResult
 
 # Only do basicConfig if no handlers have been configured
 if not logging.root.handlers:
@@ -816,3 +817,34 @@ class McritClient:
     search_samples = functools.partialmethod(_search_base, "samples")
 
     search_functions = functools.partialmethod(_search_base, "functions")
+
+    # The typed counterparts (fkie-cad/mcritweb#64): the same search, answered as a
+    # SearchResult whose entries are FamilyEntry/SampleEntry/FunctionEntry objects, like every
+    # other accessor of this client. The search_* methods above keep answering the wire dict.
+
+    def _typed_search(self, search_kind, entry_class, search_term, cursor=None, is_ascending=True, sort_by=None, limit=None):
+        data = self._search_base(search_kind, search_term, cursor=cursor, is_ascending=is_ascending, sort_by=sort_by, limit=limit)
+        if data is None:
+            return None
+        return SearchResult.fromDict(data, entry_class)
+
+    def searchFamilies(self, search_term, cursor=None, is_ascending=True, sort_by=None, limit=None) -> Optional[SearchResult[FamilyEntry]]:
+        """
+        Search families by <search_term>, answered as FamilyEntry objects
+        Supported by mcritweb API pass-through (as /search/families)
+        """
+        return self._typed_search("families", FamilyEntry, search_term, cursor=cursor, is_ascending=is_ascending, sort_by=sort_by, limit=limit)
+
+    def searchSamples(self, search_term, cursor=None, is_ascending=True, sort_by=None, limit=None) -> Optional[SearchResult[SampleEntry]]:
+        """
+        Search samples by <search_term>, answered as SampleEntry objects
+        Supported by mcritweb API pass-through (as /search/samples)
+        """
+        return self._typed_search("samples", SampleEntry, search_term, cursor=cursor, is_ascending=is_ascending, sort_by=sort_by, limit=limit)
+
+    def searchFunctions(self, search_term, cursor=None, is_ascending=True, sort_by=None, limit=None) -> Optional[SearchResult[FunctionEntry]]:
+        """
+        Search functions by <search_term>, answered as FunctionEntry objects
+        Supported by mcritweb API pass-through (as /search/functions)
+        """
+        return self._typed_search("functions", FunctionEntry, search_term, cursor=cursor, is_ascending=is_ascending, sort_by=sort_by, limit=limit)

--- a/mcrit/client/McritClient.py
+++ b/mcrit/client/McritClient.py
@@ -797,7 +797,7 @@ class McritClient:
     # search_term, is_ascending and sort_by value that were used when the cursor was returned from mcrit.
     # If those parameters are altered, mcrit's behavior is undefined.
 
-    def _search_base(self, search_kind, search_term, cursor=None, is_ascending=True, sort_by=None, limit=None):
+    def _search_request(self, search_kind, search_term, cursor=None, is_ascending=True, sort_by=None, limit=None):
         params = {
             "query": search_term,
             "is_ascending": is_ascending,
@@ -809,8 +809,10 @@ class McritClient:
         if limit is not None:
             params["limit"] = limit
         encoded_params = urllib.parse.urlencode(params)
-        response = requests.get(f"{self.mcrit_server}/search/{search_kind}?{encoded_params}", headers=self.headers)
-        return handle_response(response)
+        return requests.get(f"{self.mcrit_server}/search/{search_kind}?{encoded_params}", headers=self.headers)
+
+    def _search_base(self, search_kind, search_term, cursor=None, is_ascending=True, sort_by=None, limit=None):
+        return handle_response(self._search_request(search_kind, search_term, cursor=cursor, is_ascending=is_ascending, sort_by=sort_by, limit=limit))
 
     search_families = functools.partialmethod(_search_base, "families")
 
@@ -823,7 +825,11 @@ class McritClient:
     # other accessor of this client. The search_* methods above keep answering the wire dict.
 
     def _typed_search(self, search_kind, entry_class, search_term, cursor=None, is_ascending=True, sort_by=None, limit=None):
-        data = self._search_base(search_kind, search_term, cursor=cursor, is_ascending=is_ascending, sort_by=sort_by, limit=limit)
+        response = self._search_request(search_kind, search_term, cursor=cursor, is_ascending=is_ascending, sort_by=sort_by, limit=limit)
+        if self.raw:
+            # like the other camel-case accessors: the requests.Response itself
+            return response
+        data = handle_response(response)
         if data is None:
             return None
         return SearchResult.fromDict(data, entry_class)

--- a/mcrit/storage/SearchResult.py
+++ b/mcrit/storage/SearchResult.py
@@ -1,0 +1,62 @@
+from typing import Any, Dict, Generic, Iterator, List, Optional, Type, TypeVar
+
+EntryT = TypeVar("EntryT")
+
+
+class SearchResult(Generic[EntryT]):
+    """What a search endpoint answers, with its entries deserialized (fkie-cad/mcritweb#64).
+
+    The wire format of /search/{families,samples,functions} is a dict of dicts; the other
+    accessors of McritClient hand out FamilyEntry/SampleEntry/FunctionEntry objects. This is
+    the typed counterpart of that dict: `entries` maps the id to the entry, `id_match` is the
+    entry a numeric search term named directly (or None), `sha_match` the sample a sha256
+    search term named (samples only, or None), and `cursor` carries the two paging cursors
+    as the endpoint returned them. toDict() gives the wire format back.
+    """
+
+    def __init__(self, entry_class: Type[EntryT]) -> None:
+        self.entry_class = entry_class
+        self.entries: Dict[int, EntryT] = {}
+        self.cursor: Dict[str, Optional[str]] = {"forward": None, "backward": None}
+        self.id_match: Optional[EntryT] = None
+        self.sha_match: Optional[EntryT] = None
+        # only the sample search answers a sha_match key; toDict() gives back what came in
+        self._has_sha_match_key = False
+
+    @classmethod
+    def fromDict(cls, data: Dict[str, Any], entry_class: Type[EntryT]) -> "SearchResult[EntryT]":
+        from_dict = getattr(entry_class, "fromDict")
+        result = cls(entry_class)
+        result.entries = {int(key): from_dict(value) for key, value in (data.get("search_results") or {}).items()}
+        cursor = data.get("cursor") or {}
+        result.cursor = {"forward": cursor.get("forward"), "backward": cursor.get("backward")}
+        result.id_match = from_dict(data["id_match"]) if data.get("id_match") else None
+        result.sha_match = from_dict(data["sha_match"]) if data.get("sha_match") else None
+        result._has_sha_match_key = "sha_match" in data
+        return result
+
+    def toDict(self) -> Dict[str, Any]:
+        """The wire format, as it arrives through the client: JSON object keys are strings."""
+        data: Dict[str, Any] = {
+            "search_results": {str(key): getattr(entry, "toDict")() for key, entry in self.entries.items()},
+            "cursor": dict(self.cursor),
+            "id_match": getattr(self.id_match, "toDict")() if self.id_match is not None else None,
+        }
+        if self._has_sha_match_key or self.sha_match is not None:
+            data["sha_match"] = getattr(self.sha_match, "toDict")() if self.sha_match is not None else None
+        return data
+
+    @property
+    def direct_matches(self) -> List[EntryT]:
+        """The entries the search term named directly, by id or sha256, without duplicates."""
+        matches = [match for match in (self.id_match, self.sha_match) if match is not None]
+        return [match for index, match in enumerate(matches) if match not in matches[:index]]
+
+    def __iter__(self) -> Iterator[EntryT]:
+        return iter(self.entries.values())
+
+    def __len__(self) -> int:
+        return len(self.entries)
+
+    def __repr__(self) -> str:
+        return f"SearchResult({self.entry_class.__name__}, {len(self.entries)} entries, id_match={self.id_match is not None}, sha_match={self.sha_match is not None})"

--- a/tests/testSearchResult.py
+++ b/tests/testSearchResult.py
@@ -89,6 +89,14 @@ class McritClientTypedSearchTest(unittest.TestCase):
         self.assertTrue(all(isinstance(entry, FunctionEntry) for entry in typed))
         self.assertEqual(_as_client_answer(wire), typed.toDict())
 
+    def test_raw_responses_answer_the_response_itself(self):
+        client = McritClient("http://mcrit.test", raw_responses=True)
+        response = MagicMock(status_code=400)
+        with patch("mcrit.client.McritClient.requests.get", return_value=response):
+            self.assertIs(response, client.searchFunctions("bad query"))
+            # the dict method is unchanged: it never answered the raw response
+            self.assertIsNone(client.search_functions("bad query"))
+
     def test_a_failed_search_answers_none(self):
         client = McritClient("http://mcrit.test")
         with patch("mcrit.client.McritClient.requests.get", return_value=MagicMock(status_code=400)):

--- a/tests/testSearchResult.py
+++ b/tests/testSearchResult.py
@@ -1,0 +1,100 @@
+import json
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from smda.common.SmdaReport import SmdaReport
+
+from mcrit.client.McritClient import McritClient
+from mcrit.index.MinHashIndex import MinHashIndex
+from mcrit.storage.FamilyEntry import FamilyEntry
+from mcrit.storage.FunctionEntry import FunctionEntry
+from mcrit.storage.SampleEntry import SampleEntry
+from mcrit.storage.SearchResult import SearchResult
+
+from .context import config
+
+
+def _as_client_answer(wire):
+    """The index answers int result keys; through the client (JSON) they are strings, like toDict()"""
+    return {**wire, "search_results": {str(key): value for key, value in wire["search_results"].items()}}
+
+
+def _index_with_report():
+    index = MinHashIndex(config)
+    with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "example_report.smda")) as fjson:
+        report = SmdaReport.fromDict(json.load(fjson))
+    assert report is not None
+    report.family = "search_family"
+    index.addReport(report)
+    return index, report
+
+
+class SearchResultTest(unittest.TestCase):
+    """A search answer as objects, round-tripping the wire format (fkie-cad/mcritweb#64)"""
+
+    def test_function_search_answer_becomes_entries(self):
+        index, _ = _index_with_report()
+        wire = index.getFunctionSearchResults("offset:>=0", limit=4)
+        result = SearchResult.fromDict(wire, FunctionEntry)
+        self.assertEqual(4, len(result))
+        self.assertTrue(all(isinstance(entry, FunctionEntry) for entry in result))
+        self.assertEqual(sorted(int(k) for k in wire["search_results"]), sorted(result.entries))
+        self.assertEqual(wire["cursor"], result.cursor)
+        self.assertIsNotNone(result.cursor["forward"])
+        self.assertIsNone(result.id_match)
+        self.assertEqual(_as_client_answer(wire), result.toDict())
+
+    def test_direct_matches_are_entries_without_duplicates(self):
+        index, report = _index_with_report()
+        sample_entry = index.getStorage().getSampleBySha256(report.sha256)
+        assert sample_entry is not None
+        by_id = SearchResult.fromDict(index.getSampleSearchResults(str(sample_entry.sample_id)), SampleEntry)
+        assert isinstance(by_id.id_match, SampleEntry)
+        self.assertEqual(sample_entry.sample_id, by_id.id_match.sample_id)
+        self.assertEqual([by_id.id_match], by_id.direct_matches)
+        by_sha = SearchResult.fromDict(index.getSampleSearchResults(report.sha256), SampleEntry)
+        assert isinstance(by_sha.sha_match, SampleEntry)
+        self.assertEqual(sample_entry.sample_id, by_sha.sha_match.sample_id)
+        self.assertEqual(1, len(by_sha.direct_matches))
+        families = SearchResult.fromDict(index.getFamilySearchResults("search_family"), FamilyEntry)
+        self.assertEqual(["search_family"], [entry.family_name for entry in families])
+
+    def test_an_empty_answer_is_an_empty_result(self):
+        result = SearchResult.fromDict({"search_results": {}, "cursor": {"forward": None, "backward": None}, "id_match": None, "sha_match": None}, FunctionEntry)
+        self.assertEqual(0, len(result))
+        self.assertEqual([], result.direct_matches)
+        self.assertEqual({"forward": None, "backward": None}, result.cursor)
+
+
+class McritClientTypedSearchTest(unittest.TestCase):
+    def _client_answering(self, data):
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"status": "successful", "data": data}
+        return response
+
+    def test_typed_searches_answer_objects_and_the_old_ones_keep_the_dict(self):
+        index, _ = _index_with_report()
+        wire = index.getFunctionSearchResults("offset:>=0", limit=3)
+        client = McritClient("http://mcrit.test")
+        with patch("mcrit.client.McritClient.requests.get", return_value=self._client_answering(wire)) as get:
+            typed = client.searchFunctions("offset:>=0", limit=3, sort_by="num_blocks", is_ascending=False)
+            self.assertIn("/search/functions?", get.call_args.args[0])
+            self.assertIn("sort_by=num_blocks", get.call_args.args[0])
+            self.assertIn("is_ascending=False", get.call_args.args[0])
+            self.assertEqual(wire, client.search_functions("offset:>=0", limit=3))
+        assert typed is not None
+        self.assertIsInstance(typed, SearchResult)
+        self.assertEqual(3, len(typed))
+        self.assertTrue(all(isinstance(entry, FunctionEntry) for entry in typed))
+        self.assertEqual(_as_client_answer(wire), typed.toDict())
+
+    def test_a_failed_search_answers_none(self):
+        client = McritClient("http://mcrit.test")
+        with patch("mcrit.client.McritClient.requests.get", return_value=MagicMock(status_code=400)):
+            self.assertIsNone(client.searchSamples("bad query"))
+            self.assertIsNone(client.searchFamilies("bad query"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes fkie-cad/mcritweb#64 (McritClient should return objects for search results).

Every accessor of `McritClient` hands out `FamilyEntry` / `SampleEntry` / `FunctionEntry` objects, except the three searches, which answer the raw wire dict. This adds the typed counterpart without changing the existing methods.

## Changes

- **`mcrit/storage/SearchResult.py`**: a small generic container. `entries` maps id to entry object, `cursor` carries the forward/backward paging cursors, `id_match` / `sha_match` are the entries a numeric or sha256 search term named directly (`direct_matches` gives them without duplicates). `fromDict()` reads the wire dict, `toDict()` gives it back in the client's form (string result keys, `sha_match` only where the endpoint answered it). It iterates over its entries and has a length.
- **`McritClient.searchFamilies()` / `searchSamples()` / `searchFunctions()`**: the same request as `search_families` / `search_samples` / `search_functions` (same `cursor`, `is_ascending`, `sort_by`, `limit` parameters), answered as `SearchResult[FamilyEntry]` etc., `None` on a failed request. The `search_*` methods keep returning the dict, so no caller changes.

## Verification

- `tests/testSearchResult.py`: a function search answer becomes `FunctionEntry` objects with the cursor kept and round-trips through `toDict()`; id and sha matches on the sample search become entries and are deduplicated; the empty answer; the client builds the same URL as the dict method and answers objects; a failed request answers `None`.
- Full suite: 208 passed, `ruff check`, `ruff format --check`, `ty check` clean.
- Against a live MongoDB-backed server: `search_*(...) == search*(...).toDict()` for function, sample (with and without id match) and family searches.

The mcritweb side (consuming these in the search views) is fkie-cad/mcritweb#174.


