### PR TITLE
Answer function name searches from the distinct names

### DIFF
--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -161,6 +161,9 @@ class MongoDbStorage(StorageInterface):
     # DISTINCT_SCAN over the function_name index, tens of milliseconds even for millions of
     # functions; above the cap the search falls back to the regex, unbounded as before.
     _DISTINCT_VALUES_CAP = 10000
+    # and at most this many bytes of them in total: the matching values go into one $in, which
+    # must stay well inside MongoDB's 16 MiB command limit even when they are long mangled symbols
+    _DISTINCT_VALUES_MAX_BYTES = 1 << 20
 
     _database: Optional["Database"]
 
@@ -1818,9 +1821,18 @@ class MongoDbStorage(StorageInterface):
         return sort_list
 
     def _getDistinctValues(self, collection: str, field: str) -> Optional[List[Any]]:
-        """All distinct values of the field, or None when there are more than _DISTINCT_VALUES_CAP."""
+        """All distinct values of the field, or None when there are more than _DISTINCT_VALUES_CAP
+        of them or they exceed _DISTINCT_VALUES_MAX_BYTES in total."""
         pipeline = [{"$group": {"_id": "$" + field}}, {"$limit": self._DISTINCT_VALUES_CAP + 1}]
-        values = [document["_id"] for document in self._getDb()[collection].aggregate(pipeline)]
+        values = []
+        total_bytes = 0
+        for document in self._getDb()[collection].aggregate(pipeline):
+            value = document["_id"]
+            if isinstance(value, str):
+                total_bytes += len(value.encode("utf-8"))
+                if total_bytes > self._DISTINCT_VALUES_MAX_BYTES:
+                    return None
+            values.append(value)
         if len(values) > self._DISTINCT_VALUES_CAP:
             return None
         return values

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -24,6 +24,7 @@ from mcrit.index.SearchQueryTree import (
     BaseVisitor,
     FilterSingleElementLists,
     NodeType,
+    NotNode,
     OrNode,
     PropagateNot,
     SearchConditionNode,
@@ -54,6 +55,12 @@ class MongoSearchTranspiler(BaseVisitor):
     """
     Converts a tree to a MongoDB query.
     The input tree MUST NOT contain Not or SearchTerm nodes.
+
+    known_values maps a field to the complete list of distinct values it holds. A substring
+    condition on such a field is evaluated against that list here and emitted as an $in / $nin
+    of the values that match, which MongoDB answers from the index. The unanchored,
+    case-insensitive regex it replaces cannot use index bounds and makes MongoDB examine every
+    document of the collection when nothing matches (fkie-cad/mcritweb#76).
     """
 
     @staticmethod
@@ -80,7 +87,24 @@ class MongoSearchTranspiler(BaseVisitor):
         visited_children = [self.visit(child) for child in node.children]
         return self._or_query(*visited_children)
 
+    def __init__(self, known_values: Optional[Dict[str, List[Any]]] = None) -> None:
+        super().__init__()
+        self.known_values = known_values or {}
+
+    def _substring_condition_from_known_values(self, node: SearchConditionNode) -> Optional[Dict[str, Any]]:
+        # an empty search term matches everything, so the regex is left alone there
+        if not node.operator.endswith("?") or node.field not in self.known_values or not node.value:
+            return None
+        pattern = re.compile(re.escape(node.value), re.IGNORECASE)
+        matching = [value for value in self.known_values[node.field] if isinstance(value, str) and pattern.search(value)]
+        if node.operator == "!?":
+            return {node.field: {"$nin": matching}}
+        return {node.field: {"$in": matching}}
+
     def visitSearchConditionNode(self, node: SearchConditionNode):
+        condition_from_known_values = self._substring_condition_from_known_values(node)
+        if condition_from_known_values is not None:
+            return condition_from_known_values
         operator_to_mongo = {
             "<": "$lt",
             "<=": "$lte",
@@ -118,8 +142,25 @@ class MongoSearchTranspiler(BaseVisitor):
         return condition
 
 
+def _hasSubstringCondition(tree: NodeType, field: str) -> bool:
+    """True when the (resolved) tree holds a substring condition on the field."""
+    if isinstance(tree, SearchConditionNode):
+        return tree.field == field and tree.operator.endswith("?")
+    if isinstance(tree, (AndNode, OrNode)):
+        return any(_hasSubstringCondition(child, field) for child in tree.children)
+    if isinstance(tree, NotNode):
+        return _hasSubstringCondition(tree.child, field)
+    return False
+
+
 class MongoDbStorage(StorageInterface):
     _DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
+
+    # A substring search on function_name is answered through the distinct names of the
+    # collection when there are at most this many (fkie-cad/mcritweb#76). Listing them is one
+    # DISTINCT_SCAN over the function_name index, tens of milliseconds even for millions of
+    # functions; above the cap the search falls back to the regex, unbounded as before.
+    _DISTINCT_VALUES_CAP = 10000
 
     _database: Optional["Database"]
 
@@ -1776,7 +1817,22 @@ class MongoDbStorage(StorageInterface):
         sort_list = [(key, 1 if direction ^ is_backward_search else -1) for key, direction in full_cursor.sort_by_list]
         return sort_list
 
-    def _get_search_query(self, search_fields: List[str], search_tree: NodeType, cursor: Optional[FullSearchCursor], conditional_search_fields=None):
+    def _getDistinctValues(self, collection: str, field: str) -> Optional[List[Any]]:
+        """All distinct values of the field, or None when there are more than _DISTINCT_VALUES_CAP."""
+        pipeline = [{"$group": {"_id": "$" + field}}, {"$limit": self._DISTINCT_VALUES_CAP + 1}]
+        values = [document["_id"] for document in self._getDb()[collection].aggregate(pipeline)]
+        if len(values) > self._DISTINCT_VALUES_CAP:
+            return None
+        return values
+
+    def _get_search_query(
+        self, search_fields: List[str], search_tree: NodeType, cursor: Optional[FullSearchCursor], conditional_search_fields=None, distinct_fields: Optional[Dict[str, str]] = None
+    ):
+        """
+        distinct_fields maps a field to its collection: a substring condition on it is rewritten to
+        the distinct values that match, when the collection has few enough of them (see
+        MongoSearchTranspiler.known_values).
+        """
         # checked here as well as when the sort list is built, because this runs first: paging by an
         # unsortable field would otherwise fail in the transpiler, blaming the range operator that
         # the cursor tree happens to use instead of naming the field that cannot be sorted by
@@ -1788,7 +1844,13 @@ class MongoDbStorage(StorageInterface):
         full_tree = SearchFieldResolver(search_fields, conditional_search_fields=conditional_search_fields).visit(full_tree)
         full_tree = FilterSingleElementLists().visit(full_tree)
         full_tree = PropagateNot().visit(full_tree)
-        query = MongoSearchTranspiler().visit(full_tree)
+        known_values = {}
+        for field, collection in (distinct_fields or {}).items():
+            if _hasSubstringCondition(full_tree, field):
+                values = self._getDistinctValues(collection, field)
+                if values is not None:
+                    known_values[field] = values
+        query = MongoSearchTranspiler(known_values).visit(full_tree)
         return query
 
     ##### search ####
@@ -1823,7 +1885,7 @@ class MongoDbStorage(StorageInterface):
         result_dict = {}
         # TODO also search through function labels once we have implemented them
         search_fields = ["function_name"]
-        query = self._get_search_query(search_fields, search_tree, cursor)
+        query = self._get_search_query(search_fields, search_tree, cursor, distinct_fields={"function_name": "functions"})
         sort_list = self._get_sort_list_from_cursor(cursor)
         for function_document in self._getDb().functions.find(query, {"_id": 0}, sort=sort_list, limit=max_num_results):
             self._decodeFunction(function_document)

--- a/tests/testMongoSearchTranspiler.py
+++ b/tests/testMongoSearchTranspiler.py
@@ -60,3 +60,42 @@ class TestMongoSortableFields(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestSubstringSearchOverKnownValues(unittest.TestCase):
+    """A substring condition on a field whose distinct values are known is answered as an
+    $in / $nin of the matching values, so MongoDB uses the index instead of scanning every
+    document with a regex (fkie-cad/mcritweb#76)."""
+
+    NAMES = ["", "main", "WinMain", "decrypt_config", "sub_401000", None]
+
+    def _visit(self, operator, value, field="function_name"):
+        return MongoSearchTranspiler({"function_name": self.NAMES}).visit(SearchConditionNode(field, operator, value))
+
+    def test_a_substring_condition_becomes_the_matching_values(self):
+        self.assertEqual({"function_name": {"$in": ["main", "WinMain"]}}, self._visit("?", "main"))
+
+    def test_the_match_is_case_insensitive_like_the_regex(self):
+        self.assertEqual({"function_name": {"$in": ["main", "WinMain"]}}, self._visit("?", "MAIN"))
+        self.assertEqual({"function_name": {"$in": ["decrypt_config"]}}, self._visit("?", "CRYPT_"))
+
+    def test_nothing_matching_is_an_empty_list(self):
+        # matches no document at all, without MongoDB looking at a single one
+        self.assertEqual({"function_name": {"$in": []}}, self._visit("?", "zzzzq"))
+
+    def test_the_negated_condition_excludes_the_matching_values(self):
+        self.assertEqual({"function_name": {"$nin": ["main", "WinMain"]}}, self._visit("!?", "main"))
+
+    def test_regex_metacharacters_are_literal(self):
+        self.assertEqual({"function_name": {"$in": []}}, self._visit("?", "sub_.*"))
+        self.assertEqual({"function_name": {"$in": ["sub_401000"]}}, self._visit("?", "sub_4"))
+
+    def test_an_empty_term_keeps_the_regex(self):
+        condition = self._visit("?", "")
+        self.assertEqual(["function_name"], list(condition))
+        self.assertTrue(hasattr(condition["function_name"], "search"))
+
+    def test_other_fields_and_operators_keep_their_form(self):
+        self.assertEqual({"function_name": "main"}, self._visit("=", "main"))
+        condition = self._visit("?", "main", field="family")
+        self.assertTrue(hasattr(condition["family"], "search"))

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -560,6 +560,19 @@ class MongoDbStorageTest(MemoryStorageTest):
         finally:
             MongoDbStorage._DISTINCT_VALUES_CAP = original_cap
 
+    def testSubstringSearchFallsBackToTheRegexAboveTheByteCap(self):
+        # thousands of long mangled symbols stay under the count cap but would not fit one $in
+        self._storageWithNamedFunctions()
+        original_cap = MongoDbStorage._DISTINCT_VALUES_MAX_BYTES
+        try:
+            MongoDbStorage._DISTINCT_VALUES_MAX_BYTES = 16
+            self.assertIsNone(self.storage._getDistinctValues("functions", "function_name"))
+            query = self.storage._get_search_query(["function_name"], SearchQueryParser().parse("qz_alph"), None, distinct_fields={"function_name": "functions"})
+            self.assertTrue(hasattr(query["function_name"], "search"))
+            self.assertEqual(["qz_alpha", "QZ_Alphabet"], self._searchFunctionNames("qz_alph"))
+        finally:
+            MongoDbStorage._DISTINCT_VALUES_MAX_BYTES = original_cap
+
     def testSubstringSearchCombinesWithOtherConditionsAndNegation(self):
         self._storageWithNamedFunctions()
         self.assertEqual(["qz_alpha", "QZ_Alphabet"], self._searchFunctionNames("sample_id:0 qz_alph"))

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 from unittest import TestCase, main
+from unittest.mock import patch
 
 import pytest
 from smda.common.SmdaReport import SmdaReport
@@ -12,8 +13,11 @@ from mcrit.config.QueueConfig import QueueConfig
 from mcrit.config.ShinglerConfig import ShinglerConfig
 from mcrit.config.StorageConfig import StorageConfig
 from mcrit.index.MinHashIndex import MinHashIndex
+from mcrit.index.SearchCursor import FullSearchCursor
+from mcrit.index.SearchQueryParser import SearchQueryParser
 from mcrit.minhash.MinHash import MinHash
 from mcrit.storage.FunctionEntry import FunctionEntry
+from mcrit.storage.MongoDbStorage import MongoDbStorage
 from mcrit.storage.SampleEntry import SampleEntry
 from mcrit.storage.StorageFactory import StorageFactory
 
@@ -510,6 +514,71 @@ class MongoDbStorageTest(MemoryStorageTest):
         mcrit_config.SHINGLER_CONFIG = ShinglerConfig()
         mcrit_config.QUEUE_CONFIG = QueueConfig()
         return StorageFactory.getStorage(mcrit_config)
+
+    # --- substring search on function_name over the distinct names (fkie-cad/mcritweb#76) ----
+
+    def _storageWithNamedFunctions(self):
+        self.storage.clearStorage()
+        with open(self.example_file_path) as fjson:
+            smda_report = SmdaReport.fromDict(json.load(fjson))
+        self.storage.addSmdaReport(smda_report)
+        function_ids = sorted(entry.function_id for entry in self.storage.getFunctionsBySampleId(0))
+        names = ["qz_alpha", "QZ_Alphabet", "kryptos_config", "KryptosConfig", "sub_401000"]
+        for function_id, name in zip(function_ids, names):
+            self.storage._getDb().functions.update_one({"function_id": function_id}, {"$set": {"function_name": name}})
+        return dict(zip(names, function_ids))
+
+    def _searchFunctionNames(self, term, sort_by="function_id", is_ascending=True):
+        parsed = SearchQueryParser().parse(term)
+        cursor = FullSearchCursor(None, [(sort_by, is_ascending), ("function_id", True)] if sort_by != "function_id" else [("function_id", is_ascending)])
+        return [entry.function_name for entry in self.storage.findFunctionByString(parsed, cursor=cursor, max_num_results=100).values()]
+
+    def testSubstringSearchOnFunctionNamesUsesTheDistinctNames(self):
+        by_name = self._storageWithNamedFunctions()
+        self.assertEqual(["qz_alpha", "QZ_Alphabet"], self._searchFunctionNames("qz_alph"))
+        self.assertEqual(["kryptos_config", "KryptosConfig"], self._searchFunctionNames("KRYPTOS"))
+        self.assertEqual(["QZ_Alphabet", "qz_alpha"], self._searchFunctionNames("qz_alph", is_ascending=False))
+        self.assertEqual([], self._searchFunctionNames("zzzzq"))
+        # the query MongoDB gets is an $in of the matching names, not a regex
+        query = self.storage._get_search_query(["function_name"], SearchQueryParser().parse("qz_alph"), None, distinct_fields={"function_name": "functions"})
+        self.assertEqual({"function_name": {"$in": ["QZ_Alphabet", "qz_alpha"]}}, {k: {op: sorted(v) for op, v in c.items()} for k, c in query.items()})
+        self.assertEqual([entry.function_id for entry in self.storage.findFunctionByString(SearchQueryParser().parse("zzzzq")).values()], [])
+        self.assertEqual(sorted(by_name.values())[:2], sorted(entry.function_id for entry in self.storage.findFunctionByString(SearchQueryParser().parse("qz_alph")).values()))
+
+    def testSubstringSearchFallsBackToTheRegexAboveTheCap(self):
+        self._storageWithNamedFunctions()
+        original_cap = MongoDbStorage._DISTINCT_VALUES_CAP
+        try:
+            MongoDbStorage._DISTINCT_VALUES_CAP = 2
+            self.assertIsNone(self.storage._getDistinctValues("functions", "function_name"))
+            query = self.storage._get_search_query(["function_name"], SearchQueryParser().parse("qz_alph"), None, distinct_fields={"function_name": "functions"})
+            self.assertTrue(hasattr(query["function_name"], "search"))
+            # same answers either way
+            self.assertEqual(["qz_alpha", "QZ_Alphabet"], self._searchFunctionNames("qz_alph"))
+            self.assertEqual([], self._searchFunctionNames("zzzzq"))
+            self.assertEqual(["kryptos_config", "KryptosConfig"], self._searchFunctionNames("KRYPTOS"))
+        finally:
+            MongoDbStorage._DISTINCT_VALUES_CAP = original_cap
+
+    def testSubstringSearchCombinesWithOtherConditionsAndNegation(self):
+        self._storageWithNamedFunctions()
+        self.assertEqual(["qz_alpha", "QZ_Alphabet"], self._searchFunctionNames("sample_id:0 qz_alph"))
+        self.assertEqual([], self._searchFunctionNames("sample_id:1 qz_alph"))
+        excluded = self._searchFunctionNames("function_name:!?qz_alph")
+        self.assertNotIn("qz_alpha", excluded)
+        self.assertNotIn("QZ_Alphabet", excluded)
+        self.assertIn("kryptos_config", excluded)
+        self.assertEqual(len(self.storage.getFunctionsBySampleId(0)) - 2, len(excluded))
+
+    def testDistinctValuesAreListedOnlyForSubstringSearches(self):
+        self._storageWithNamedFunctions()
+        with patch.object(self.storage, "_getDistinctValues", wraps=self.storage._getDistinctValues) as listing:
+            self.storage.findFunctionByString(SearchQueryParser().parse("sample_id:0"))
+            self.assertEqual(0, listing.call_count)
+            self.storage.findFunctionByString(SearchQueryParser().parse("function_name:qz_alpha"))
+            self.assertEqual(0, listing.call_count)
+            self.storage.findFunctionByString(SearchQueryParser().parse("qz_alph"))
+            self.assertEqual(1, listing.call_count)
 
     def testCounterInitIsIdempotent(self):
         # constructing storage repeatedly against the same database must not add counter documents (#105)


### PR DESCRIPTION
Closes fkie-cad/mcritweb#76 (searching for functions is painfully slow, ~30 s, on larger databases if no results are found).

## Cause

A free-text function search becomes an unanchored, case-insensitive regex on `function_name`. MongoDB cannot bound an index with that, so when nothing matches it examines every function document before it can answer the empty page: seconds on a million functions, the reported 30 s on larger databases. With a non-default sort (`sort_by=num_blocks` etc.) it examines every document even when there are hits, since it cannot stop early.

## Fix

Function names repeat heavily: most are empty, the rest are symbols shared across samples (the live test database holds 9 distinct names for 1158 functions). So the set of distinct names is small where the collection is large.

`MongoDbStorage.findFunctionByString` now:

1. Lists the distinct names with one `$group` + `$limit` aggregation, which MongoDB runs as a `DISTINCT_SCAN` over the existing `function_name` index (tens of milliseconds for millions of functions, verified with `explain()`). Only when the query actually holds a substring condition on `function_name`; `sample_id:0` or `function_name:main` (equality) do not pay for it.
2. Evaluates the substring condition against that list in Python with the same escaped, case-insensitive pattern, and hands MongoDB an `$in` (or `$nin` for `!?`) of the matching names, which it answers from the index. Nothing matching becomes `$in: []`, so the empty page costs nothing.
3. Above `_DISTINCT_VALUES_CAP` (10000) distinct names the search keeps the regex, unbounded as before. That is the one case this PR does not speed up; it needs an n-gram index, which is out of scope.

`MongoSearchTranspiler` takes an optional `known_values` map for this; an empty search term keeps the regex (it matches everything), other fields and operators are untouched.

## Measurements

Two million synthetic functions, MongoDB 7, page of 101, from the storage's own `_get_search_query` + `find`:

| collection | search | before | after |
|---|---|---|---|
| 5000 distinct names | no result, default sort | 4.2 s (2M docs) | 22 ms (0 docs) |
| 5000 distinct names | name held by 19 functions | 4.2 s | 2 ms |
| 5000 distinct names | `beacon` (515 names), sorted by num_blocks | 1.5 s | 62 ms |
| 5000 distinct names | `main` (986 names), default sort | 15 ms | 78 ms |
| 5000 distinct names | `e` (4014 names), default sort | 5 ms | 27 ms |
| 1.94M distinct names (above cap) | no result | 4.3 s | 4.1 s (regex fallback, +70 ms listing) |

The common-term default-sort case is the only one that gets slower, by tens of milliseconds, because the regex scan in id order finds its 101 hits almost immediately there.

## Verification

- `tests/testMongoSearchTranspiler.py`: matching values become `$in` / `$nin`, case-insensitive like the regex, metacharacters literal, nothing matching is an empty list, empty term and other fields keep their form.
- `tests/testStorage.py` (Mongo): the search answers the same entries through the rewrite and through the regex fallback (cap patched to 2), combined with other conditions and negation, and the listing runs only for substring conditions.
- Full suite: 214 passed, `ruff check`, `ruff format --check`, `ty check` clean.
- Live: server restarted with the change, `/search/functions` for a no-result term, a name in both cases, `sample_id:0 decrypt`, `sample_id:1 decrypt` (no result), `function_name:!?decrypt`, the empty term and a term with regex metacharacters all answer as before; MCRITweb's function listing, sample page and search page render the same rows.

