### PR TITLE
Keep the family counters consistent with the collections (#151)

### DIFF
--- a/mcrit/Worker.py
+++ b/mcrit/Worker.py
@@ -258,6 +258,10 @@ class Worker(QueueRemoteCallee):
     def rebuildIndex(self, progress_reporter=NoProgressReporter()):
         return self._storage.rebuildMinhashBandIndex(progress_reporter=progress_reporter)
 
+    @Remote()
+    def recomputeFamilyStats(self):
+        return self._storage.recomputeFamilyStats()
+
     # Reports PROGRESS
     @Remote(progress=True)
     def recalculatePicHashes(self, progress_reporter=NoProgressReporter()):

--- a/mcrit/client/McritClient.py
+++ b/mcrit/client/McritClient.py
@@ -105,6 +105,15 @@ class McritClient:
             return response
         return handle_response(response)
 
+    def recomputeFamilyStats(self):
+        """
+        Schedule a job that sets every family's sample/function counters from the collections (#151); answers the job id
+        """
+        response = requests.post(f"{self.mcrit_server}/recompute_family_stats", headers=self.headers)
+        if self.raw:
+            return response
+        return handle_response(response)
+
     def recalculatePicHashes(self):
         response = requests.get(f"{self.mcrit_server}/recalculate_pichashes", headers=self.headers)
         if self.raw:

--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -339,6 +339,7 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
     """
     def updateMinHashes(self, function_ids):
     def rebuildIndex(self):
+    def recomputeFamilyStats(self):
     def recalculatePicHashes(self):
     def recalculateMinHashes(self):
     def getMatchesForReport(self, report):

--- a/mcrit/server/StatusResource.py
+++ b/mcrit/server/StatusResource.py
@@ -95,6 +95,13 @@ class StatusResource:
         return
 
     @timing
+    def on_post_recompute_family_stats(self, req, resp):
+        job_id = self.index.recomputeFamilyStats(force_recalculation=True)
+        resp.data = jsonify({"status": "successful", "data": job_id})
+        db_log_msg(self.index, req, "StatusResource.on_post_recompute_family_stats - success.")
+        return
+
+    @timing
     def on_get_recalculate_pichashes(self, req, resp):
         index_report = self.index.recalculatePicHashes(force_recalculation=True)
         resp.data = jsonify({"status": "successful", "data": index_report})

--- a/mcrit/server/StatusResource.py
+++ b/mcrit/server/StatusResource.py
@@ -96,6 +96,7 @@ class StatusResource:
 
     @timing
     def on_post_recompute_family_stats(self, req, resp):
+        """Schedule a job that sets every family's sample, function and library counters from the collections, recreating missing family documents. Answers the job id."""
         job_id = self.index.recomputeFamilyStats(force_recalculation=True)
         resp.data = jsonify({"status": "successful", "data": job_id})
         db_log_msg(self.index, req, "StatusResource.on_post_recompute_family_stats - success.")

--- a/mcrit/server/application_routes.py
+++ b/mcrit/server/application_routes.py
@@ -103,6 +103,8 @@ def get_app():
     _app.add_route("/complete_minhashes", status_resource, suffix="complete_minhashes")  # get
     # schedule a job that drops all minhash bands and rebuilds the index using all existing minhashes
     _app.add_route("/rebuild_index", status_resource, suffix="rebuild_index")  # get
+    # schedule a job that sets every family's sample/function counters from the collections (#151)
+    _app.add_route("/recompute_family_stats", status_resource, suffix="recompute_family_stats")  # post
     # schedule a job that updates all function_entries where the pichash was possibly calculated with an outdated SMDA version
     _app.add_route("/recalculate_pichashes", status_resource, suffix="recalculate_pichashes")  # get
     # schedule a job that updates all function_entries where the minhash was possibly calculated with an outdated SMDA version

--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -224,9 +224,13 @@ class MemoryStorage(StorageInterface):
 
         sample_entry = self.getSampleById(sample_id)
         assert sample_entry is not None
-        self._updateFamilyStats(sample_entry.family_id, -1, -sample_entry.statistics["num_functions"], -int(sample_entry.is_library))
+        # by what was actually removed, and an emptied family goes with its last sample, like
+        # the MongoDB backend does (#151)
+        self._updateFamilyStats(sample_entry.family_id, -1, -len(function_ids), -int(sample_entry.is_library))
         # remove sample
         del self._samples[sample_id]
+        if sample_entry.family_id != 0 and not any(s.family_id == sample_entry.family_id for s in self._samples.values()):
+            self._families.pop(sample_entry.family_id, None)
         return True
 
     def modifySample(self, sample_id: int, update_information: dict) -> bool:
@@ -308,6 +312,27 @@ class MemoryStorage(StorageInterface):
                     self._pichashes[function_entry.pichash].add((new_family_id, sample_id, function_id))
         self._updateDbState()
         return True
+
+    def recomputeFamilyStats(self, progress_reporter=None) -> Dict[str, Any]:
+        report: Dict[str, Any] = {"num_families": 0, "num_families_corrected": 0, "num_families_created": 0, "corrections": {}}
+        for sample_entry in self._samples.values():
+            if sample_entry.family_id not in self._families:
+                self._families[sample_entry.family_id] = FamilyEntry(family_name=sample_entry.family, family_id=sample_entry.family_id)
+                report["num_families_created"] += 1
+        functions_by_family: Dict[int, int] = {}
+        for function_entry in self._functions.values():
+            functions_by_family[function_entry.family_id] = functions_by_family.get(function_entry.family_id, 0) + 1
+        for family_id, family_entry in self._families.items():
+            samples = [sample_entry for sample_entry in self._samples.values() if sample_entry.family_id == family_id]
+            actual = {"num_samples": len(samples), "num_functions": functions_by_family.get(family_id, 0), "num_library_samples": len([s for s in samples if s.is_library])}
+            stored = {key: getattr(family_entry, key) for key in actual}
+            report["num_families"] += 1
+            if stored != actual:
+                for key, value in actual.items():
+                    setattr(family_entry, key, value)
+                report["num_families_corrected"] += 1
+                report["corrections"][family_id] = {"before": stored, "after": actual}
+        return report
 
     def deleteFamily(self, family_id: int, keep_samples: bool = False) -> bool:
         if family_id not in self._families:

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -608,23 +608,36 @@ class MongoDbStorage(StorageInterface):
                 minhashes_to_remove[band_number][band_hash].append(function_minhash["function_id"])
         self._updateBands(minhashes_to_remove, method="pull")
 
-        # update family stats
-        self._updateFamilyStats(sample_entry.family_id, -1, -sample_entry.statistics["num_functions"], -int(sample_entry.is_library))
         # remove functions
         self._deleteXcfgForFunctionIds([function_minhash["function_id"] for function_minhash in function_minhashes])
-        self._getDb().functions.delete_many({"sample_id": sample_id})
+        num_functions_deleted = self._getDb().functions.delete_many({"sample_id": sample_id}).deleted_count
         # remove sample
-        self._getDb().samples.delete_one({"sample_id": sample_id})
-        # delete family if empty
-        family_info = self.getFamily(sample_entry.family_id)
-        assert family_info is not None
-        if family_info.num_samples == 0 and family_info.family_id != 0:
-            self._getDb().families.delete_one({"family_id": family_info.family_id})
+        num_samples_deleted = self._getDb().samples.delete_one({"sample_id": sample_id}).deleted_count
+        # update family stats by what was actually removed, not by what the sample claimed (#151)
+        self._updateFamilyStats(sample_entry.family_id, -num_samples_deleted, -num_functions_deleted, -int(sample_entry.is_library and num_samples_deleted))
+        self._deleteFamilyIfEmpty(sample_entry.family_id)
         self._updateDbState()
         return True
 
-    def _updateFamilyStats(self, family_id, num_samples_inc, num_functions_inc, num_library_samples_inc):
+    def _deleteFamilyIfEmpty(self, family_id: int) -> None:
+        # judged by the samples that exist, not by a counter that may have drifted (#151)
+        if family_id != 0 and self._getDb().samples.count_documents({"family_id": family_id}, limit=1) == 0:
+            self._getDb().families.delete_one({"family_id": family_id})
+
+    def _ensureFamilyDocument(self, family_id: int, family_name: str) -> None:
+        """Create the family document for an id that samples reference but no document describes.
+
+        Imports carry family ids from the exporting instance; a sample whose family document is
+        missing would otherwise have its statistics increments silently discarded (#151).
+        """
         self._getDb().families.update_one(
+            {"family_id": family_id},
+            {"$setOnInsert": FamilyEntry(family_name=family_name, family_id=family_id).toDict()},
+            upsert=True,
+        )
+
+    def _updateFamilyStats(self, family_id, num_samples_inc, num_functions_inc, num_library_samples_inc):
+        result = self._getDb().families.update_one(
             {"family_id": family_id},
             {
                 "$inc": {
@@ -634,55 +647,36 @@ class MongoDbStorage(StorageInterface):
                 },
             },
         )
+        if result.matched_count == 0:
+            # an increment against a missing family is lost; say so instead of drifting quietly (#151)
+            LOGGER.warning("Family %d has no document, its statistics update (%+d samples, %+d functions) was not applied.", family_id, num_samples_inc, num_functions_inc)
 
     def modifySample(self, sample_id: int, update_information: dict) -> bool:
         if not self.isSampleId(sample_id):
             return False
         sample_entry = self.getSampleById(sample_id)
         assert sample_entry is not None
+        # statistics move by atomic increments: two concurrent relabels of samples in the same
+        # family used to compute from the same pre-read document and lose one update (#151)
+        is_library = sample_entry.is_library
         if "is_library" in update_information:
-            is_library_info_changed = sample_entry.is_library != update_information["is_library"]
-            self._getDb().samples.update_one({"sample_id": sample_id}, {"$set": {"is_library": update_information["is_library"]}})
-            family_entry = self.getFamily(sample_entry.family_id)
-            assert family_entry is not None
-            if is_library_info_changed:
-                new_value = family_entry.num_library_samples + (1 if update_information["is_library"] else -1)
-                self._getDb().families.update_one({"family_id": sample_entry.family_id}, {"$set": {"num_library_samples": new_value}})
+            new_is_library = bool(update_information["is_library"])
+            self._getDb().samples.update_one({"sample_id": sample_id}, {"$set": {"is_library": new_is_library}})
+            if new_is_library != is_library:
+                self._updateFamilyStats(sample_entry.family_id, 0, 0, 1 if new_is_library else -1)
+            is_library = new_is_library
         if "family_name" in update_information:
-            old_family_entry = self.getFamily(sample_entry.family_id)
-            new_family_entry = self.getFamily(self.addFamily(update_information["family_name"]))
-            assert old_family_entry is not None and new_family_entry is not None
+            old_family_id = sample_entry.family_id
             family_name = update_information["family_name"]
-            family_id = new_family_entry.family_id
-            # update sample_entry and function_entries with new family information
-            self._getDb().samples.update_one({"sample_id": sample_id}, {"$set": {"family_id": family_id, "family": family_name}})
-            self._getDb().functions.update_many({"sample_id": sample_id}, {"$set": {"family_id": family_id}})
-            # update family entry with statistics
-            self._getDb().families.update_one(
-                {"family_id": old_family_entry.family_id},
-                {
-                    "$set": {
-                        "num_samples": old_family_entry.num_samples - 1,
-                        "num_functions": old_family_entry.num_functions - sample_entry.statistics["num_functions"],
-                        "num_library_samples": old_family_entry.num_library_samples - (1 if sample_entry.is_library else 0),
-                    }
-                },
-            )
-            self._getDb().families.update_one(
-                {"family_id": family_id},
-                {
-                    "$set": {
-                        "num_samples": new_family_entry.num_samples + 1,
-                        "num_functions": new_family_entry.num_functions + sample_entry.statistics["num_functions"],
-                        "num_library_samples": new_family_entry.num_library_samples + (1 if sample_entry.is_library else 0),
-                    }
-                },
-            )
-            old_family_entry = self.getFamily(sample_entry.family_id)
-            assert old_family_entry is not None
-            # delete family if empty
-            if old_family_entry.num_samples == 0 and old_family_entry.family_id != 0:
-                self._getDb().families.delete_one({"family_id": old_family_entry.family_id})
+            family_id = self.addFamily(family_name)
+            if family_id != old_family_id:
+                # update sample_entry and function_entries with new family information; the
+                # functions matched are the functions moved, whatever the sample's statistics say
+                self._getDb().samples.update_one({"sample_id": sample_id}, {"$set": {"family_id": family_id, "family": family_name}})
+                num_functions_moved = self._getDb().functions.update_many({"sample_id": sample_id}, {"$set": {"family_id": family_id}}).matched_count
+                self._updateFamilyStats(old_family_id, -1, -num_functions_moved, -int(is_library))
+                self._updateFamilyStats(family_id, +1, num_functions_moved, int(is_library))
+                self._deleteFamilyIfEmpty(old_family_id)
             self._updateDbState()
         if "version" in update_information:
             self._getDb().samples.update_one({"sample_id": sample_id}, {"$set": {"version": update_information["version"]}})
@@ -722,6 +716,44 @@ class MongoDbStorage(StorageInterface):
             self._getDb().functions.update_many({"family_id": family_id}, {"$set": {"family_id": new_family_id}})
             self._updateDbState()
         return True
+
+    def recomputeFamilyStats(self, progress_reporter=None) -> Dict[str, Any]:
+        """Set every family's counters from the samples and functions that exist (#151).
+
+        The per-family counters are denormalised and incremented on every write path; a lost
+        update anywhere leaves them drifted, and /status sums them as the corpus size. This
+        recomputes them with one aggregation over samples and one over functions, creates a
+        document for any family id that samples reference without one, and reports what changed.
+        """
+        db = self._getDb()
+        samples_by_family: Dict[int, Dict[str, Any]] = {}
+        for row in db.samples.aggregate(
+            [{"$group": {"_id": "$family_id", "num_samples": {"$sum": 1}, "num_library_samples": {"$sum": {"$cond": ["$is_library", 1, 0]}}, "family": {"$first": "$family"}}}]
+        ):
+            samples_by_family[row["_id"]] = row
+        functions_by_family: Dict[int, int] = {}
+        for row in db.functions.aggregate([{"$group": {"_id": "$family_id", "num_functions": {"$sum": 1}}}]):
+            functions_by_family[row["_id"]] = row["num_functions"]
+        report: Dict[str, Any] = {"num_families": 0, "num_families_corrected": 0, "num_families_created": 0, "corrections": {}}
+        known_family_ids = {document["family_id"] for document in db.families.find({}, {"family_id": 1, "_id": 0})}
+        for family_id, row in samples_by_family.items():
+            if family_id not in known_family_ids:
+                self._ensureFamilyDocument(family_id, str(row.get("family") or ""))
+                report["num_families_created"] += 1
+        for family_document in db.families.find({}, {"_id": 0, "family_id": 1, "num_samples": 1, "num_functions": 1, "num_library_samples": 1}):
+            family_id = family_document["family_id"]
+            actual = {
+                "num_samples": samples_by_family.get(family_id, {}).get("num_samples", 0),
+                "num_functions": functions_by_family.get(family_id, 0),
+                "num_library_samples": samples_by_family.get(family_id, {}).get("num_library_samples", 0),
+            }
+            report["num_families"] += 1
+            stored = {key: family_document.get(key) for key in actual}
+            if stored != actual:
+                db.families.update_one({"family_id": family_id}, {"$set": actual})
+                report["num_families_corrected"] += 1
+                report["corrections"][family_id] = {"before": stored, "after": actual}
+        return report
 
     def deleteFamily(self, family_id: int, keep_samples: bool = False) -> bool:
         family_entry = self.getFamily(family_id)
@@ -846,6 +878,7 @@ class MongoDbStorage(StorageInterface):
             sample_id = self._useCounter("samples")
             sample_entry.sample_id = sample_id
             self._dbInsert("samples", sample_entry.toDict())
+            self._ensureFamilyDocument(sample_entry.family_id, sample_entry.family)
             self._updateFamilyStats(sample_entry.family_id, +1, sample_entry.statistics["num_functions"], int(sample_entry.is_library))
             self._updateDbState()
         else:

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -635,6 +635,8 @@ class MongoDbStorage(StorageInterface):
             {"$setOnInsert": FamilyEntry(family_name=family_name, family_id=family_id).toDict()},
             upsert=True,
         )
