### PR TITLE
Remove a band document its last function leaves, never create one on delete (#149)

### DIFF
--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -1061,6 +1061,10 @@ class MongoDbStorage(StorageInterface):
                     band_hashes[band_number][band_hash].append(minhash.function_id)
         self._updateBands(band_hashes)
 
+    # a band document whose posting list is empty (or missing) holds nothing a candidate
+    # lookup could find; it is residue, not index (#149)
+    _EMPTY_BAND_DOCUMENT = {"$or": [{"function_ids": {"$size": 0}}, {"function_ids": {"$exists": False}}]}
+
     def _updateBands(self, band_hashes: Dict[int, Dict[int, List[int]]], method="push") -> int:
         if method not in ["push", "pull"]:
             raise ValueError(f"MongoDbStorage._updateBands() can only do 'push' and 'pull', not '{method}'.")
@@ -1071,14 +1075,27 @@ class MongoDbStorage(StorageInterface):
                 if len(function_ids) < 1:
                     continue
                 if method == "push":
-                    update_command = {"$push": {"function_ids": {"$each": function_ids}}}
+                    # a band hash seen for the first time gets its document here
+                    band_updates.append(UpdateOne({"band_hash": band_hash}, {"$push": {"function_ids": {"$each": function_ids}}}, upsert=True))
                 else:
-                    update_command = {"$pull": {"function_ids": {"$in": function_ids}}}
-                band_updates.append(UpdateOne({"band_hash": band_hash}, update_command, upsert=True))
+                    # pulling from a band hash that has no document must not create one (#149)
+                    band_updates.append(UpdateOne({"band_hash": band_hash}, {"$pull": {"function_ids": {"$in": function_ids}}}))
             if band_updates:
-                self._getDb()["band_%d" % band_number].bulk_write(band_updates, ordered=False)
+                collection = self._getDb()["band_%d" % band_number]
+                collection.bulk_write(band_updates, ordered=False)
+                if method == "pull":
+                    # a posting list the pull emptied is removed, not kept as a tombstone; scoped to
+                    # the hashes just touched, so it is one indexed delete per band (#149)
+                    collection.delete_many({"band_hash": {"$in": list(band_data)}, **self._EMPTY_BAND_DOCUMENT})
             num_band_updates += len(band_updates)
         return num_band_updates
+
+    def purgeEmptyBandDocuments(self) -> int:
+        """Remove the empty band documents that deletions left behind before #149; returns how many."""
+        removed = 0
+        for band_number in range(self._storage_config.STORAGE_NUM_BANDS):
+            removed += self._getDb()["band_%d" % band_number].delete_many(self._EMPTY_BAND_DOCUMENT).deleted_count
+        return removed
 
     def _collectBandHashTargets(self, function_id_to_minhash: Dict[int, "MinHash"]):
         """band_number -> set(band_hash) to query, and band_number -> band_hash -> query function_ids."""

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -606,6 +606,46 @@ class MongoDbStorageTest(MemoryStorageTest):
         self.assertEqual(len(minhashes), rebuild_result["minhash_functions_indexed"])
         self.assertEqual(bands_before, dumpBands())
 
+    def _storageWithBandedSample(self):
+        self.storage.clearStorage()
+        smda_report = SmdaReport.fromFile(self.example_file_path)
+        sample_entry = self.storage.addSmdaReport(smda_report)
+        minhashes = [MinHash(function_id=function_id, minhash_signature=[0x30 + function_id + index for index in range(10)], minhash_bits=8) for function_id in [0, 2, 3, 5, 7, 8]]
+        self.storage.addMinHashes(minhashes)
+        return sample_entry, ["band_%d" % band_id for band_id in range(self.storage._storage_config.STORAGE_NUM_BANDS)]
+
+    def testDeleteSampleLeavesNoEmptyBandDocuments(self):
+        # #149: a pull that empties a posting list removes the document, and a pull on a
+        # band hash without a document does not create one
+        sample_entry, band_collections = self._storageWithBandedSample()
+        db = self.storage._getDb()
+        self.assertGreater(sum(db[c].count_documents({}) for c in band_collections), 0)
+        self.storage.deleteSample(sample_entry.sample_id)
+        for collection in band_collections:
+            self.assertEqual(0, db[collection].count_documents({}), collection)
+        # the same pull again, against an index that no longer holds the hashes: nothing appears
+        self.storage._updateBands({0: {12345: [1, 2]}, 1: {67890: [3]}}, method="pull")
+        self.assertEqual(0, db.band_0.count_documents({}))
+        self.assertEqual(0, db.band_1.count_documents({}))
+
+    def testPullingKeepsTheOtherMembersOfABand(self):
+        self.storage.clearStorage()
+        db = self.storage._getDb()
+        db.band_0.insert_one({"band_hash": 4242, "function_ids": [1, 2, 3]})
+        db.band_0.insert_one({"band_hash": 4343, "function_ids": [1]})
+        self.storage._updateBands({0: {4242: [1], 4343: [1]}}, method="pull")
+        self.assertEqual([2, 3], db.band_0.find_one({"band_hash": 4242})["function_ids"])
+        self.assertIsNone(db.band_0.find_one({"band_hash": 4343}))
+
+    def testPurgeEmptyBandDocumentsRemovesOnlyTheTombstones(self):
+        self.storage.clearStorage()
+        db = self.storage._getDb()
+        db.band_0.insert_many([{"band_hash": 1, "function_ids": []}, {"band_hash": 2}, {"band_hash": 3, "function_ids": [7]}])
+        db.band_1.insert_one({"band_hash": 9, "function_ids": []})
+        self.assertEqual(3, self.storage.purgeEmptyBandDocuments())
+        self.assertEqual([3], [d["band_hash"] for d in db.band_0.find({}, {"band_hash": 1})])
+        self.assertEqual(0, db.band_1.count_documents({}))
+
 
 @pytest.mark.mongo
 class MongoDbXcfgSplitTest(TestCase):


### PR DESCRIPTION
Closes #149 (deleteSample leaves empty band documents behind, and its upsert can create them).

## Cause

`_updateBands` issued the same upserting `UpdateOne` for both directions. On the pull path that meant a posting list the pull emptied stayed behind as `{"band_hash": h, "function_ids": []}`, and a pull on a band hash without a document created `{"band_hash": h}` instead of doing nothing. The issue measured 3,052 such tombstones from deleting three samples on a live instance, and the second case makes a delete grow the index whenever the stored minhashes and the current projection have diverged.

## Fix

- The pull path no longer upserts.
- After each band's bulk write on the pull path, the documents among the hashes just touched whose posting list is empty (or missing) are deleted: one indexed `delete_many` per band, scoped to the touched hashes, so no scan.
- `purgeEmptyBandDocuments()` removes the residue older deletions left, for an operator to run once after upgrading; it is not run automatically. The reasoning in the issue (a full rebuild also clears it) still holds.

Matching is unaffected either way: an empty posting list never contributed candidates.

## Verification

- `tests/testStorage.py` (Mongo): deleting a sample leaves every band collection empty and a repeated pull against the emptied index creates nothing; a pull keeps the other members of a band and removes only the document it emptied; the purge removes the two tombstone shapes and keeps a live document.
- Storage suite: 52 passed, `ruff check`, `ruff format --check`, `ty check` clean.

Related: danielplohmann/mcrit#142's selective repair (pull, then push, per sample) would otherwise leave a fresh tombstone set on every run.

