### PR TITLE
Reclaim the jobs of a worker that died without unwinding (#150)

### DIFF
--- a/mcrit/libs/mongoqueue.py
+++ b/mcrit/libs/mongoqueue.py
@@ -15,6 +15,7 @@
 
 import json
 import logging
+import threading
 import time
 import traceback
 from datetime import datetime, timedelta
@@ -74,6 +75,11 @@ class MongoQueue:
         # the jobs it holds can be reclaimed. Both are throttled off the poll loop.
         self.heartbeat_interval: float = max(1.0, self.timeout / 3)
         self._last_heartbeat: float = 0.0
+        # the heartbeat has to keep going while a job runs, and jobs run synchronously in the
+        # poll loop (a job longer than the timeout would otherwise look dead and be reclaimed):
+        # a daemon thread refreshes it from registration to unregistration
+        self._heartbeat_stop: Optional[threading.Event] = None
+        self._heartbeat_thread: Optional[threading.Thread] = None
         self._last_reclaim: float = 0.0
 
     def _getCollection(self):
@@ -217,9 +223,34 @@ class MongoQueue:
                 upsert=True,
             )
             self._last_heartbeat = time.monotonic()
+            self._startHeartbeatThread()
         self.release_orphaned_jobs()
 
+    def _startHeartbeatThread(self):
+        if self._heartbeat_thread is not None and self._heartbeat_thread.is_alive():
+            return
+        self._heartbeat_stop = threading.Event()
+        self._heartbeat_thread = threading.Thread(target=self._heartbeatLoop, name=f"heartbeat-{self.consumer_id}", daemon=True)
+        self._heartbeat_thread.start()
+
+    def _heartbeatLoop(self):
+        stop = self._heartbeat_stop
+        assert stop is not None
+        while not stop.wait(self.heartbeat_interval):
+            try:
+                self.heartbeat(force=True)
+            except Exception:
+                LOGGER.warning("Heartbeat of %s could not be written.", self.consumer_id, exc_info=True)
+
+    def _stopHeartbeatThread(self):
+        if self._heartbeat_stop is not None:
+            self._heartbeat_stop.set()
+        if self._heartbeat_thread is not None:
+            self._heartbeat_thread.join(timeout=self.heartbeat_interval + 1)
+        self._heartbeat_thread = None
+
     def unregisterWorker(self):
