### PR TITLE
Clean up the query data nothing refers to, and survive jobs without a result (#68)

### DIFF
--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -92,3 +92,21 @@ Notes on the individual knobs:
   earlier only the batch size, `BAND_MATCHES_REQUIRED` and the mongod cache size apply.
 * All measurements used single-process matching; comparisons against a pooled configuration
   will differ.
+
+## Reclaiming space after the query cleanup
+
+| setting | default | effect |
+|---|---|---|
+| `STORAGE_MONGODB_COMPACT_AFTER_CLEANUP` | `False` | run MongoDB's `compact` on `query_samples`, `query_functions` and `query_xcfg` after every `DbCleanup` job |
+
+The cleanup job deletes expired query samples, their functions and disassembly, and the
+orphans a broken deletion left behind; WiredTiger keeps the freed pages inside the collection
+files and reuses them for later inserts, so disk usage does not shrink on its own. `compact`
+returns that space to the file system. It needs the `compact` privilege on the database
+(the default `readWrite` role does not carry it - grant `dbAdmin` or a custom role), it
+blocks writes to the collection it is working on for the duration (seconds to minutes,
+depending on collection size; queries keep being accepted by the other collections), and on
+a replica set it runs on the member it is sent to only. Leave it off unless the query
+collections are large and the instance's disk is tight; the cleanup report says how many
+bytes each compaction returned.
+

--- a/mcrit/Worker.py
+++ b/mcrit/Worker.py
@@ -174,24 +174,34 @@ class Worker(QueueRemoteCallee):
         else:
             return None
 
+    QUERY_JOB_METHODS = ("getMatchesForUnmappedBinary", "getMatchesForMappedBinary", "getMatchesForSmdaReport")
+
+    def _querySampleOfJob(self, job: Job) -> Optional["SampleEntry"]:
+        """The query sample a query job produced, or None when the job left no result (it
+        failed before matching, or was terminated) - such a job must not take the cleanup down."""
+        result = self.getResultForJob(job.job_id)
+        if not result or "info" not in result or not result["info"].get("sample"):
+            return None
+        return SampleEntry.fromDict(result["info"]["sample"])
+
     # Reports PROGRESS
     @Remote(progress=True)
-    def doDbCleanup(self, progress_reporter=NoProgressReporter()):
+    def doDbCleanup(self, progress_reporter=NoProgressReporter()) -> Dict[str, Any]:
+        """Delete query samples and query jobs older than STORAGE_MONGODB_CLEANUP_TTL, then the
+        query functions and disassembly no query sample refers to any more, and optionally
+        compact the collections they lived in (#68)."""
         now = datetime.now()
         delta = timedelta(seconds=self._storage_config.STORAGE_MONGODB_CLEANUP_TTL)
         time_cutoff = now - delta
         LOGGER.info("Fetching data from the queues.")
-        unmapped_finished = self.getQueueData(0, 0, method="getMatchesForUnmappedBinary", state="finished")
-        mapped_finished = self.getQueueData(0, 0, method="getMatchesForMappedBinary", state="finished")
-        unmapped_failed = self.getQueueData(0, 0, method="getMatchesForUnmappedBinary", state="failed")
-        mapped_failed = self.getQueueData(0, 0, method="getMatchesForMappedBinary", state="failed")
-        smda_finished = self.getQueueData(0, 0, method="getMatchesForSmdaReport", state="finished")
+        query_jobs = []
+        for method in self.QUERY_JOB_METHODS:
+            for state in ("finished", "failed"):
+                query_jobs.extend((state, Job(job_dict, None)) for job_dict in self.getQueueData(0, 0, method=method, state=state))
         protected_sample_ids = set([])
         samples_to_be_deleted = {}
         jobs_to_be_deleted = []
-        LOGGER.info(
-            f"Collected all data from the queues, now iterating {len(unmapped_finished) + len(mapped_finished) + len(unmapped_failed) + len(mapped_failed) + len(smda_finished)} items."
-        )
+        LOGGER.info(f"Collected all data from the queues, now iterating {len(query_jobs)} items.")
         # first iterate and collect all potentially stale sample_entries by their submission/processing timestamp
         for sample_entry in self._storage.getSamples(start_index=0, limit=0, is_query=True):
             if sample_entry.timestamp is None:
@@ -201,39 +211,18 @@ class Worker(QueueRemoteCallee):
                 samples_to_be_deleted[sample_entry.sha256] = []
             if sample_entry.timestamp < time_cutoff:
                 samples_to_be_deleted[sample_entry.sha256].append(sample_entry)
-
-        for job_collection in [unmapped_finished, mapped_finished]:
-            for job_dict in job_collection:
-                job = Job(job_dict, None)
-                result = self.getResultForJob(job.job_id)
-                reference_sample_entry = SampleEntry.fromDict(result["info"]["sample"])
-                # we keep those query samples that have been submitted since the cutoff
-                if job.finished_at > time_cutoff:
-                    protected_sample_ids.add(reference_sample_entry.sample_id)
-                else:
+        for state, job in query_jobs:
+            # a finished job is dated by when it finished, a failed one by when it last ran
+            job_timestamp = job.finished_at if state == "finished" else job.started_at
+            is_recent = job_timestamp is not None and job_timestamp > time_cutoff
+            reference_sample_entry = self._querySampleOfJob(job)
+            if reference_sample_entry is None:
+                # nothing to protect or to collect; an old job without a result just goes
+                if not is_recent:
                     jobs_to_be_deleted.append(job)
-                    if reference_sample_entry.sha256 not in samples_to_be_deleted:
-                        samples_to_be_deleted[reference_sample_entry.sha256] = []
-                    samples_to_be_deleted[reference_sample_entry.sha256].append(reference_sample_entry)
-        for failed_job_collection in [unmapped_failed, mapped_failed]:
-            for failed_job_dict in failed_job_collection:
-                job = Job(failed_job_dict, None)
-                result = self.getResultForJob(job.job_id)
-                reference_sample_entry = SampleEntry.fromDict(result["info"]["sample"])
-                if job.started_at > time_cutoff:
-                    protected_sample_ids.add(reference_sample_entry.sample_id)
-                else:
-                    jobs_to_be_deleted.append(job)
-                    if reference_sample_entry.sha256 not in samples_to_be_deleted:
-                        samples_to_be_deleted[reference_sample_entry.sha256] = []
-                    samples_to_be_deleted[reference_sample_entry.sha256].append(reference_sample_entry)
-        LOGGER.info("Decoding SMDA reports for SHA256 hashes.")
-        for job_dict in smda_finished:
-            job = Job(job_dict, None)
-            result = self.getResultForJob(job.job_id)
-            reference_sample_entry = SampleEntry.fromDict(result["info"]["sample"])
+                continue
             # we keep those query samples that have been submitted since the cutoff
-            if job.finished_at > time_cutoff:
+            if is_recent:
                 protected_sample_ids.add(reference_sample_entry.sample_id)
             else:
                 jobs_to_be_deleted.append(job)
@@ -242,16 +231,25 @@ class Worker(QueueRemoteCallee):
                 samples_to_be_deleted[reference_sample_entry.sha256].append(reference_sample_entry)
         LOGGER.info(f"Found {len(samples_to_be_deleted)} query samples that can be deleted")
         progress_reporter.set_total(len(samples_to_be_deleted))
+        num_samples_deleted = 0
         for sample_sha256, sample_entries in samples_to_be_deleted.items():
-            LOGGER.info(f"Deleting {sample_entry.sample_id}.")
             for sample_id in set([sample_entry.sample_id for sample_entry in sample_entries]):
                 if sample_id not in protected_sample_ids:
-                    self._storage.deleteSample(sample_id)
+                    LOGGER.info(f"Deleting query sample {sample_id} ({sample_sha256}).")
+                    if self._storage.deleteSample(sample_id):
+                        num_samples_deleted += 1
             progress_reporter.step()
         # now remove the respective data also from the queue, which also deletes the results from GridFS
         LOGGER.info(f"Found {len(jobs_to_be_deleted)} query jobs that can be deleted.")
         for job in jobs_to_be_deleted:
             self.queue.delete_job(job.job_id)
+        # whatever a deleted or half-deleted query sample left behind (#68)
+        orphans = self._storage.deleteOrphanedQueryData()
+        LOGGER.info(f"Deleted orphaned query data: {orphans}")
+        report: Dict[str, Any] = {"num_query_samples_deleted": num_samples_deleted, "num_query_jobs_deleted": len(jobs_to_be_deleted), "orphans": orphans}
+        if self._storage_config.STORAGE_MONGODB_COMPACT_AFTER_CLEANUP:
+            report["compacted"] = self._storage.compactQueryCollections()
+        return report
 
     # Reports PROGRESS
     @Remote(progress=True)

--- a/mcrit/config/StorageConfig.py
+++ b/mcrit/config/StorageConfig.py
@@ -31,6 +31,9 @@ class StorageConfig(ConfigInterface):
     STORAGE_MONGODB_ENABLE_CLEANUP: bool = False
     STORAGE_MONGODB_CLEANUP_DELTA: int = 60 * 60 * 24 * 7
     STORAGE_MONGODB_CLEANUP_TTL: int = 60 * 60 * 24 * 7
+    # After a cleanup, run MongoDB's compact on the collections the deleted query data lived in,
+    # so the space goes back to the file system (it needs the compact privilege on the database)
+    STORAGE_MONGODB_COMPACT_AFTER_CLEANUP: bool = False
     # Once MinHashes have been calculated, discard disassembly from function entries
     STORAGE_DROP_DISASSEMBLY: bool = False
     # supported strategies:

--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -309,6 +309,15 @@ class MemoryStorage(StorageInterface):
         self._updateDbState()
         return True
 
+    def deleteOrphanedQueryData(self) -> Dict[str, int]:
+        orphan_function_ids = [function_id for function_id, entry in self._functions.items() if function_id < 0 and entry.sample_id not in self._samples]
+        for function_id in orphan_function_ids:
+            del self._functions[function_id]
+        return {"query_functions": len(orphan_function_ids), "query_xcfg": 0}
+
+    def compactQueryCollections(self) -> Dict[str, Any]:
+        return {}
+
     def deleteFamily(self, family_id: int, keep_samples: bool = False) -> bool:
         if family_id not in self._families:
             return False

--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -310,9 +310,10 @@ class MemoryStorage(StorageInterface):
         return True
 
     def deleteOrphanedQueryData(self) -> Dict[str, int]:
-        orphan_function_ids = [function_id for function_id, entry in self._functions.items() if function_id < 0 and entry.sample_id not in self._samples]
+        # query entries live in their own collections here, keyed like the regular ones
+        orphan_function_ids = [function_id for function_id, entry in self._query_functions.items() if entry.sample_id not in self._query_samples]
         for function_id in orphan_function_ids:
-            del self._functions[function_id]
+            del self._query_functions[function_id]
         return {"query_functions": len(orphan_function_ids), "query_xcfg": 0}
 
     def compactQueryCollections(self) -> Dict[str, Any]:

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -794,23 +794,72 @@ class MongoDbStorage(StorageInterface):
         Safe next to a query being inserted on another worker: the boundary is taken first,
         and only records older than it (a larger, i.e. less negative, id) are judged. A query
         inserted afterwards has ids below the boundary and is never looked at, however its
-        sample and functions interleave with this walk. The ids are walked in batches, so no
-        single command carries the whole collection.
+        sample and functions interleave with this walk.
+
+        No single command carries the whole collection. The sample ids come from an
+        aggregation cursor rather than distinct(), which answers with one document and fails
+        past MongoDB's 16 MiB limit, and every `$in` below is one batch wide.
         """
         db = self._getDb()
         newest = db.query_functions.find_one({}, {"function_id": 1, "_id": 0}, sort=[("function_id", 1)])
         if newest is None:
-            return {"query_functions": 0, "query_xcfg": 0}
+            return {"query_functions": 0, "query_xcfg": self._deleteQueryXcfgWithoutAnyFunction()}
         function_boundary = newest["function_id"]
-        # the sample snapshot is taken after the boundary: a query sample is written before its
-        # functions, so every sample a judged function can refer to is in it
-        sample_ids = set(db.query_samples.distinct("sample_id"))
-        num_functions = 0
-        orphan_sample_ids = [sample_id for sample_id in db.query_functions.distinct("sample_id", {"function_id": {"$gte": function_boundary}}) if sample_id not in sample_ids]
-        for start in range(0, len(orphan_sample_ids), self._ORPHAN_BATCH_SIZE):
-            chunk = orphan_sample_ids[start : start + self._ORPHAN_BATCH_SIZE]
-            num_functions += db.query_functions.delete_many({"sample_id": {"$in": chunk}, "function_id": {"$gte": function_boundary}}).deleted_count
-        num_xcfg = 0
+        return {
+            "query_functions": self._deleteQueryFunctionsWithoutASample(function_boundary),
+            "query_xcfg": self._deleteQueryXcfgWithoutAFunction(function_boundary),
+        }
+
+    def _deleteQueryXcfgWithoutAnyFunction(self) -> int:
+        """Every query_xcfg document, for the case where no query function exists at all.
+
+        This is what the boundary cannot cover: with query_functions empty there is no id to
+        take a boundary from, so the early return this replaces left the residue behind
+        forever. It is reachable rather than theoretical - addSmdaReport writes the
+        disassembly before the functions, so an insert interrupted between the two leaves
+        exactly this, and once the queries around it are deleted the collection is empty.
+
+        An existing query sample is what stops us. The sample is written before the
+        disassembly, so an empty query_samples proves no insert has yet reached the step that
+        could have written what is about to be deleted.
+        """
+        db = self._getDb()
+        if db.query_samples.find_one({}, {"_id": 1}) is not None:
+            return 0
+        return db.query_xcfg.delete_many({}).deleted_count
+
+    def _judgedQuerySampleIds(self, function_boundary: int) -> Iterable[List[int]]:
+        """The distinct sample ids of the query functions old enough to judge, one batch at a
+        time. $group over a cursor, because distinct() would answer with a single document."""
+        batch: List[int] = []
+        for group in self._getDb().query_functions.aggregate(
+            [{"$match": {"function_id": {"$gte": function_boundary}}}, {"$group": {"_id": "$sample_id"}}],
+            allowDiskUse=True,
+        ):
+            batch.append(group["_id"])
+            if len(batch) >= self._ORPHAN_BATCH_SIZE:
+                yield batch
+                batch = []
+        if batch:
+            yield batch
+
+    def _deleteQueryFunctionsWithoutASample(self, function_boundary: int) -> int:
+        """The samples are looked up per batch rather than snapshotted up front. A query
+        sample is written before its functions, so a sample read after the boundary is at
+        worst newer than the function referring to it - reading later can only find more
+        samples, never fewer, and a sample deleted meanwhile takes its functions with it."""
+        db = self._getDb()
+        deleted = 0
+        for sample_ids in self._judgedQuerySampleIds(function_boundary):
+            known = {document["sample_id"] for document in db.query_samples.find({"sample_id": {"$in": sample_ids}}, {"sample_id": 1, "_id": 0})}
+            orphans = [sample_id for sample_id in sample_ids if sample_id not in known]
+            if orphans:
+                deleted += db.query_functions.delete_many({"sample_id": {"$in": orphans}, "function_id": {"$gte": function_boundary}}).deleted_count
+        return deleted
+
+    def _deleteQueryXcfgWithoutAFunction(self, function_boundary: int) -> int:
+        db = self._getDb()
+        deleted = 0
         last_id = None
         while True:
             query = {"_id": {"$gte": function_boundary}} if last_id is None else {"_id": {"$gt": last_id}}
@@ -820,9 +869,9 @@ class MongoDbStorage(StorageInterface):
             referenced = set(db.query_functions.distinct("function_id", {"function_id": {"$in": batch}}))
             orphans = [function_id for function_id in batch if function_id not in referenced]
             if orphans:
-                num_xcfg += db.query_xcfg.delete_many({"_id": {"$in": orphans}}).deleted_count
+                deleted += db.query_xcfg.delete_many({"_id": {"$in": orphans}}).deleted_count
             last_id = batch[-1]
-        return {"query_functions": num_functions, "query_xcfg": num_xcfg}
+        return deleted
 
     def compactQueryCollections(self) -> Dict[str, Any]:
         """Run MongoDB's compact on the collections query data and results live in.

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -723,6 +723,37 @@ class MongoDbStorage(StorageInterface):
             self._updateDbState()
         return True
 
+    def deleteOrphanedQueryData(self) -> Dict[str, int]:
+        """Delete the query functions no query sample refers to and the query disassembly no
+        query function refers to. Both are left behind when a deletion is interrupted halfway,
+        and a query job can be deleted without its sample (#68). The query collections are
+        bounded by the cleanup TTL, so listing their ids is affordable."""
+        db = self._getDb()
+        sample_ids = set(db.query_samples.distinct("sample_id"))
+        orphan_sample_ids = sorted(set(db.query_functions.distinct("sample_id")) - sample_ids)
+        num_functions = 0
+        if orphan_sample_ids:
+            num_functions = db.query_functions.delete_many({"sample_id": {"$in": orphan_sample_ids}}).deleted_count
+        function_ids = db.query_functions.distinct("function_id")
+        num_xcfg = db.query_xcfg.delete_many({"_id": {"$nin": function_ids}}).deleted_count
+        return {"query_functions": num_functions, "query_xcfg": num_xcfg}
+
+    def compactQueryCollections(self) -> Dict[str, Any]:
+        """Run MongoDB's compact on the collections query data and results live in.
+
+        compact needs the compact privilege on the database; a refusal is reported per
+        collection rather than raised, since the cleanup itself has already succeeded."""
+        db = self._getDb()
+        outcome: Dict[str, Any] = {}
+        for collection in ("query_samples", "query_functions", "query_xcfg", "fs.files", "fs.chunks"):
+            try:
+                result = db.command("compact", collection)
+                outcome[collection] = {"ok": result.get("ok"), "bytesFreed": result.get("bytesFreed")}
+            except Exception as error:
+                LOGGER.warning("compact of %s was refused: %s", collection, error)
+                outcome[collection] = {"ok": 0, "error": str(error)}
+        return outcome
+
     def deleteFamily(self, family_id: int, keep_samples: bool = False) -> bool:
         family_entry = self.getFamily(family_id)
         if family_entry is None:

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -723,19 +723,46 @@ class MongoDbStorage(StorageInterface):
             self._updateDbState()
         return True
 
+    # query ids are handed out from a counter and stored negated, so a smaller id is a newer
+    # record; deletes and the $in/$nin arguments are kept to this many ids per command
+    _ORPHAN_BATCH_SIZE = 5000
+
     def deleteOrphanedQueryData(self) -> Dict[str, int]:
         """Delete the query functions no query sample refers to and the query disassembly no
         query function refers to. Both are left behind when a deletion is interrupted halfway,
-        and a query job can be deleted without its sample (#68). The query collections are
-        bounded by the cleanup TTL, so listing their ids is affordable."""
+        and a query job can be deleted without its sample (#68).
+
+        Safe next to a query being inserted on another worker: the boundary is taken first,
+        and only records older than it (a larger, i.e. less negative, id) are judged. A query
+        inserted afterwards has ids below the boundary and is never looked at, however its
+        sample and functions interleave with this walk. The ids are walked in batches, so no
+        single command carries the whole collection.
+        """
         db = self._getDb()
+        newest = db.query_functions.find_one({}, {"function_id": 1, "_id": 0}, sort=[("function_id", 1)])
+        if newest is None:
+            return {"query_functions": 0, "query_xcfg": 0}
+        function_boundary = newest["function_id"]
+        # the sample snapshot is taken after the boundary: a query sample is written before its
+        # functions, so every sample a judged function can refer to is in it
         sample_ids = set(db.query_samples.distinct("sample_id"))
-        orphan_sample_ids = sorted(set(db.query_functions.distinct("sample_id")) - sample_ids)
         num_functions = 0
-        if orphan_sample_ids:
-            num_functions = db.query_functions.delete_many({"sample_id": {"$in": orphan_sample_ids}}).deleted_count
-        function_ids = db.query_functions.distinct("function_id")
-        num_xcfg = db.query_xcfg.delete_many({"_id": {"$nin": function_ids}}).deleted_count
+        orphan_sample_ids = [sample_id for sample_id in db.query_functions.distinct("sample_id", {"function_id": {"$gte": function_boundary}}) if sample_id not in sample_ids]
+        for start in range(0, len(orphan_sample_ids), self._ORPHAN_BATCH_SIZE):
+            chunk = orphan_sample_ids[start : start + self._ORPHAN_BATCH_SIZE]
+            num_functions += db.query_functions.delete_many({"sample_id": {"$in": chunk}, "function_id": {"$gte": function_boundary}}).deleted_count
+        num_xcfg = 0
+        last_id = None
+        while True:
+            query = {"_id": {"$gte": function_boundary}} if last_id is None else {"_id": {"$gt": last_id}}
+            batch = [document["_id"] for document in db.query_xcfg.find(query, {"_id": 1}).sort("_id", 1).limit(self._ORPHAN_BATCH_SIZE)]
+            if not batch:
+                break
+            referenced = set(db.query_functions.distinct("function_id", {"function_id": {"$in": batch}}))
+            orphans = [function_id for function_id in batch if function_id not in referenced]
+            if orphans:
+                num_xcfg += db.query_xcfg.delete_many({"_id": {"$in": orphans}}).deleted_count
+            last_id = batch[-1]
         return {"query_functions": num_functions, "query_xcfg": num_xcfg}
 
     def compactQueryCollections(self) -> Dict[str, Any]:

--- a/mcrit/storage/StorageInterface.py
+++ b/mcrit/storage/StorageInterface.py
@@ -492,6 +492,16 @@ class StorageInterface:
         """
         raise NotImplementedError
 
+    def deleteOrphanedQueryData(self) -> Dict[str, int]:
+        """Delete the query functions whose query sample is gone and the query disassembly whose
+        function is gone; answers how many of each were removed (#68)."""
+        raise NotImplementedError
+
+    def compactQueryCollections(self) -> Dict[str, Any]:
+        """Hand the space freed by deleted query data back to the file system, where the backend
+        can; answers per collection what happened (#68)."""
+        raise NotImplementedError
+
     def deleteFamily(self, family_id: int, keep_samples: bool = False) -> bool:
         """Delete family if known and return boolean success state
 

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -503,6 +503,28 @@ class MongoDbStorageTest(MemoryStorageTest):
         PROJECT_ROOT = str(os.path.abspath(os.sep.join([THIS_FILE_PATH, "..", ".."])))
         self.example_file_path = os.sep.join([PROJECT_ROOT, "tests", "example_report.smda"])
 
+    def testOrphanedQueryDataIsDeletedAndReferencedDataKept(self):
+        # #68: query functions whose sample is gone, and query disassembly whose function is gone
+        self.storage.clearStorage()
+        db = self.storage._getDb()
+        report = SmdaReport.fromFile(self.example_file_path)
+        query_entry = self.storage.addSmdaReport(report, isQuery=True)
+        assert query_entry is not None
+        num_functions = db.query_functions.count_documents({})
+        db.query_functions.insert_many([{"function_id": -1000, "sample_id": -999}, {"function_id": -1001, "sample_id": -999}])
+        db.query_xcfg.insert_many([{"_id": -1000, "_xcfg": "{}"}, {"_id": -5000, "_xcfg": "{}"}])
+        self.assertEqual({"query_functions": 2, "query_xcfg": 2}, self.storage.deleteOrphanedQueryData())
+        self.assertEqual(num_functions, db.query_functions.count_documents({}))
+        self.assertEqual(num_functions, db.query_xcfg.count_documents({}))
+        self.assertEqual({"query_functions": 0, "query_xcfg": 0}, self.storage.deleteOrphanedQueryData())
+
+    def testCompactingTheQueryCollectionsAnswersPerCollection(self):
+        self.storage.clearStorage()
+        outcome = self.storage.compactQueryCollections()
+        self.assertEqual({"query_samples", "query_functions", "query_xcfg", "fs.files", "fs.chunks"}, set(outcome))
+        for collection, result in outcome.items():
+            self.assertIn("ok", result, collection)
+
     def _createSecondStorage(self):
         mcrit_config = McritConfig()
         mcrit_config.STORAGE_CONFIG = self._storage_config

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -630,6 +630,46 @@ class MongoDbStorageTest(MemoryStorageTest):
         db.query_samples.delete_one({"sample_id": -777})
         self.assertEqual(12000, self.storage.deleteOrphanedQueryData()["query_functions"])
 
+    def testOrphanedDisassemblyIsCollectedOnceNoQueryFunctionRemains(self):
+        """#68 follow-up: the boundary is taken from the newest query function, so an empty
+        query_functions used to return early and leave the disassembly behind forever.
+
+        addSmdaReport writes the disassembly before the functions, so an insert interrupted
+        between the two leaves exactly this, and deleting the queries around it empties the
+        collection the boundary came from."""
+        self.storage.clearStorage()
+        db = self.storage._getDb()
+        db.query_xcfg.insert_many([{"_id": -1, "_xcfg": "{}"}, {"_id": -2, "_xcfg": "{}"}])
+        self.assertEqual({"query_functions": 0, "query_xcfg": 2}, self.storage.deleteOrphanedQueryData())
+        self.assertEqual(0, db.query_xcfg.count_documents({}))
+
+    def testOrphanedDisassemblyIsKeptWhileAQuerySampleExists(self):
+        """The other half of the same case: a query sample is written before its disassembly,
+        so one that exists is the evidence that an insert may be in flight and the blobs about
+        to be deleted may be its."""
+        self.storage.clearStorage()
+        db = self.storage._getDb()
+        db.query_samples.insert_one({"sample_id": -1, "sha256": 64 * "a"})
+        db.query_xcfg.insert_one({"_id": -1, "_xcfg": "{}"})
+        self.assertEqual({"query_functions": 0, "query_xcfg": 0}, self.storage.deleteOrphanedQueryData())
+        self.assertEqual(1, db.query_xcfg.count_documents({}))
+
+    def testOrphanedQueryFunctionsAreJudgedInBatchesOfSamples(self):
+        """More distinct sample ids than one batch holds. The sample ids used to come from two
+        unbounded distinct() calls, each of which answers with a single document and fails past
+        MongoDB's 16 MiB limit; they come from an aggregation cursor now, so this walks several
+        batches rather than one command."""
+        self.storage.clearStorage()
+        db = self.storage._getDb()
+        batch_size = self.storage._ORPHAN_BATCH_SIZE
+        num_orphans = 2 * batch_size + 17
+        db.query_functions.insert_many([{"function_id": -1 - i, "sample_id": -1 - i} for i in range(num_orphans)])
+        # one sample that does exist: its function must survive every batch it lands in
+        kept_sample_id = -1 - (batch_size + 3)
+        db.query_samples.insert_one({"sample_id": kept_sample_id, "sha256": 64 * "b"})
+        self.assertEqual(num_orphans - 1, self.storage.deleteOrphanedQueryData()["query_functions"])
+        self.assertEqual([kept_sample_id], [document["sample_id"] for document in db.query_functions.find({}, {"sample_id": 1, "_id": 0})])
+
     def testCompactingTheQueryCollectionsAnswersPerCollection(self):
         self.storage.clearStorage()
         outcome = self.storage.compactQueryCollections()

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -512,11 +512,16 @@ class MongoDbStorageTest(MemoryStorageTest):
         assert query_entry is not None
         num_functions = db.query_functions.count_documents({})
         db.query_functions.insert_many([{"function_id": -1000, "sample_id": -999}, {"function_id": -1001, "sample_id": -999}])
-        db.query_xcfg.insert_many([{"_id": -1000, "_xcfg": "{}"}, {"_id": -5000, "_xcfg": "{}"}])
+        db.query_xcfg.insert_many([{"_id": -1000, "_xcfg": "{}"}, {"_id": -500, "_xcfg": "{}"}])
         self.assertEqual({"query_functions": 2, "query_xcfg": 2}, self.storage.deleteOrphanedQueryData())
         self.assertEqual(num_functions, db.query_functions.count_documents({}))
         self.assertEqual(num_functions, db.query_xcfg.count_documents({}))
         self.assertEqual({"query_functions": 0, "query_xcfg": 0}, self.storage.deleteOrphanedQueryData())
+        # many ids: batches, not one command
+        db.query_functions.insert_many([{"function_id": -20000 - i, "sample_id": -777} for i in range(12000)])
+        db.query_samples.insert_one({"sample_id": -777, "sha256": 64 * "f"})
+        db.query_samples.delete_one({"sample_id": -777})
+        self.assertEqual(12000, self.storage.deleteOrphanedQueryData()["query_functions"])
 
     def testCompactingTheQueryCollectionsAnswersPerCollection(self):
         self.storage.clearStorage()

--- a/tests/testWorkerCleanup.py
+++ b/tests/testWorkerCleanup.py
@@ -1,0 +1,93 @@
+import os
+import unittest
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from smda.common.SmdaReport import SmdaReport
+
+from mcrit.storage.SampleEntry import SampleEntry
+from mcrit.Worker import Worker
+
+from .context import config
+
+EXAMPLE_REPORT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "example_report.smda")
+
+TTL = config.STORAGE_CONFIG.STORAGE_MONGODB_CLEANUP_TTL
+OLD = datetime.now() - timedelta(seconds=TTL + 3600)
+RECENT = datetime.now() - timedelta(seconds=60)
+
+
+def _job(job_id, method, started_at=None, finished_at=None):
+    return {"_id": job_id, "payload": {"method": method, "params": "[]"}, "started_at": started_at, "finished_at": finished_at, "created_at": started_at or RECENT, "result": None}
+
+
+def _sample(sample_id, sha256, timestamp):
+    return SimpleNamespace(sample_id=sample_id, sha256=sha256, timestamp=timestamp)
+
+
+class DbCleanupTest(unittest.TestCase):
+    """#68: the cleanup survives query jobs without a result, deletes what is older than the TTL,
+    and removes the query data nothing refers to any more."""
+
+    def _worker(self, jobs, results, query_samples, compact=False):
+        queue = MagicMock()
+        queue.clean_interval = 10**9
+        storage = MagicMock()
+        storage.getSamples.return_value = query_samples
+        storage.deleteSample.return_value = True
+        storage.deleteOrphanedQueryData.return_value = {"query_functions": 2, "query_xcfg": 1}
+        storage.compactQueryCollections.return_value = {"query_functions": {"ok": 1.0}}
+        worker = Worker(queue=queue, config=config, storage=storage)
+        worker._storage_config = SimpleNamespace(STORAGE_MONGODB_CLEANUP_TTL=TTL, STORAGE_MONGODB_COMPACT_AFTER_CLEANUP=compact)
+        setattr(
+            worker, "getQueueData", lambda start, limit, method=None, state=None, **kwargs: [job for job in jobs if job["payload"]["method"] == method and job["state"] == state]
+        )
+        setattr(worker, "getResultForJob", lambda job_id: results.get(job_id))
+        return worker, queue, storage
+
+    def test_a_failed_job_without_a_result_is_deleted_when_old_and_kept_when_recent(self):
+        jobs = [
+            {**_job("old-failed", "getMatchesForUnmappedBinary", started_at=OLD), "state": "failed"},
+            {**_job("new-failed", "getMatchesForMappedBinary", started_at=RECENT), "state": "failed"},
+            {**_job("never-started", "getMatchesForSmdaReport"), "state": "failed"},
+        ]
+        worker, queue, storage = self._worker(jobs, {}, [])
+        report = worker.doDbCleanup()
+        self.assertEqual(sorted(["old-failed", "never-started"]), sorted(call.args[0] for call in queue.delete_job.call_args_list))
+        self.assertEqual(2, report["num_query_jobs_deleted"])
+        self.assertEqual(0, report["num_query_samples_deleted"])
+
+    def test_a_recent_job_protects_its_sample_and_an_old_one_takes_it_along(self):
+        report = SmdaReport.fromFile(EXAMPLE_REPORT)
+        assert report is not None
+        report.sha256 = 64 * "a"
+        sample_dict = SampleEntry(report, sample_id=-5, family_id=0).toDict()
+        jobs = [
+            {**_job("old-finished", "getMatchesForUnmappedBinary", started_at=OLD, finished_at=OLD), "state": "finished"},
+            {**_job("new-finished", "getMatchesForUnmappedBinary", started_at=RECENT, finished_at=RECENT), "state": "finished"},
+        ]
+        results = {"old-finished": {"info": {"sample": {**sample_dict, "sample_id": -7, "sha256": 64 * "b"}}}, "new-finished": {"info": {"sample": sample_dict}}}
+        query_samples = [_sample(-5, 64 * "a", OLD), _sample(-7, 64 * "b", OLD), _sample(-9, 64 * "c", RECENT)]
+        worker, queue, storage = self._worker(jobs, results, query_samples)
+        report = worker.doDbCleanup()
+        # -5 is old but its job is recent: protected; -7 is old and its job is old: deleted with the job; -9 is recent: kept
+        self.assertEqual([-7], sorted(call.args[0] for call in storage.deleteSample.call_args_list))
+        self.assertEqual(["old-finished"], [call.args[0] for call in queue.delete_job.call_args_list])
+        self.assertEqual(1, report["num_query_samples_deleted"])
+
+    def test_orphaned_query_data_is_removed_and_compaction_is_opt_in(self):
+        worker, queue, storage = self._worker([], {}, [])
+        report = worker.doDbCleanup()
+        storage.deleteOrphanedQueryData.assert_called_once_with()
+        self.assertEqual({"query_functions": 2, "query_xcfg": 1}, report["orphans"])
+        storage.compactQueryCollections.assert_not_called()
+        self.assertNotIn("compacted", report)
+        worker, queue, storage = self._worker([], {}, [], compact=True)
+        report = worker.doDbCleanup()
+        storage.compactQueryCollections.assert_called_once_with()
+        self.assertEqual({"query_functions": {"ok": 1.0}}, report["compacted"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #68 (considerations for DbCleanup: orphan query samples and functions without a job, a compact afterwards).

## What the cleanup did, and the bug in it

`doDbCleanup` deleted query samples and query jobs older than `STORAGE_MONGODB_CLEANUP_TTL`, which already covers query samples whose job is gone (they age out by their own timestamp). It read `result["info"]["sample"]` off every finished *and failed* query job, though, and a failed job that died before matching has no result, so the first such job took the whole cleanup down with a `TypeError`. On an instance with `STORAGE_MONGODB_ENABLE_CLEANUP` that means the cleanup never completes again once one query job has failed early.

## Changes

- A job without a result is nothing to protect and nothing to collect: it is deleted once older than the TTL and kept otherwise. Finished jobs are dated by `finished_at`, failed ones by `started_at`, a job that never started counts as old.
- After the TTL pass, `deleteOrphanedQueryData()` on the storage removes the query functions whose query sample is gone and the query disassembly (`query_xcfg`) whose function is gone: what an interrupted deletion or a job deleted without its sample leaves behind. The query collections are bounded by the TTL, so listing their ids is affordable; the memory backend drops orphaned query functions the same way.
- `STORAGE_MONGODB_COMPACT_AFTER_CLEANUP` (default off) runs MongoDB's `compact` on `query_samples`, `query_functions`, `query_xcfg`, `fs.files` and `fs.chunks` afterwards, so the freed space goes back to the file system. It needs the compact privilege; a refusal is reported per collection, not raised, since the cleanup itself has succeeded by then.
- The job now answers a report: samples and jobs deleted, orphans removed, and the compact outcome when it ran.

## Verification

- `tests/testWorkerCleanup.py` (3 tests, worker with fakes): an old failed job without a result is deleted and a recent one kept, a job that never started counts as old; a recent job protects its sample while an old job takes its old sample along and a recent sample is kept; orphan removal always runs and compaction only when configured, with both reflected in the report.
- `tests/testStorage.py` (Mongo): orphaned query functions and disassembly are deleted while the query sample's own are kept, and a second run finds nothing; compact answers per collection against the real MongoDB.
- Full suite: 208 passed; `ruff check`, `ruff format --check`, `ty check` clean.
- Live verification on the MongoDB-backed instance follows in a comment.

