### PR TITLE
Say which documents are over MongoDB's size limit, and keep the sample (#42)

### DIFF
--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -341,6 +341,20 @@ class MongoDbStorage(StorageInterface):
         if len(data) == 0:
             return []
         documents = [self._toBinary(document) for document in data]
+        # measure before the first wire batch goes out: once pymongo has sent earlier batches
+        # and then hits an oversized document, DocumentTooLarge carries no nInserted, so the
+        # committed documents could not be told apart from the rest (review of #42)
+        if collection in self._DROPPABLE_WHEN_OVERSIZED:
+            documents, oversized = self._splitOversizedDocuments(documents)
+            if oversized:
+                offenders = [{"document": self._describeDocument(document), "bytes": size} for document, size in oversized]
+                self._dbLogError(
+                    'Database insert_many for collection "%s": %d document(s) exceed the 16 MiB limit and are dropped.' % (collection, len(oversized)),
+                    details={"oversized": offenders, "dropped": True},
+                )
+                LOGGER.warning("Dropping the disassembly of %d function(s) over MongoDB's 16 MiB document limit: %s", len(oversized), offenders)
+                if not documents:
+                    return []
         try:
             insert_result = self._getDb()[collection].insert_many(documents)
             if insert_result.acknowledged:
@@ -354,7 +368,12 @@ class MongoDbStorage(StorageInterface):
             # in, the rest is not. Find out which documents are too large and say so, since
             # MongoDB's own message only carries a size (#42)
             inserted = documents[: error.details.get("nInserted", 0)] if isinstance(error, BulkWriteError) else []
-            fitting, oversized = self._splitOversizedDocuments(documents[len(inserted) :])
+            if "_id" in documents[0]:
+                # whatever earlier wire batches committed is in; never retry those ids
+                present = set(document["_id"] for document in self._getDb()[collection].find({"_id": {"$in": [document["_id"] for document in documents]}}, {"_id": 1}))
+                inserted = [document for document in documents if document["_id"] in present]
+            remaining = [document for document in documents if document not in inserted]
+            fitting, oversized = self._splitOversizedDocuments(remaining)
             offenders = [{"document": self._describeDocument(document), "bytes": size} for document, size in oversized]
             self._dbLogError(
                 'Database insert_many for collection "%s" failed: %d document(s) exceed the 16 MiB limit.' % (collection, len(oversized)),

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -11,9 +11,11 @@ from operator import itemgetter
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import numpy as np
+from bson import encode as bson_encode
 from packaging import version
 from picblocks.blockhasher import BlockHasher
 from pymongo import MongoClient, UpdateOne
+from pymongo.errors import BulkWriteError, DocumentTooLarge
 from smda.common.BinaryInfo import BinaryInfo
 from smda.common.SmdaFunction import SmdaFunction
 from smda.SmdaConfig import SmdaConfig
@@ -303,14 +305,65 @@ class MongoDbStorage(StorageInterface):
             )
             raise ValueError("Database insert failed.")
 
+    # MongoDB refuses a document over this size; pymongo raises DocumentTooLarge for the whole
+    # batch before anything is written (#42)
+    _MAX_DOCUMENT_BYTES = 16 * 1024 * 1024
+    # collections whose documents are droppable when oversized: a function without its stored
+    # disassembly is still a function, one that cannot be inserted takes the whole sample down
+    _DROPPABLE_WHEN_OVERSIZED = ("xcfg", "query_xcfg")
+
+    @staticmethod
+    def _describeDocument(document: Dict) -> Dict[str, Any]:
+        keys = ("_id", "function_id", "sample_id", "family_id", "sha256", "offset")
+        return {key: document[key] for key in keys if key in document}
+
+    def _splitOversizedDocuments(self, documents: List[Dict]) -> Tuple[List[Dict], List[Tuple[Dict, int]]]:
+        fitting, oversized = [], []
+        for document in documents:
+            size = len(bson_encode(document))
+            if size > self._MAX_DOCUMENT_BYTES:
+                oversized.append((document, size))
+            else:
+                fitting.append(document)
+        return fitting, oversized
+
+    @staticmethod
+    def _isTooLargeError(error: Exception) -> bool:
+        """pymongo rejects a clearly oversized document itself (DocumentTooLarge); one just over
+        the limit reaches the server, which answers a write error (code 2 or 10334, "too large")."""
+        if isinstance(error, DocumentTooLarge):
+            return True
+        if isinstance(error, BulkWriteError):
+            return any(write_error.get("code") in (2, 10334) or "too large" in str(write_error.get("errmsg", "")) for write_error in error.details.get("writeErrors", []))
+        return False
+
     def _dbInsertMany(self, collection: str, data: List["Dict"]):
         if len(data) == 0:
             return []