+        self._stopHeartbeatThread()
         if self.queue_counters is not None:
             self._getQueueCounters().find_one_and_update(
                 {"name": "workers"},
@@ -233,16 +264,22 @@ class MongoQueue:
             return
         if not force and time.monotonic() - self._last_heartbeat < self.heartbeat_interval:
             return
-        self._getQueueCounters().find_one_and_update({"name": "workers"}, {"$set": {f"heartbeats.{self.consumer_id}": datetime.now()}}, upsert=True)
+        # re-adds the registration as well: a worker judged dead by mistake (paused, a stalled
+        # database connection) lost its current job to a reclaim, but must serve the next ones
+        self._getQueueCounters().find_one_and_update(
+            {"name": "workers"}, {"$addToSet": {"workers": self.consumer_id}, "$set": {f"heartbeats.{self.consumer_id}": datetime.now()}}, upsert=True
+        )
         self._last_heartbeat = time.monotonic()
 
     def _live_worker_ids(self, now=None):
         """The registered workers whose heartbeat is younger than the timeout.
 
-        A registered worker without any heartbeat is one that never wrote one, i.e. a
-        process from before heartbeats existed that was not shut down cleanly - it is
-        treated as dead, the same as a heartbeat older than the timeout. A worker killed
-        with SIGKILL never unregisters, so registration alone is not liveness (#150).
+        A registered worker without any heartbeat is either a process from before heartbeats
+        existed (a rolling upgrade: it may well be busy with a job) or one that died before
+        writing its first one. It is given the benefit of the doubt once: a heartbeat is
+        stamped for it now, so it counts as alive for one timeout and is judged like every
+        other worker after that. A worker killed with SIGKILL never unregisters, so
+        registration alone is not liveness (#150).
         """
         now = now or datetime.now()
         registration = self._getQueueCounters().find_one({"name": "workers"}, {"workers": 1, "heartbeats": 1, "_id": 0})
@@ -252,7 +289,11 @@ class MongoQueue:
         live = set()
         for worker_id in registration.get("workers") or []:
             last_seen = heartbeats.get(worker_id)
-            if last_seen is not None and now - last_seen < timedelta(seconds=self.timeout):
+            if last_seen is None:
+                # only if still absent: two pollers must not keep re-stamping each other's view
+                self._getQueueCounters().update_one({"name": "workers", f"heartbeats.{worker_id}": {"$exists": False}}, {"$set": {f"heartbeats.{worker_id}": now}})
+                live.add(worker_id)
+            elif now - last_seen < timedelta(seconds=self.timeout):
                 live.add(worker_id)
         return live
 

--- a/mcrit/libs/mongoqueue.py
+++ b/mcrit/libs/mongoqueue.py
@@ -14,6 +14,8 @@
 
 
 import json
+import logging
+import time
 import traceback
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
@@ -22,6 +24,8 @@ import gridfs
 import pymongo
 from bson.objectid import ObjectId
 from pymongo import MongoClient, ReturnDocument, UpdateOne
+
+LOGGER = logging.getLogger(__name__)
 
 DEFAULT_INSERT: Dict[str, Any] = {
     "locked_by": None,
@@ -65,6 +69,12 @@ class MongoQueue:
         self.cache_time: float = 10**9
         # overridden by QueueFactory from QUEUE_CLEAN_INTERVAL
         self.clean_interval: float = queue_config.QUEUE_CLEAN_INTERVAL
+        # worker liveness (#150): a worker refreshes its heartbeat while polling, and a
+        # registered worker whose heartbeat is older than the timeout counts as dead, so
+        # the jobs it holds can be reclaimed. Both are throttled off the poll loop.
+        self.heartbeat_interval: float = max(1.0, self.timeout / 3)
+        self._last_heartbeat: float = 0.0
+        self._last_reclaim: float = 0.0
 
     def _getCollection(self):
         # because of gunicorn and forking workers, we want to delay creation of MongoClient until actual usage and avoid it within __init__()
@@ -201,12 +211,57 @@ class MongoQueue:
 
     def registerWorker(self):
         if self.consumer_id != "index":
-            self._getQueueCounters().find_one_and_update({"name": "workers"}, {"$push": {"workers": self.consumer_id}}, upsert=True)
+            self._getQueueCounters().find_one_and_update(
+                {"name": "workers"},
+                {"$addToSet": {"workers": self.consumer_id}, "$set": {f"heartbeats.{self.consumer_id}": datetime.now()}},
+                upsert=True,
+            )
+            self._last_heartbeat = time.monotonic()
         self.release_orphaned_jobs()
 
     def unregisterWorker(self):
         if self.queue_counters is not None:
-            self._getQueueCounters().find_one_and_update({"name": "workers"}, {"$pull": {"workers": self.consumer_id}}, upsert=True)
+            self._getQueueCounters().find_one_and_update(
+                {"name": "workers"},
+                {"$pull": {"workers": self.consumer_id}, "$unset": {f"heartbeats.{self.consumer_id}": ""}},
+                upsert=True,
+            )
+
+    def heartbeat(self, force=False):
+        """Record that this worker is alive. Throttled to heartbeat_interval unless forced."""
+        if self.consumer_id == "index":
+            return
+        if not force and time.monotonic() - self._last_heartbeat < self.heartbeat_interval:
+            return
+        self._getQueueCounters().find_one_and_update({"name": "workers"}, {"$set": {f"heartbeats.{self.consumer_id}": datetime.now()}}, upsert=True)
+        self._last_heartbeat = time.monotonic()
+
+    def _live_worker_ids(self, now=None):
+        """The registered workers whose heartbeat is younger than the timeout.
+
+        A registered worker without any heartbeat is one that never wrote one, i.e. a
+        process from before heartbeats existed that was not shut down cleanly - it is
+        treated as dead, the same as a heartbeat older than the timeout. A worker killed
+        with SIGKILL never unregisters, so registration alone is not liveness (#150).
+        """
+        now = now or datetime.now()
+        registration = self._getQueueCounters().find_one({"name": "workers"}, {"workers": 1, "heartbeats": 1, "_id": 0})
+        if not registration:
+            return set()
+        heartbeats = registration.get("heartbeats") or {}
+        live = set()
+        for worker_id in registration.get("workers") or []:
+            last_seen = heartbeats.get(worker_id)
+            if last_seen is not None and now - last_seen < timedelta(seconds=self.timeout):
+                live.add(worker_id)
+        return live
+
+    def _housekeeping(self):
+        """Called off the poll loop: refresh our heartbeat, reclaim what dead workers hold."""
+        self.heartbeat()
+        if time.monotonic() - self._last_reclaim >= self.timeout:
+            self.release_orphaned_jobs()
+            self._last_reclaim = time.monotonic()
 
     def close(self):
         """Close the in memory queue connection."""
@@ -236,7 +291,7 @@ class MongoQueue:
         `locked_at` is only bumped by Job.progressor(), and a matcher running as a single
         batch never steps its progress reporter, so a long job can look "stale" while it
         is healthily running. Reclaiming it would decrement attempts_left underneath a
-        live worker.
+        live worker. release_orphaned_jobs() tests the worker's liveness instead (#150).
         """
         self._getCollection().find_one_and_update(
             # timedelta()'s first positional argument is DAYS: the timeout, which is
@@ -292,6 +347,8 @@ class MongoQueue:
             )
 
     def next(self):
+        self._getCollection()
+        self._housekeeping()
         current_time = datetime.now()
         job = self._getCollection().find_one_and_update(
             filter={
@@ -488,12 +545,19 @@ class MongoQueue:
         return entry.metadata
 
     def get_cached_job_id(self, payload):
+        # a job is only worth handing out again when it is finished, waiting, or actually
+        # in flight on a live worker - not when a dead worker still holds its lock (#150)
         job = self._wrap_one(
             self._getCollection().find_one(
                 {
                     "attempts_left": {"$gt": 0},
                     "payload.descriptor": payload["descriptor"],
                     "terminated": False,
+                    "$or": [
+                        {"finished_at": {"$ne": None}},
+                        {"locked_by": None},
+                        {"locked_by": {"$in": sorted(self._live_worker_ids())}},
+                    ],
                 },
                 sort=[("created_at", pymongo.DESCENDING)],
             )
@@ -556,26 +620,51 @@ class MongoQueue:
         )
 
     def release_orphaned_jobs(self):
-        # release all jobs associated with non- or no longer existing worker_ids, if they are started, locked, but not finished.
-        all_worker_ids = set([wid for wid in self._getCollection().distinct("locked_by") if wid])
-        active_workers = self._getQueueCounters().find_one({"name": "workers"}, {"workers": 1, "_id": 0})
-        orphan_ids = []
-        if active_workers:
-            active_worker_ids = set(active_workers["workers"])
-            orphan_ids = all_worker_ids.difference(active_worker_ids)
-        else:
-            orphan_ids = all_worker_ids
+        """Return the jobs held by workers that are not alive to the queue.
 
-        orphaned_jobs = []
-        for orphan_id in orphan_ids:
-            for job in self._getCollection().find(filter={"locked_by": orphan_id, "started_at": {"$ne": None}, "finished_at": {"$eq": None}}):
-                orphaned_jobs.append(job)
-
-        for orphan_consumer_id in orphan_ids:
-            self._getCollection().update_many(
-                filter={"locked_by": orphan_consumer_id, "started_at": {"$ne": None}, "finished_at": {"$eq": None}},
-                update={"$set": {"locked_by": None, "locked_at": None}, "$inc": {"attempts_left": -1}},
+        A worker is alive while it is registered with a fresh heartbeat; one that was
+        never registered, unregistered, or stopped heartbeating (killed with SIGKILL,
+        OOM) is not, and its unfinished jobs are released with one attempt fewer, like
+        a worker's own error path does. Dead registrations are dropped along the way, so
+        the worker list stops accumulating ids of processes that are long gone (#150).
+        """
+        now = datetime.now()
+        live_worker_ids = self._live_worker_ids(now)
+        registration = self._getQueueCounters().find_one({"name": "workers"}, {"workers": 1, "_id": 0}) or {}
+        dead_registered = [worker_id for worker_id in registration.get("workers") or [] if worker_id not in live_worker_ids]
+        if dead_registered:
+            self._getQueueCounters().update_one(
+                {"name": "workers"},
+                {"$pull": {"workers": {"$in": dead_registered}}, "$unset": {f"heartbeats.{worker_id}": "" for worker_id in dead_registered}},
             )
+        holders = set(wid for wid in self._getCollection().distinct("locked_by") if wid)
+        orphan_ids = sorted(holders.difference(live_worker_ids))
+        if not orphan_ids:
+            return
+        stranded = {"locked_by": {"$in": orphan_ids}, "started_at": {"$ne": None}, "finished_at": None}
+        counter_updates = []
+        released = 0
+        for job_id in [job["_id"] for job in self._getCollection().find(stranded, {"_id": 1})]:
+            # per job, like Job.error(): the attempt that died counts, and a job out of
+            # attempts fails and releases whatever waits on it instead of being requeued
+            job = self._getCollection().find_one_and_update(
+                {"_id": job_id, **stranded},
+                {"$set": {"locked_by": None, "locked_at": None}, "$inc": {"attempts_left": -1}},
+                return_document=ReturnDocument.AFTER,
+            )
+            if job is None:
+                continue
+            released += 1
+            method = job["payload"]["method"]
+            counter_updates.append((method, "in_progress", -1))
+            if job["attempts_left"] <= 0:
+                self._notify_dependent_jobs(str(job["_id"]))
+                counter_updates.append((method, "failed", 1))
+            else:
+                counter_updates.append((method, "queued", 1))
+        if released:
+            LOGGER.warning("Released %d job(s) held by dead worker(s) %s back to the queue.", released, ", ".join(orphan_ids))
+            self.updateQueueCounters(counter_updates)
 
     def terminate_all_jobs(self):
         pass

--- a/tests/testMongoQueue.py
+++ b/tests/testMongoQueue.py
@@ -199,5 +199,142 @@ class MongoQueueTest(TestCase):
         self.assertEqual(job, None)
 
 
+@pytest.mark.mongo
+class WorkerLivenessTest(TestCase):
+    """Jobs held by a worker that died without unwinding are reclaimed, and never served
+    as a cached result to an identical resubmission (#150)."""
+
+    def setUp(self):
+        self.client = pymongo.MongoClient(os.environ.get("TEST_MONGODB"))
+        self.queue_config = QueueConfig()
+        self.queue_config.QUEUE_SERVER, self.queue_config.QUEUE_PORT = getTestMongoServerAndPort()
+        self.queue_config.QUEUE_MONGODB_DBNAME = "test_queue"
+        self.queue_config.QUEUE_MONGODB_COLLECTION_NAME = "queue_liveness"
+        self.timeout = 5
+        self.worker_a = self._worker("Worker-a")
+        self.worker_b = self._worker("Worker-b")
+        self.server = self._worker("index")
+
+    def tearDown(self):
+        self.client.drop_database("test_queue")
+
+    def _worker(self, consumer_id):
+        return MongoQueue(self.queue_config, consumer_id, timeout=self.timeout)
+
+    def _registration(self):
+        return self.worker_a._getQueueCounters().find_one({"name": "workers"}, {"_id": 0}) or {}
+
+    def _document(self, job_id):
+        document = self.worker_a._getCollection().find_one({"_id": job_id})
+        assert document is not None
+        return document
+
+    def _age_heartbeat(self, consumer_id, seconds):
+        self.worker_a._getQueueCounters().update_one({"name": "workers"}, {"$set": {f"heartbeats.{consumer_id}": datetime.now() - timedelta(seconds=seconds)}})
+
+    def _claimed_by(self, queue, descriptor="d"):
+        queue.put({"method": "test_method", "descriptor": descriptor})
+        job = queue.next()
+        assert job is not None
+        return job
+
+    def test_registering_records_a_heartbeat_and_unregistering_removes_it(self):
+        self.worker_a._getCollection()
+        registration = self._registration()
+        self.assertIn("Worker-a", registration["workers"])
+        self.assertIsInstance(registration["heartbeats"]["Worker-a"], datetime)
+        self.server._getCollection()
+        self.assertNotIn("index", self._registration()["workers"])
+        self.worker_a.unregisterWorker()
+        registration = self._registration()
+        self.assertNotIn("Worker-a", registration["workers"])
+        self.assertNotIn("Worker-a", registration.get("heartbeats", {}))
+
+    def test_a_worker_is_live_only_with_a_fresh_heartbeat(self):
+        self.worker_a._getCollection()
+        self.worker_b._getCollection()
+        self.assertEqual({"Worker-a", "Worker-b"}, self.server._live_worker_ids())
+        self._age_heartbeat("Worker-b", self.timeout + 1)
+        self.assertEqual({"Worker-a"}, self.server._live_worker_ids())
+        # a registration without any heartbeat is a process from before heartbeats existed
+        self.worker_a._getQueueCounters().update_one({"name": "workers"}, {"$unset": {"heartbeats.Worker-a": ""}})
+        self.assertEqual(set(), self.server._live_worker_ids())
+
+    def test_a_dead_workers_job_is_reclaimed_and_a_live_ones_is_kept(self):
+        dead_job = self._claimed_by(self.worker_a, "dead")
+        live_job = self._claimed_by(self.worker_b, "live")
+        self._age_heartbeat("Worker-a", self.timeout + 1)  # Worker-a was SIGKILLed: still registered, no heartbeat
+        self.server.release_orphaned_jobs()
+        reclaimed = self._document(dead_job.job_id)
+        self.assertIsNone(reclaimed["locked_by"])
+        self.assertIsNone(reclaimed["locked_at"])
+        self.assertEqual(self.worker_a.max_attempts - 1, reclaimed["attempts_left"])
+        kept = self._document(live_job.job_id)
+        self.assertEqual("Worker-b", kept["locked_by"])
+        self.assertEqual(self.worker_b.max_attempts, kept["attempts_left"])
+        # the dead registration is gone, the live one stays
+        registration = self._registration()
+        self.assertEqual(["Worker-b"], registration["workers"])
+        self.assertEqual(["Worker-b"], list(registration["heartbeats"]))
+        # and another worker picks the reclaimed job up
+        self.assertEqual(dead_job.job_id, self.worker_b.next().job_id)
+
+    def test_a_job_never_registered_for_is_reclaimed_too(self):
+        job = self._claimed_by(self.worker_a)
+        self.worker_a.unregisterWorker()
+        self.server.release_orphaned_jobs()
+        self.assertIsNone(self._document(job.job_id)["locked_by"])
+
+    def test_reclaiming_the_last_attempt_fails_the_job_and_frees_its_dependents(self):
+        job = self._claimed_by(self.worker_a, "last")
+        self.worker_a._getCollection().update_one({"_id": job.job_id}, {"$set": {"attempts_left": 1}})
+        self.worker_b.put({"method": "test_method", "descriptor": "waiting"}, await_jobs=[str(job.job_id)])
+        self._age_heartbeat("Worker-a", self.timeout + 1)
+        self.server.release_orphaned_jobs()
+        failed = self._document(job.job_id)
+        self.assertEqual(0, failed["attempts_left"])
+        self.assertIsNone(failed["locked_by"])
+        waiting = self.worker_b.next()
+        assert waiting is not None
+        self.assertEqual("waiting", waiting.payload["descriptor"])
+        counters = {c["name"]: c for c in self.worker_a._getQueueCounters().find({"name": "test_method"})}
+        self.assertEqual(1, counters["test_method"]["failed"])
+
+    def test_a_stranded_job_is_not_served_as_a_cached_result(self):
+        job = self._claimed_by(self.worker_a, "shared")
+        payload = {"descriptor": "shared"}
+        # in flight on a live worker: served
+        self.assertEqual(job.job_id, self.server.get_cached_job_id(payload))
+        self._age_heartbeat("Worker-a", self.timeout + 1)
+        # the same job, its worker dead: not served
+        self.assertIsNone(self.server.get_cached_job_id(payload))
+        # once reclaimed it waits in the queue, and a waiting job is served again
+        self.server.release_orphaned_jobs()
+        self.assertEqual(job.job_id, self.server.get_cached_job_id(payload))
+        # a finished job is served whatever its worker's state
+        self.worker_b.next().complete()
+        self.worker_b._getQueueCounters().update_one({"name": "workers"}, {"$set": {"heartbeats.Worker-b": datetime.now() - timedelta(seconds=self.timeout + 1)}})
+        self.assertEqual(job.job_id, self.server.get_cached_job_id(payload))
+
+    def test_polling_refreshes_the_heartbeat_and_reclaims_periodically(self):
+        stranded = self._claimed_by(self.worker_a)
+        self.worker_b._getCollection()  # registering reclaims too, so Worker-a dies only afterwards
+        self._age_heartbeat("Worker-a", self.timeout + 1)
+        before = self._registration()["heartbeats"]["Worker-b"]
+        # polling right after registering is inside the heartbeat interval: no write
+        self.worker_b._last_reclaim = time.monotonic()
+        self.assertIsNone(self.worker_b.next())
+        self.assertEqual(before, self._registration()["heartbeats"]["Worker-b"])
+        self.assertEqual("Worker-a", self._document(stranded.job_id)["locked_by"])
+        # past the interval it heartbeats, and past the timeout it reclaims: the stranded
+        # job is released and claimed in the same poll
+        self.worker_b._last_heartbeat = 0.0
+        self.worker_b._last_reclaim = 0.0
+        claimed = self.worker_b.next()
+        assert claimed is not None
+        self.assertEqual(stranded.job_id, claimed.job_id)
+        self.assertGreater(self._registration()["heartbeats"]["Worker-b"], before)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testMongoQueue.py
+++ b/tests/testMongoQueue.py
@@ -216,6 +216,8 @@ class WorkerLivenessTest(TestCase):
         self.server = self._worker("index")
 
     def tearDown(self):
+        for queue in (self.worker_a, self.worker_b, self.server):
+            queue._stopHeartbeatThread()
         self.client.drop_database("test_queue")
 
     def _worker(self, consumer_id):
@@ -257,8 +259,36 @@ class WorkerLivenessTest(TestCase):
         self._age_heartbeat("Worker-b", self.timeout + 1)
         self.assertEqual({"Worker-a"}, self.server._live_worker_ids())
         # a registration without any heartbeat is a process from before heartbeats existed
+        # (a rolling upgrade): it is stamped now and gets one timeout of grace before it is
+        # judged like everybody else
         self.worker_a._getQueueCounters().update_one({"name": "workers"}, {"$unset": {"heartbeats.Worker-a": ""}})
+        self.worker_a._stopHeartbeatThread()
+        self.assertEqual({"Worker-a"}, self.server._live_worker_ids())
+        self.assertIsInstance(self._registration()["heartbeats"]["Worker-a"], datetime)
+        self.assertEqual({"Worker-a"}, self.server._live_worker_ids(now=datetime.now() + timedelta(seconds=self.timeout - 1)))
+        self.assertEqual(set(), self.server._live_worker_ids(now=datetime.now() + timedelta(seconds=self.timeout + 1)))
+
+    def test_the_heartbeat_keeps_going_while_a_job_runs(self):
+        """jobs run synchronously in the poll loop, so a job longer than the timeout would look
+        like a dead worker without the heartbeat thread"""
+        self.worker_a._getCollection()
+        self.assertTrue(self.worker_a._heartbeat_thread is not None and self.worker_a._heartbeat_thread.is_alive())
+        self._age_heartbeat("Worker-a", self.timeout + 1)
         self.assertEqual(set(), self.server._live_worker_ids())
+        # no poll happens here - the thread alone brings the heartbeat back within one interval
+        time.sleep(self.worker_a.heartbeat_interval + 1)
+        self.assertEqual({"Worker-a"}, self.server._live_worker_ids())
+        # a worker judged dead by mistake was unregistered by the reclaim; its next heartbeat
+        # registers it again, so it keeps serving jobs
+        self.server.release_orphaned_jobs()
+        self._age_heartbeat("Worker-a", self.timeout + 1)
+        self.server.release_orphaned_jobs()
+        self.assertNotIn("Worker-a", self._registration().get("workers", []))
+        time.sleep(self.worker_a.heartbeat_interval + 1)
+        self.assertIn("Worker-a", self._registration()["workers"])
+        self.assertEqual({"Worker-a"}, self.server._live_worker_ids())
+        self.worker_a.unregisterWorker()
+        self.assertIsNone(self.worker_a._heartbeat_thread)
 
     def test_a_dead_workers_job_is_reclaimed_and_a_live_ones_is_kept(self):
         dead_job = self._claimed_by(self.worker_a, "dead")


### PR DESCRIPTION
Closes #150 (a hard-killed worker strands its job forever, and the stranded job is then served to identical resubmissions).

## Cause

A worker killed with SIGKILL (the OOM killer's way) never runs its context manager's exit, so its registration and the lock on the job it was running stay behind. `next()` only hands out unlocked jobs, and `release_orphaned_jobs()` only released jobs of *unregistered* workers, which a killed worker is not. So the job stayed locked for good, and `get_cached_job_id()` handed its id to every identical resubmission, which then waited on work that could never run.

## Fix

Registration alone is not liveness, so workers now carry a heartbeat:

- `registerWorker()` records a heartbeat next to the registration; `next()` refreshes it off the poll loop, throttled to a third of the queue timeout (one write per 100 s at the default 300 s).
- A registered worker whose heartbeat is older than the timeout is dead. `release_orphaned_jobs()` releases the unfinished jobs of every worker that is not live, with one attempt fewer; a job out of attempts fails and notifies its dependents, like `Job.error()` does; the queue counters follow. Dead registrations are dropped, so the worker list stops accumulating ids of long-gone processes. It runs when a worker starts, as before, and from the poll loop once per timeout.
- `get_cached_job_id()` only serves a job that is finished, waiting, or in flight on a live worker.
- A registration without any heartbeat is a pre-heartbeat process that was not shut down cleanly and is treated as dead. `locked_at` is still not used for liveness, for the reason `repair()` documents (a healthy long job would look stale).

Known limit, unchanged from before: if the *parent* of a spawning worker is killed while its child still runs the job, the child may still complete it after the reclaim, so the job can run twice. The timeout bounds when that window opens.

## Verification

- `tests/testMongoQueue.py` `WorkerLivenessTest` (7 tests): registration writes and removal of the heartbeat; liveness by heartbeat age, including the no-heartbeat case; a dead worker's job is reclaimed with one attempt fewer while a live worker's is kept and the dead registration pruned; a job never registered for; reclaiming the last attempt fails the job and frees its dependent, with the failed counter incremented; the cached-job lookup skips the stranded job, serves it again once reclaimed, and serves a finished one regardless; polling heartbeats only past the interval and reclaims past the timeout.
- Queue, worker-resilience and remote-call suites: 55 passed; `ruff check`, `ruff format --check`, `ty check` clean.
- Live, on the MongoDB-backed instance: five forced jobs queued, the worker `kill -9`'d while running one. The job was left with `locked_by` set, `finished_at: None`, `attempts_left: 3` and the registration still present, exactly as the issue describes. A replacement worker started, processed the other queued jobs, and at 295 s (the dead heartbeat's age passing the 300 s timeout) released the stranded job, ran it and finished it with a result; the dead registration was gone from the worker list.

Note: this touches `get_cached_job_id` next to #160; the two merge cleanly (kept both conditions) and that combination is what the live instance ran for this verification.