+        # the id came from elsewhere (an import): the counter must never hand it out again
+        self._getDb().counters.update_one({"name": "families"}, {"$max": {"value": family_id + 1}}, upsert=True)
 
     def _updateFamilyStats(self, family_id, num_samples_inc, num_functions_inc, num_library_samples_inc):
         result = self._getDb().families.update_one(
@@ -661,8 +663,10 @@ class MongoDbStorage(StorageInterface):
         is_library = sample_entry.is_library
         if "is_library" in update_information:
             new_is_library = bool(update_information["is_library"])
-            self._getDb().samples.update_one({"sample_id": sample_id}, {"$set": {"is_library": new_is_library}})
-            if new_is_library != is_library:
+            # the counter follows the transition this write performs, not the value read
+            # before it: two concurrent identical requests would otherwise both count
+            transition = self._getDb().samples.update_one({"sample_id": sample_id, "is_library": {"$ne": new_is_library}}, {"$set": {"is_library": new_is_library}})
+            if transition.modified_count:
                 self._updateFamilyStats(sample_entry.family_id, 0, 0, 1 if new_is_library else -1)
             is_library = new_is_library
         if "family_name" in update_information:
@@ -670,13 +674,17 @@ class MongoDbStorage(StorageInterface):
             family_name = update_information["family_name"]
             family_id = self.addFamily(family_name)
             if family_id != old_family_id:
-                # update sample_entry and function_entries with new family information; the
-                # functions matched are the functions moved, whatever the sample's statistics say
-                self._getDb().samples.update_one({"sample_id": sample_id}, {"$set": {"family_id": family_id, "family": family_name}})
-                num_functions_moved = self._getDb().functions.update_many({"sample_id": sample_id}, {"$set": {"family_id": family_id}}).matched_count
-                self._updateFamilyStats(old_family_id, -1, -num_functions_moved, -int(is_library))
-                self._updateFamilyStats(family_id, +1, num_functions_moved, int(is_library))
-                self._deleteFamilyIfEmpty(old_family_id)
+                # gated on the family the sample was read in: of two concurrent moves only the
+                # one that performs the transition adjusts the counters. The functions moved
+                # are the ones still carrying the old family, whatever the sample's statistics say
+                moved = self._getDb().samples.update_one({"sample_id": sample_id, "family_id": old_family_id}, {"$set": {"family_id": family_id, "family": family_name}})
+                if moved.modified_count:
+                    num_functions_moved = (
+                        self._getDb().functions.update_many({"sample_id": sample_id, "family_id": old_family_id}, {"$set": {"family_id": family_id}}).modified_count
+                    )
+                    self._updateFamilyStats(old_family_id, -1, -num_functions_moved, -int(is_library))
+                    self._updateFamilyStats(family_id, +1, num_functions_moved, int(is_library))
+                    self._deleteFamilyIfEmpty(old_family_id)
             self._updateDbState()
         if "version" in update_information:
             self._getDb().samples.update_one({"sample_id": sample_id}, {"$set": {"version": update_information["version"]}})
@@ -740,19 +748,64 @@ class MongoDbStorage(StorageInterface):
             if family_id not in known_family_ids:
                 self._ensureFamilyDocument(family_id, str(row.get("family") or ""))
                 report["num_families_created"] += 1
-        for family_document in db.families.find({}, {"_id": 0, "family_id": 1, "num_samples": 1, "num_functions": 1, "num_library_samples": 1}):
-            family_id = family_document["family_id"]
-            actual = {
-                "num_samples": samples_by_family.get(family_id, {}).get("num_samples", 0),
-                "num_functions": functions_by_family.get(family_id, 0),
-                "num_library_samples": samples_by_family.get(family_id, {}).get("num_library_samples", 0),
-            }
-            report["num_families"] += 1
-            stored = {key: family_document.get(key) for key in actual}
-            if stored != actual:
-                db.families.update_one({"family_id": family_id}, {"$set": actual})
-                report["num_families_corrected"] += 1
-                report["corrections"][family_id] = {"before": stored, "after": actual}
+        # a counter is only replaced while it still holds what was read next to the aggregate:
+        # a concurrent ingest, move or deletion that incremented it in between fails the filter,
+        # and the family is aggregated again. Increments landing after the write are consistent
+        # with it (their sample is not in the aggregate either way), so two passes converge.
+        pending = {document["family_id"] for document in db.families.find({}, {"_id": 0, "family_id": 1})}
+        for _ in range(3):
+            if not pending:
+                break
+            retry = set()
+            for family_document in db.families.find(
+                {"family_id": {"$in": sorted(pending)}}, {"_id": 0, "family_id": 1, "num_samples": 1, "num_functions": 1, "num_library_samples": 1}
+            ):
+                family_id = family_document["family_id"]
+                actual = {
+                    "num_samples": samples_by_family.get(family_id, {}).get("num_samples", 0),
+                    "num_functions": functions_by_family.get(family_id, 0),
+                    "num_library_samples": samples_by_family.get(family_id, {}).get("num_library_samples", 0),
+                }
+                if family_id not in report["corrections"]:
+                    report["num_families"] += 1
+                stored = {key: family_document.get(key) for key in actual}
+                if stored == actual:
+                    continue
+                written = db.families.update_one({"family_id": family_id, **stored}, {"$set": actual})
+                if written.modified_count:
+                    if family_id not in report["corrections"]:
+                        report["num_families_corrected"] += 1
+                    report["corrections"][family_id] = {"before": stored, "after": actual}
+                else:
+                    retry.add(family_id)
+            if not retry:
+                break
+            # re-aggregate only the families a concurrent write touched
+            samples_by_family.update(
+                {
+                    row["_id"]: row
+                    for row in db.samples.aggregate(
+                        [
+                            {"$match": {"family_id": {"$in": sorted(retry)}}},
+                            {
+                                "$group": {
+                                    "_id": "$family_id",
+                                    "num_samples": {"$sum": 1},
+                                    "num_library_samples": {"$sum": {"$cond": ["$is_library", 1, 0]}},
+                                    "family": {"$first": "$family"},
+                                }
+                            },
+                        ]
+                    )
+                }
+            )
+            functions_by_family.update(
+                {
+                    row["_id"]: row["num_functions"]
+                    for row in db.functions.aggregate([{"$match": {"family_id": {"$in": sorted(retry)}}}, {"$group": {"_id": "$family_id", "num_functions": {"$sum": 1}}}])
+                }
+            )
+            pending = retry
         return report
 
     def deleteFamily(self, family_id: int, keep_samples: bool = False) -> bool:

--- a/mcrit/storage/StorageInterface.py
+++ b/mcrit/storage/StorageInterface.py
@@ -492,6 +492,11 @@ class StorageInterface:
         """
         raise NotImplementedError
 
+    def recomputeFamilyStats(self, progress_reporter=None) -> Dict[str, Any]:
+        """Set every family's sample/function counters from the samples and functions that exist,
+        and report how many families were corrected (#151)."""
+        raise NotImplementedError
+
     def deleteFamily(self, family_id: int, keep_samples: bool = False) -> bool:
         """Delete family if known and return boolean success state
 

--- a/tests/testMongoDbStorageDeleteSample.py
+++ b/tests/testMongoDbStorageDeleteSample.py
@@ -19,11 +19,23 @@ class FakeCollection:
         self.find_calls.append((query, projection))
         return list(self.documents)
 
+    def _matching(self, query):
+        return [document for document in self.documents if all(document.get(key) == value for key, value in query.items())]
+
     def delete_many(self, query):
         self.delete_many_calls.append(query)
+        matching = self._matching(query)
+        self.documents = [document for document in self.documents if document not in matching]
+        return SimpleNamespace(deleted_count=len(matching))
 
     def delete_one(self, query):
         self.delete_one_calls.append(query)
+        matching = self._matching(query)[:1]
+        self.documents = [document for document in self.documents if document not in matching]
+        return SimpleNamespace(deleted_count=len(matching))
+
+    def count_documents(self, query, limit=None):
+        return len(self._matching(query))
 
 
 class FakeDb(dict):
@@ -43,11 +55,11 @@ class MongoDbStorageDeleteSampleTest(TestCase):
     def testDeleteSampleUsesProjectedFunctionFields(self):
         functions = FakeCollection(
             [
-                {"function_id": 10, "minhash": bytes(range(40)).hex()},
-                {"function_id": 11, "minhash": bytes(range(40, 80)).hex()},
+                {"sample_id": 7, "function_id": 10, "minhash": bytes(range(40)).hex()},
+                {"sample_id": 7, "function_id": 11, "minhash": bytes(range(40, 80)).hex()},
             ]
         )
-        samples = FakeCollection()
+        samples = FakeCollection([{"sample_id": 7, "family_id": 1}])
         families = FakeCollection()
         # deleting a sample also removes the disassembly split out of the function documents (#137)
         xcfg = FakeCollection()
@@ -110,7 +122,10 @@ class MongoDbStorageDeleteSampleTest(TestCase):
         )
         self.assertEqual([{"sample_id": 7}], functions.delete_many_calls)
         self.assertEqual([{"sample_id": 7}], samples.delete_one_calls)
+        # decremented by what was deleted (two function documents, one sample), and the family
+        # deleted because no sample references it any more (#151)
         self.assertEqual([(1, -1, -2, 0)], family_updates)
+        self.assertEqual([{"family_id": 1}], families.delete_one_calls)
         self.assertEqual(1, len(band_updates))
         self.assertEqual("pull", band_updates[0][1])
 

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 from unittest import TestCase, main
+from unittest.mock import patch
 
 import pytest
 from smda.common.SmdaReport import SmdaReport
@@ -109,6 +110,80 @@ class MemoryStorageTest(TestCase):
         # family deletion
         self.storage.deleteFamily(4)
         self.assertEqual(None, self.storage.getFamilyId("family_1a"))
+
+    def _twoReports(self, family="family_1"):
+        with open(self.example_file_path) as fjson:
+            smda_json = json.load(fjson)
+        report_a = SmdaReport.fromDict(smda_json)
+        report_b = SmdaReport.fromDict(smda_json)
+        assert report_a is not None and report_b is not None
+        report_a.family = report_b.family = family
+        report_b.sha256 = 64 * "b"
+        return report_a, report_b
+
+    def _actualFamilyCounts(self, family_id):
+        samples = [s for s in self.storage.getSamples(0, 1000) if s.family_id == family_id]
+        num_functions = sum(len(self.storage.getFunctionsBySampleId(s.sample_id) or []) for s in samples)
+        return {"num_samples": len(samples), "num_functions": num_functions, "num_library_samples": len([s for s in samples if s.is_library])}
+
+    def _storedFamilyCounts(self, family_id):
+        family = self.storage.getFamily(family_id)
+        assert family is not None
+        return {"num_samples": family.num_samples, "num_functions": family.num_functions, "num_library_samples": family.num_library_samples}
+
+    def testFamilyStatsFollowTheSamplesThroughMovesAndDeletions(self):
+        # #151: the per-family counters are what the samples and functions say, after every write path
+        self.storage.clearStorage()
+        report_a, report_b = self._twoReports()
+        sample_a = self.storage.addSmdaReport(report_a)
+        sample_b = self.storage.addSmdaReport(report_b)
+        assert sample_a is not None and sample_b is not None
+        family_1 = sample_a.family_id
+        self.assertEqual({"num_samples": 2, "num_functions": 20, "num_library_samples": 0}, self._storedFamilyCounts(family_1))
+        self.storage.modifySample(sample_a.sample_id, {"is_library": True})
+        self.assertEqual(1, self._storedFamilyCounts(family_1)["num_library_samples"])
+        self.storage.modifySample(sample_a.sample_id, {"is_library": True})  # unchanged: no double count
+        self.assertEqual(1, self._storedFamilyCounts(family_1)["num_library_samples"])
+        # moving a sample moves its counts, and the same family is not a move at all
+        self.storage.modifySample(sample_a.sample_id, {"family_name": "family_1"})
+        self.assertEqual(self._actualFamilyCounts(family_1), self._storedFamilyCounts(family_1))
+        self.storage.modifySample(sample_a.sample_id, {"family_name": "family_2"})
+        family_2 = self.storage.getFamilyId("family_2")
+        self.assertEqual({"num_samples": 1, "num_functions": 10, "num_library_samples": 1}, self._storedFamilyCounts(family_2))
+        self.assertEqual({"num_samples": 1, "num_functions": 10, "num_library_samples": 0}, self._storedFamilyCounts(family_1))
+        self.assertEqual(self._actualFamilyCounts(family_2), self._storedFamilyCounts(family_2))
+        # deleting the last sample of a family deletes the family; deleting one of two keeps it
+        self.storage.deleteSample(sample_a.sample_id)
+        self.assertIsNone(self.storage.getFamily(family_2))
+        self.assertEqual({"num_samples": 1, "num_functions": 10, "num_library_samples": 0}, self._storedFamilyCounts(family_1))
+        self.assertEqual(
+            {"num_families": 0, "num_families_corrected": 0, "num_families_created": 0, "corrections": {}} | {"num_families": len(self.storage.getFamilyIds())},
+            self.storage.recomputeFamilyStats(),
+        )
+
+    def testRecomputeFamilyStatsCorrectsDriftedCounters(self):
+        self.storage.clearStorage()
+        report_a, _ = self._twoReports()
+        sample_a = self.storage.addSmdaReport(report_a)
+        assert sample_a is not None
+        family_id = sample_a.family_id
+        self._driftFamilyCounters(family_id, num_samples=5, num_functions=3)
+        self.assertEqual({"num_samples": 5, "num_functions": 3, "num_library_samples": 0}, self._storedFamilyCounts(family_id))
+        report = self.storage.recomputeFamilyStats()
+        self.assertEqual(1, report["num_families_corrected"])
+        self.assertEqual(
+            {"before": {"num_samples": 5, "num_functions": 3, "num_library_samples": 0}, "after": {"num_samples": 1, "num_functions": 10, "num_library_samples": 0}},
+            report["corrections"][family_id],
+        )
+        self.assertEqual({"num_samples": 1, "num_functions": 10, "num_library_samples": 0}, self._storedFamilyCounts(family_id))
+        stats = self.storage.getStats(with_pichash=False)
+        self.assertEqual(1, stats["num_samples"])
+        self.assertEqual(10, stats["num_functions"])
+
+    def _driftFamilyCounters(self, family_id, num_samples, num_functions):
+        family = self.storage._families[family_id]
+        family.num_samples = num_samples
+        family.num_functions = num_functions
 
     def testSampleHandling(self):
         self.storage.clearStorage()
@@ -502,6 +577,40 @@ class MongoDbStorageTest(MemoryStorageTest):
         THIS_FILE_PATH = str(os.path.abspath(__file__))
         PROJECT_ROOT = str(os.path.abspath(os.sep.join([THIS_FILE_PATH, "..", ".."])))
         self.example_file_path = os.sep.join([PROJECT_ROOT, "tests", "example_report.smda"])
+
+    def _driftFamilyCounters(self, family_id, num_samples, num_functions):
+        self.storage._getDb().families.update_one({"family_id": family_id}, {"$set": {"num_samples": num_samples, "num_functions": num_functions}})
+
+    def testRecomputeCreatesTheFamilyDocumentSamplesReferenceWithoutOne(self):
+        # the family_id 1908 case of #151: samples carry an id that no family document describes
+        self.storage.clearStorage()
+        report_a, _ = self._twoReports()
+        sample_a = self.storage.addSmdaReport(report_a)
+        assert sample_a is not None
+        db = self.storage._getDb()
+        db.families.delete_one({"family_id": sample_a.family_id})
+        report = self.storage.recomputeFamilyStats()
+        self.assertEqual(1, report["num_families_created"])
+        self.assertEqual("family_1", self.storage.getFamily(sample_a.family_id).family_name)
+        self.assertEqual({"num_samples": 1, "num_functions": 10, "num_library_samples": 0}, self._storedFamilyCounts(sample_a.family_id))
+
+    def testImportingASampleEnsuresItsFamilyDocument(self):
+        self.storage.clearStorage()
+        report_a, _ = self._twoReports()
+        sample_entry = SampleEntry(report_a, sample_id=0, family_id=77)
+        self.storage.importSampleEntry(sample_entry)
+        family = self.storage.getFamily(77)
+        assert family is not None
+        self.assertEqual("family_1", family.family_name)
+        self.assertEqual(1, family.num_samples)
+        self.assertEqual(10, family.num_functions)
+
+    def testAStatsUpdateAgainstAMissingFamilyIsLogged(self):
+        self.storage.clearStorage()
+        with patch("mcrit.storage.MongoDbStorage.LOGGER") as logger:
+            self.storage._updateFamilyStats(4242, 1, 10, 0)
+        self.assertIn("has no document", logger.warning.call_args.args[0])
+        self.assertEqual(4242, logger.warning.call_args.args[1])
 
     def _createSecondStorage(self):
         mcrit_config = McritConfig()

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -594,6 +594,32 @@ class MongoDbStorageTest(MemoryStorageTest):
         self.assertEqual("family_1", self.storage.getFamily(sample_a.family_id).family_name)
         self.assertEqual({"num_samples": 1, "num_functions": 10, "num_library_samples": 0}, self._storedFamilyCounts(sample_a.family_id))
 
+    def testAnEnsuredFamilyIdIsNeverHandedOutAgain(self):
+        # an imported family id at or beyond the counter would otherwise be re-issued by addFamily
+        self.storage.clearStorage()
+        report_a, _ = self._twoReports()
+        self.storage.importSampleEntry(SampleEntry(report_a, sample_id=0, family_id=5))
+        self.assertGreater(self.storage.addFamily("after_import"), 5)
+        self.assertEqual(1, self.storage._getDb().families.count_documents({"family_id": 5}))
+
+    def testAMoveIsCountedOnlyByTheRequestThatPerformsIt(self):
+        # of two identical concurrent moves only one changes the sample; the other must not
+        # touch the counters (modelled by the second call seeing the sample already moved)
+        self.storage.clearStorage()
+        report_a, _ = self._twoReports()
+        sample_a = self.storage.addSmdaReport(report_a)
+        assert sample_a is not None
+        family_1 = sample_a.family_id
+        self.storage.modifySample(sample_a.sample_id, {"family_name": "family_moved"})
+        family_moved = self.storage.getFamilyId("family_moved")
+        self.assertEqual(self._actualFamilyCounts(family_moved), self._storedFamilyCounts(family_moved))
+        # the sample document is already in family_moved: a stale request for the same move
+        db = self.storage._getDb()
+        db.samples.update_one({"sample_id": sample_a.sample_id}, {"$set": {"family_id": family_1, "family": "family_1"}})
+        db.samples.update_one({"sample_id": sample_a.sample_id}, {"$set": {"family_id": family_moved, "family": "family_moved"}})
+        self.storage.modifySample(sample_a.sample_id, {"family_name": "family_moved"})
+        self.assertEqual(self._actualFamilyCounts(family_moved), self._storedFamilyCounts(family_moved))
+
     def testImportingASampleEnsuresItsFamilyDocument(self):
         self.storage.clearStorage()
         report_a, _ = self._twoReports()


### PR DESCRIPTION
Closes #151 (family statistics drift from the collections they summarise, and /status reports the drifted values as the corpus size).

## Changes, per write path in the issue

1. **`_updateFamilyStats` against a missing family** is no longer a silent discard: it logs a warning naming the family and the lost increment. It does not upsert, since a family document without a name is worse than none.
2. **`importSampleEntry`** creates the family document for an imported family id that has none (`_ensureFamilyDocument`, `$setOnInsert` on the id, named from the sample's family), before incrementing.
3. **`modifySample`** uses atomic `$inc` everywhere. The is_library toggle increments the family only when the flag actually changes. A family move increments both families by the number of functions the move actually matched, and relabelling into the same family is not a move at all.
4. **`deleteSample`** decrements by what `delete_many`/`delete_one` removed, not by the sample's stored statistics.
5. **Family deletion** on both paths is judged by whether any sample still references the family (`count_documents(..., limit=1)`), not by the counter.
6. **`recomputeFamilyStats()`** sets every family's three counters from one `$group` over samples and one over functions, creates the family document for ids that samples reference without one (the family 1908 case), and reports every correction with before/after. It runs as a job through the worker (`POST /recompute_family_stats`, `McritClient.recomputeFamilyStats()`), for an operator to schedule after bulk operations.

The memory backend follows the same semantics: it deletes an emptied family with its last sample, decrements by what it removed, and implements `recomputeFamilyStats`, so the shared storage tests cover both.

`getStats` still sums the counters, as the issue accepted; they are now kept right and can be put right.

## Verification

- `tests/testStorage.py`, on both backends: counters follow two samples through library toggles (twice, no double count), a same-family relabel, a move, and the deletion of a family's last sample; a drifted counter is corrected and reported, and `/status`' figures follow. Mongo-only: a family document deleted from under its samples is recreated by the recompute with its name; importing a sample with an unknown family id creates the family document with the right counts; an increment against a missing family is logged. The projected-fields delete test's fake collections now honour deletions and counts.
- Full suite: 210 passed; `ruff check`, `ruff format --check`, `ty check` clean.
- Live, on the MongoDB-backed instance: with counters drifted by hand `/status` reported 104 samples for an actual 4; the recompute job corrected the one family and `/status` answered 4 / 1158 again. Through the API, setting is_library twice counted once, moving a sample to a new family and back moved its 218 functions with it and deleted the emptied family, and after every step the counters equalled the collections. Deleting a family document from under its sample and recomputing recreated it with the right name and counts.

Note: `deleteSample` here touches lines next to #171; the two merge cleanly, and that combination is what the live instance ran.