+        documents = [self._toBinary(document) for document in data]
         try:
-            insert_result = self._getDb()[collection].insert_many([self._toBinary(document) for document in data])
+            insert_result = self._getDb()[collection].insert_many(documents)
             if insert_result.acknowledged:
                 return insert_result.inserted_ids
             return None
+        except (DocumentTooLarge, BulkWriteError) as error:
+            if not self._isTooLargeError(error):
+                self._dbLogError('Database insert_many for collection "%s" failed.' % collection, details={"traceback": traceback.format_exc().split("\n")})
+                raise ValueError("Database insert failed.")
+            # an ordered insert stops at the first oversized document: what came before it is
+            # in, the rest is not. Find out which documents are too large and say so, since
+            # MongoDB's own message only carries a size (#42)
+            inserted = documents[: error.details.get("nInserted", 0)] if isinstance(error, BulkWriteError) else []
+            fitting, oversized = self._splitOversizedDocuments(documents[len(inserted) :])
+            offenders = [{"document": self._describeDocument(document), "bytes": size} for document, size in oversized]
+            self._dbLogError(
+                'Database insert_many for collection "%s" failed: %d document(s) exceed the 16 MiB limit.' % (collection, len(oversized)),
+                details={"oversized": offenders, "dropped": collection in self._DROPPABLE_WHEN_OVERSIZED},
+            )
+            if collection not in self._DROPPABLE_WHEN_OVERSIZED:
+                raise ValueError(f"Database insert failed: {len(oversized)} document(s) for '{collection}' exceed MongoDB's 16 MiB document limit ({offenders})")
+            LOGGER.warning("Dropping the disassembly of %d function(s) over MongoDB's 16 MiB document limit: %s", len(oversized), offenders)
+            return [document["_id"] for document in inserted] + (self._dbInsertMany(collection, fitting) or [])
         except Exception:
             self._dbLogError(
                 'Database insert_many for collection "%s" failed.' % collection,

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 from unittest import TestCase, main
+from unittest.mock import patch
 
 import pytest
 from smda.common.SmdaReport import SmdaReport
@@ -502,6 +503,51 @@ class MongoDbStorageTest(MemoryStorageTest):
         THIS_FILE_PATH = str(os.path.abspath(__file__))
         PROJECT_ROOT = str(os.path.abspath(os.sep.join([THIS_FILE_PATH, "..", ".."])))
         self.example_file_path = os.sep.join([PROJECT_ROOT, "tests", "example_report.smda"])
+
+    def testAnOversizedDisassemblyBlobIsDroppedAndTheFunctionKept(self):
+        # #42: MongoDB refuses a document over 16 MiB; the whole batch used to fail as
+        # "Database insert failed." with nothing saying which document, and the sample was lost
+        self.storage.clearStorage()
+        db = self.storage._getDb()
+        huge = "x" * (16 * 1024 * 1024 + 1)
+        with patch("mcrit.storage.MongoDbStorage.LOGGER") as logger:
+            self.storage._insertXcfgDocuments([{"function_id": 5, "_xcfg": huge}, {"function_id": 6, "_xcfg": "{}"}])
+        self.assertIn("Dropping the disassembly of %d function(s)", logger.warning.call_args.args[0])
+        self.assertEqual(1, logger.warning.call_args.args[1])
+        self.assertEqual([6], [document["_id"] for document in db.xcfg.find({}, {"_id": 1})])
+        error = db.error.find_one({}, sort=[("ts", -1)])
+        assert error is not None
+        self.assertIn("exceed the 16 MiB limit", error["error_msg"])
+        self.assertEqual(5, error["error_details"]["oversized"][0]["document"]["_id"])
+        self.assertGreater(error["error_details"]["oversized"][0]["bytes"], 16 * 1024 * 1024)
+        self.assertTrue(error["error_details"]["dropped"])
+
+    def testAnOversizedFunctionDocumentFailsNamingItself(self):
+        self.storage.clearStorage()
+        huge = "x" * (16 * 1024 * 1024 + 1)
+        with self.assertRaises(ValueError) as raised:
+            self.storage._dbInsertMany("functions", [{"function_id": 8, "sample_id": 1}, {"function_id": 9, "sample_id": 1, "blob": huge}, {"function_id": 10, "sample_id": 1}])
+        self.assertIn("16 MiB", str(raised.exception))
+        self.assertIn("'function_id': 9", str(raised.exception))
+        self.assertNotIn("'function_id': 10", str(raised.exception))
+        # the ordered insert stopped at the oversized document
+        self.assertEqual([8], [d["function_id"] for d in self.storage._getDb().functions.find({}, {"function_id": 1})])
+
+    def testAnOversizedBlobInTheMiddleKeepsTheOthers(self):
+        self.storage.clearStorage()
+        huge = "x" * (16 * 1024 * 1024 + 1)
+        with patch("mcrit.storage.MongoDbStorage.LOGGER"):
+            inserted = self.storage._insertXcfgDocuments(
+                [
+                    {"function_id": 1, "_xcfg": "{}"},
+                    {"function_id": 2, "_xcfg": huge},
+                    {"function_id": 3, "_xcfg": "{}"},
+                    {"function_id": 4, "_xcfg": huge},
+                    {"function_id": 5, "_xcfg": "{}"},
+                ]
+            )
+        self.assertIsNone(inserted)
+        self.assertEqual([1, 3, 5], sorted(document["_id"] for document in self.storage._getDb().xcfg.find({}, {"_id": 1})))
 
     def _createSecondStorage(self):
         mcrit_config = McritConfig()


### PR DESCRIPTION
Closes #42 (Mongo: BSON document might be bigger than 16 MB).

## Cause

An insert batch with one document over MongoDB's 16 MiB document limit failed as a bare `ValueError("Database insert failed.")`, with the error log carrying only the traceback, so nothing said which sample or function was responsible, and the sample was lost. The reporter saw it 4 times in 120k files. Since v1.7.0 the disassembly lives in its own `xcfg` documents, one per function, which is where a single giant function ends up over the limit.

Two shapes of the error exist: pymongo raises `DocumentTooLarge` before sending a clearly oversized document, and MongoDB answers a write error (code 2, "object to insert too large") for one just over the limit, which pymongo surfaces as `BulkWriteError` after inserting the documents before it (ordered insert).

## Fix

`_dbInsertMany` recognises both, measures the documents the ordered insert did not get to, and logs the oversized ones with their identifying fields (`_id`, `function_id`, `sample_id`, `sha256`, `offset`) and byte sizes.

- For the blob collections (`xcfg`, `query_xcfg`) it drops the oversized blobs with a warning and inserts the rest. The sample and all its functions are stored; only the disassembly of the affected function is missing, which the readers already treat as "no disassembly" (they decode a missing blob to `{}`). That function then gets no MinHash, as any function without disassembly.
- For any other collection it raises a `ValueError` naming the documents, since a function or sample document that cannot be stored cannot be dropped.

## Verification

- `tests/testStorage.py` (Mongo): a blob one byte over the limit is dropped with a warning naming one function, the other blob is stored, and the error log records the offender with its size and that it was dropped; an oversized blob in the middle of five keeps the other three; an oversized function document fails with a message naming exactly that document and the ordered insert's earlier document stays stored.
- Storage suite: 52 passed; `ruff check`, `ruff format --check`, `ty check` clean.
- The tests run against a real MongoDB 7 and exercise the server-side write error path (the one the issue's 60 MB case would take through pymongo's own check).

