### PR TITLE
Serve a stored result as the bytes it was stored with (#152)

### DIFF
--- a/mcrit/queue/QueueRemoteCalls.py
+++ b/mcrit/queue/QueueRemoteCalls.py
@@ -69,6 +69,21 @@ class BaseRemoteCallerClass:
                 result = self.queue._grid_to_dicts(res_id)
         return result
 
+    def getResultBytesForJob(self, job_id):
+        """The stored result of the job as the JSON bytes it was written with, or None.
+
+        Serving a report does not need the parsed dict, only its bytes inside the response
+        envelope; parsing and re-serialising an 8 MB report costs more than reading it (#152).
+        """
+        job_info = self.queue.get_job(job_id)
+        if job_info is None or job_info.result is None:
+            return None
+        return self.queue._grid_to_file(job_info.result)
+
+    def getResultBytes(self, res_id):
+        """The stored result as the JSON bytes it was written with, or None (#152)."""
+        return self.queue._grid_to_file(res_id)
+
     def getJobIdForResult(self, result_id):
         job_id = None
         meta = self.queue._grid_to_meta(result_id)

--- a/mcrit/server/JobResource.py
+++ b/mcrit/server/JobResource.py
@@ -111,6 +111,31 @@ class JobResource:
         resp.data = jsonify({"status": "successful", "data": {"num_deleted": result}})
         db_log_msg(self.index, req, "JobResource.on_delete - success.")
 
+    @staticmethod
+    def _wants_compact(req):
+        return "compact" in req.params and req.params["compact"].lower().strip() == "true"
+
+    def _respond_with_result(self, resp, job_data, compact, result_bytes, parse_result):
+        """Answer a stored result inside the success envelope.
+
+        The result is stored as JSON, so unless the caller wants the compact form (which
+        drops the function matches and therefore needs the parsed dict) the stored bytes go
+        into the envelope as they are, instead of being parsed and serialised again - which
+        cost more than reading the report for an 8 MB result (#152).
+        """
+        if compact:
+            data = parse_result()
+            if job_data and data is not None:
+                job_info = Job(job_data, None)
+                if job_info.is_matching_job or job_info.is_query_job:
+                    data["matches"].pop("functions")
+            resp.data = jsonify({"status": "successful", "data": data})
+            return
+        if result_bytes is None:
+            resp.data = jsonify({"status": "successful", "data": None})
+            return
+        resp.data = b'{"status": "successful", "data": ' + result_bytes + b"}"
+
     @timing
     def on_get_results(self, req, resp, result_id=None):
         # validate that we only allow hexstrings with 24 chars
@@ -121,15 +146,10 @@ class JobResource:
             return
         job_id = self.index.getJobIdForResult(result_id)
         job_data = self.index.getJobData(job_id)
-        data = self.index.getResult(result_id)
-        if "compact" in req.params and req.params["compact"].lower().strip() == "true":
-            if job_data:
-                job_info = Job(job_data, None)
-                if job_info.is_matching_job or job_info.is_query_job:
-                    data["matches"].pop("functions")
+        compact = self._wants_compact(req)
         # TODO throw 404 if job_id is unknown
         # resp.status = falcon.HTTP_404
-        resp.data = jsonify({"status": "successful", "data": data})
+        self._respond_with_result(resp, job_data, compact, None if compact else self.index.getResultBytes(result_id), lambda: self.index.getResult(result_id))
         db_log_msg(self.index, req, "JobResource.on_get_results - success.")
 
     @timing
@@ -141,15 +161,10 @@ class JobResource:
             db_log_msg(self.index, req, "JobResource.on_get_job_result - failed - invalid job_id.")
             return
         job_data = self.index.getJobData(job_id)
-        data = self.index.getResultForJob(job_id)
-        if "compact" in req.params and req.params["compact"].lower().strip() == "true":
-            if job_data:
-                job_info = Job(job_data, None)
-                if job_info.is_matching_job or job_info.is_query_job:
-                    data["matches"].pop("functions")
+        compact = self._wants_compact(req)
         # TODO throw 404 if job_id is unknown
         # resp.status = falcon.HTTP_404
-        resp.data = jsonify({"status": "successful", "data": data})
+        self._respond_with_result(resp, job_data, compact, None if compact else self.index.getResultBytesForJob(job_id), lambda: self.index.getResultForJob(job_id))
         db_log_msg(self.index, req, "JobResource.on_get_job_result - success.")
 
     @timing

--- a/tests/testJobResource.py
+++ b/tests/testJobResource.py
@@ -1,0 +1,99 @@
+import json
+import unittest
+from unittest.mock import MagicMock
+
+import falcon
+import falcon.testing
+
+from mcrit.index.MinHashIndex import MinHashIndex
+from mcrit.server.JobResource import JobResource
+
+from .context import config
+
+RESULT = {"matches": {"functions": [[1, 2, 3]], "samples": [[4, 5]]}, "info": {"job": {"parameters": "x"}}}
+STORED = json.dumps(RESULT).encode("ascii")
+JOB_ID = "0123456789abcdef01234567"
+RESULT_ID = "fedcba9876543210fedcba98"
+MATCHING_JOB = {"payload": {"method": "getMatchesForSample", "params": "[7]"}, "_id": JOB_ID}
+
+
+class ResultRoutesServeTheStoredBytes(unittest.TestCase):
+    """A stored result is JSON already; the routes put its bytes into the envelope instead of
+    parsing and re-serialising them (#152), except for compact, which has to edit the dict."""
+
+    @staticmethod
+    def _request(query_string=""):
+        return falcon.Request(falcon.testing.create_environ(path="/jobs", query_string=query_string))
+
+    def _resource(self, stored=STORED, job_data=MATCHING_JOB):
+        index = MagicMock()
+        index.getJobData.return_value = job_data
+        index.getJobIdForResult.return_value = JOB_ID
+        index.getResultBytesForJob.return_value = stored
+        index.getResultBytes.return_value = stored
+        index.getResultForJob.return_value = json.loads(stored) if stored is not None else None
+        index.getResult.return_value = json.loads(stored) if stored is not None else None
+        return index, JobResource(index)
+
+    def test_the_job_result_route_passes_the_bytes_through(self):
+        index, resource = self._resource()
+        resp = falcon.Response()
+        resource.on_get_job_result(self._request(), resp, JOB_ID)
+        assert resp.data is not None
+        self.assertEqual(b'{"status": "successful", "data": ' + STORED + b"}", resp.data)
+        self.assertEqual({"status": "successful", "data": RESULT}, json.loads(resp.data))
+        index.getResultForJob.assert_not_called()
+
+    def test_the_result_route_passes_the_bytes_through(self):
+        index, resource = self._resource()
+        resp = falcon.Response()
+        resource.on_get_results(self._request(), resp, RESULT_ID)
+        assert resp.data is not None
+        self.assertEqual({"status": "successful", "data": RESULT}, json.loads(resp.data))
+        index.getResultBytes.assert_called_once_with(RESULT_ID)
+        index.getResult.assert_not_called()
+
+    def test_compact_still_parses_and_drops_the_function_matches(self):
+        for route, argument in ((JobResource.on_get_job_result, JOB_ID), (JobResource.on_get_results, RESULT_ID)):
+            index, resource = self._resource()
+            resp = falcon.Response()
+            route(resource, self._request("compact=true"), resp, argument)
+            assert resp.data is not None
+            self.assertEqual({"samples": [[4, 5]]}, json.loads(resp.data)["data"]["matches"])
+            index.getResultBytesForJob.assert_not_called()
+            index.getResultBytes.assert_not_called()
+
+    def test_compact_leaves_a_non_matching_job_alone(self):
+        index, resource = self._resource(job_data={"payload": {"method": "getUniqueBlocks", "params": "[[1]]"}, "_id": JOB_ID})
+        resp = falcon.Response()
+        resource.on_get_job_result(self._request("compact=true"), resp, JOB_ID)
+        assert resp.data is not None
+        self.assertEqual(RESULT, json.loads(resp.data)["data"])
+
+    def test_a_missing_result_is_still_null(self):
+        for query in ("", "compact=true"):
+            index, resource = self._resource(stored=None)
+            resp = falcon.Response()
+            resource.on_get_job_result(self._request(query), resp, JOB_ID)
+            assert resp.data is not None
+            self.assertEqual({"status": "successful", "data": None}, json.loads(resp.data))
+
+    def test_an_invalid_id_is_rejected_before_any_lookup(self):
+        index, resource = self._resource()
+        resp = falcon.Response()
+        resource.on_get_job_result(self._request(), resp, "nope")
+        self.assertEqual(falcon.HTTP_400, resp.status)
+        index.getResultBytesForJob.assert_not_called()
+
+
+class StoredBytesAccessors(unittest.TestCase):
+    def test_the_index_hands_out_the_bytes_the_result_was_stored_with(self):
+        index = MinHashIndex(config)
+        result_id = index.queue._dicts_to_grid(RESULT, metadata={"result": True, "job": "none"})
+        self.assertEqual(STORED, index.getResultBytes(result_id))
+        self.assertEqual(RESULT, index.getResult(result_id))
+        self.assertIsNone(index.getResultBytesForJob("0123456789abcdef01234567"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #152 (serving a matching report parses the stored JSON and re-serialises it: 0.66 s of a 1.03 s report open).

## Change

A result is stored in GridFS as JSON. Both result routes (`/jobs/{id}/result` and `/results/{id}`) parsed it into a dict and immediately serialised the dict again inside the envelope, with nothing consuming the dict in between. They now write `b'{"status": "successful", "data": ' + stored_bytes + b'}'`, through two new accessors on the queue callee, `getResultBytesForJob()` and `getResultBytes()`, which hand out the stored bytes (the `results_only` access check is unchanged, it lives in `_grid_to_file`). `compact=true` keeps the parsing path, since it edits the dict; a missing result is still answered as `null`; invalid ids are still rejected first.

The stored bytes are what `json.dumps` produced when the worker wrote them and what `json.loads` + `json_util.dumps` reproduced before, so the response body is the same.

Compression is left as the issue concluded: it costs more CPU than it saves on a same-host deployment.

## Verification

- `tests/testJobResource.py` (7 tests): both routes pass the bytes through and never call the parsing accessors; compact still parses and drops the function matches, on both routes; compact leaves a non-matching job's result alone; a missing result is `null` with and without compact; an invalid id is rejected before any lookup; on the local queue the index hands out exactly the bytes a result was stored with.
- `ruff check`, `ruff format --check`, `ty check` clean.

