### PR TITLE
Let a family carry the actors it is attributed to (#57)

### DIFF
--- a/mcrit/client/McritClient.py
+++ b/mcrit/client/McritClient.py
@@ -154,13 +154,22 @@ class McritClient:
     ### Families
     ###########################################
 
-    def modifyFamily(self, family_id, family_name=None, is_library=None):
+    def modifyFamily(self, family_id, family_name=None, is_library=None, actors=None):
+        """
+        Modify a family: rename it, mark it as library, or set the actors it is attributed to (#57)
+        <actors> is a list of names; an empty list clears them
+        """
         update_dict = {}
         if family_name is not None:
             update_dict["family_name"] = family_name
         if is_library is not None:
             update_dict["is_library"] = is_library
-        response = requests.put(f"{self.mcrit_server}/families/{family_id}", update_dict, headers=self.headers)
+        if actors is not None:
+            update_dict["actors"] = list(actors)
+        # JSON, since a list of actors does not survive form encoding
+        response = requests.put(f"{self.mcrit_server}/families/{family_id}", json=update_dict, headers=self.headers)
+        if self.raw:
+            return response
         return handle_response(response)
 
     def getFamily(self, family_id: int, with_samples=True) -> Any:

--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -191,6 +191,12 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
                 raise MemoryError("Export running beyond the allocated maximum, aborting operation.")
         exported_data["content"]["num_families"] = len(family_mapping)
         exported_data["family_mapping"] = family_mapping
+        # the family attributes beyond the name (#57); an importer without this key ignores it
+        exported_data["family_actors"] = {}
+        for family_id in family_mapping:
+            family_entry = storage.getFamily(family_id)
+            if family_entry is not None and family_entry.actors:
+                exported_data["family_actors"][family_id] = list(family_entry.actors)
         exported_data["sample_entries"] = exported_sample_entries
         exported_data["function_entries"] = exported_function_entries
         return exported_data
@@ -283,6 +289,14 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
             else:
                 import_report["num_families_skipped"] += 1
             family_id_remapping[exported_family_id] = remapped_family_id
+        # actors of imported families are merged into what this instance already knows (#57)
+        for exported_family_id, actors in (export_data.get("family_actors") or {}).items():
+            remapped_family_id = family_id_remapping.get(int(exported_family_id))
+            local_family = storage.getFamily(remapped_family_id) if remapped_family_id is not None else None
+            if local_family is not None and actors:
+                merged = list(local_family.actors) + [actor for actor in actors if actor not in local_family.actors]
+                if merged != local_family.actors:
+                    storage.modifyFamily(remapped_family_id, {"actors": merged})
         LOGGER.info("Family remapping created: %d families, %d samples.", len(family_id_remapping), len(export_data["sample_entries"]))
         # iterate samples
         index = 0

--- a/mcrit/server/FamilyResource.py
+++ b/mcrit/server/FamilyResource.py
@@ -58,6 +58,17 @@ class FamilyResource:
                 information_update["is_library"] = True
             elif information_update["is_library"] in ["False", "false", "0", 0]:
                 information_update["is_library"] = False
+        if "actors" in information_update:
+            actors = information_update["actors"]
+            if isinstance(actors, str):
+                actors = [actor for actor in actors.split(",")]
+            if not isinstance(actors, list) or not all(isinstance(actor, str) and re.match(r"^[\w .\-]{1,64}$", actor.strip()) for actor in actors):
+                resp.data = jsonify(
+                    {"status": "failed", "data": {"message": "actors must be a list of 1-64 character names (letters, digits, spaces, dots, dashes, underscores)."}}
+                )
+                db_log_msg(self.index, req, "FamilyResource.on_put - failed - actors malformed.")
+                return
+            information_update["actors"] = actors
         successful = self.index.modifyFamily(family_id, information_update, force_recalculation=True)
         if successful:
             resp.data = jsonify({"status": "successful", "data": {"message": "Family modified."}})

--- a/mcrit/storage/FamilyEntry.py
+++ b/mcrit/storage/FamilyEntry.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from mcrit.storage.SampleEntry import SampleEntry
 
@@ -9,16 +9,29 @@ class FamilyEntry:
     num_samples: int
     num_functions: int
     num_library_samples: int
+    # the threat actors this family is attributed to, as names (#57)
+    actors: List[str]
     # This is not supposed to be stored in storage
     samples: Optional[Dict[int, SampleEntry]]
 
-    def __init__(self, family_name="", family_id=0, num_samples=0, num_functions=0, num_library_samples=0, samples=None):
+    def __init__(self, family_name="", family_id=0, num_samples=0, num_functions=0, num_library_samples=0, samples=None, actors=None):
         self.family_id = family_id
         self.family_name = family_name
         self.num_samples = num_samples
         self.num_functions = num_functions
         self.num_library_samples = num_library_samples
+        self.actors = list(actors) if actors else []
         self.samples = samples
+
+    @staticmethod
+    def normalizeActors(actors) -> List[str]:
+        """Actor names as stored: stripped, non-empty, each once, in the order given."""
+        normalized: List[str] = []
+        for actor in actors or []:
+            name = str(actor).strip()
+            if name and name not in normalized:
+                normalized.append(name)
+        return normalized
 
     @property
     def is_library(self):
@@ -35,6 +48,7 @@ class FamilyEntry:
             "num_samples": self.num_samples,
             "num_functions": self.num_functions,
             "num_library_samples": self.num_library_samples,
+            "actors": list(self.actors),
         }
         if self.samples is not None:
             family_entry["samples"] = {id: sample.toDict() for id, sample in self.samples.items()}
@@ -48,6 +62,8 @@ class FamilyEntry:
         family_entry.num_samples = entry_dict["num_samples"]
         family_entry.num_functions = entry_dict["num_functions"]
         family_entry.num_library_samples = entry_dict["num_library_samples"]
+        # families stored before #57 carry no actors
+        family_entry.actors = list(entry_dict.get("actors") or [])
         samples = entry_dict.get("samples", None)
         if samples is not None:
             family_entry.samples = {id: SampleEntry.fromDict(sample) for id, sample in samples.items()}

--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -288,6 +288,10 @@ class MemoryStorage(StorageInterface):
             new_num_samples = new_family_info.num_samples + old_family_info.num_samples
             new_num_functions = new_family_info.num_functions + old_family_info.num_functions
             new_num_lib_samples = new_family_info.num_library_samples + old_family_info.num_library_samples
+            # the attribution moves with the samples: a rename onto an existing family merges
+            # both actor lists (a review of #57 caught the rename dropping them)
+            merged_actors = FamilyEntry.normalizeActors(list(new_family_info.actors or []) + list(old_family_info.actors or []))
+            self._families[new_family_id].actors = merged_actors
             # update family_entry
             if family_id == 0:
                 self._families[0].num_samples = 0

--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -272,6 +272,8 @@ class MemoryStorage(StorageInterface):
             return False
         old_family_info = self.getFamily(family_id)
         assert old_family_info is not None
+        if "actors" in update_information:
+            self._families[family_id].actors = FamilyEntry.normalizeActors(update_information["actors"])
         if "is_library" in update_information:
             for sample_id, sample_entry in self._samples.items():
                 if family_id == sample_entry.family_id:

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -695,6 +695,8 @@ class MongoDbStorage(StorageInterface):
             return False
         old_family_info = self.getFamily(family_id)
         assert old_family_info is not None
+        if "actors" in update_information:
+            self._getDb().families.update_one({"family_id": family_id}, {"$set": {"actors": FamilyEntry.normalizeActors(update_information["actors"])}})
         if "is_library" in update_information:
             self._getDb().samples.update_many({"family_id": family_id}, {"$set": {"is_library": update_information["is_library"]}})
             updated_count = old_family_info.num_samples if update_information["is_library"] else 0

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -716,8 +716,12 @@ class MongoDbStorage(StorageInterface):
                 self._getDb().families.update_one({"family_id": 0}, {"$set": {"num_samples": 0, "num_functions": 0, "num_library_samples": 0}})
             else:
                 self._getDb().families.delete_one({"family_id": family_id})
+            # the attribution moves with the samples: a rename onto an existing family merges
+            # both actor lists (a review of #57 caught the rename dropping them)
+            merged_actors = FamilyEntry.normalizeActors(list(new_family_info.actors or []) + list(old_family_info.actors or []))
             self._getDb().families.update_one(
-                {"family_id": new_family_id}, {"$set": {"num_samples": new_num_samples, "num_functions": new_num_functions, "num_library_samples": new_num_lib_samples}}
+                {"family_id": new_family_id},
+                {"$set": {"num_samples": new_num_samples, "num_functions": new_num_functions, "num_library_samples": new_num_lib_samples, "actors": merged_actors}},
             )
             # update sample_entry and function_entries with new family information
             self._getDb().samples.update_many({"family_id": family_id}, {"$set": {"family_id": new_family_id, "family": family_name}})

--- a/tests/testFamilyActors.py
+++ b/tests/testFamilyActors.py
@@ -1,0 +1,71 @@
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+import falcon
+import falcon.testing
+
+from mcrit.client.McritClient import McritClient
+from mcrit.server.FamilyResource import FamilyResource
+from mcrit.storage.FamilyEntry import FamilyEntry
+
+
+class FamilyEntryActors(unittest.TestCase):
+    """#57: a family carries the actors it is attributed to"""
+
+    def test_round_trip_and_defaults(self):
+        entry = FamilyEntry(family_name="win.citadel", family_id=5, actors=["Actor A", "Actor B"])
+        self.assertEqual(["Actor A", "Actor B"], entry.toDict()["actors"])
+        self.assertEqual(["Actor A", "Actor B"], FamilyEntry.fromDict(entry.toDict()).actors)
+        legacy = entry.toDict()
+        del legacy["actors"]
+        self.assertEqual([], FamilyEntry.fromDict(legacy).actors)
+        self.assertEqual([], FamilyEntry(family_name="x").actors)
+
+    def test_normalisation(self):
+        self.assertEqual(["A", "B"], FamilyEntry.normalizeActors([" A ", "B", "A", "", "  "]))
+        self.assertEqual([], FamilyEntry.normalizeActors(None))
+
+
+class FamilyActorsRoute(unittest.TestCase):
+    def _put(self, body):
+        payload = json.dumps(body)
+        environ = falcon.testing.create_environ(path="/families/5", method="PUT", body=payload, headers={"Content-Type": "application/json"})
+        return falcon.Request(environ)
+
+    def test_actors_are_validated_and_passed_on(self):
+        index = MagicMock()
+        index.modifyFamily.return_value = True
+        resp = falcon.Response()
+        FamilyResource(index).on_put(self._put({"actors": ["Actor A", "APT-1"]}), resp, 5)
+        self.assertEqual(falcon.HTTP_202, resp.status)
+        index.modifyFamily.assert_called_once_with(5, {"actors": ["Actor A", "APT-1"]}, force_recalculation=True)
+        # a comma separated string is accepted too, malformed names are not
+        index.modifyFamily.reset_mock()
+        FamilyResource(index).on_put(self._put({"actors": "one, two"}), falcon.Response(), 5)
+        index.modifyFamily.assert_called_once_with(5, {"actors": ["one", " two"]}, force_recalculation=True)
+        index.modifyFamily.reset_mock()
+        resp = falcon.Response()
+        FamilyResource(index).on_put(self._put({"actors": ["<script>"]}), resp, 5)
+        self.assertEqual(falcon.HTTP_400, resp.status)
+        index.modifyFamily.assert_not_called()
+        resp = falcon.Response()
+        FamilyResource(index).on_put(self._put({"actors": [1, 2]}), resp, 5)
+        self.assertEqual(falcon.HTTP_400, resp.status)
+
+
+class FamilyActorsClient(unittest.TestCase):
+    def test_the_client_sends_actors_as_json(self):
+        client = McritClient("http://mcrit.test")
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"status": "successful", "data": {"message": "Family modified."}}
+        with patch("mcrit.client.McritClient.requests.put", return_value=response) as put:
+            client.modifyFamily(5, actors=["A", "B"])
+        self.assertEqual({"actors": ["A", "B"]}, put.call_args.kwargs["json"])
+        with patch("mcrit.client.McritClient.requests.put", return_value=response) as put:
+            client.modifyFamily(5, family_name="new_name", is_library=True)
+        self.assertEqual({"family_name": "new_name", "is_library": True}, put.call_args.kwargs["json"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testMinHashIndex.py
+++ b/tests/testMinHashIndex.py
@@ -1,5 +1,6 @@
-#!/usr/bin/python
+import json
 
+#!/usr/bin/python
 import logging
 import os
 import unittest
@@ -160,6 +161,25 @@ class EscaperProvenanceTestSuite(unittest.TestCase):
         export_data = index.getExportData()
         export_data["config"].update(config_overrides)
         return export_data
+
+    def testExportCarriesFamilyActorsAndImportMergesThem(self):
+        # #57
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "example_report.smda")) as fjson:
+            report = SmdaReport.fromDict(json.load(fjson))
+        assert report is not None
+        report.family = "actors_family"
+        source = MinHashIndex(config)
+        sample_entry = source.getStorage().addSmdaReport(report)
+        assert sample_entry is not None
+        source.getStorage().modifyFamily(sample_entry.family_id, {"actors": ["Actor A"]})
+        export_data = source.getExportData()
+        self.assertEqual({sample_entry.family_id: ["Actor A"]}, export_data["family_actors"])
+        target = MinHashIndex(config)
+        target_family_id = target.getStorage().addFamily("actors_family")
+        target.getStorage().modifyFamily(target_family_id, {"actors": ["Actor B"]})
+        # through JSON, as an export file travels: the family ids become strings
+        target.addImportData(json.loads(json.dumps(export_data)))
+        self.assertEqual(["Actor B", "Actor A"], target.getStorage().getFamily(target_family_id).actors)
 
     def testImportOfMatchingEscaperIsNotFlagged(self):
         index = MinHashIndex(config)

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -109,6 +109,16 @@ class MemoryStorageTest(TestCase):
         # family deletion
         self.storage.deleteFamily(4)
         self.assertEqual(None, self.storage.getFamilyId("family_1a"))
+        # actors (#57): set, normalised, kept through a rename, cleared
+        self.assertEqual([], self.storage.getFamily(2).actors)
+        self.assertTrue(self.storage.modifyFamily(2, {"actors": [" Actor A", "Actor B", "Actor A"]}))
+        self.assertEqual(["Actor A", "Actor B"], self.storage.getFamily(2).actors)
+        self.storage.modifyFamily(2, {"family_name": "family_2b", "actors": ["Actor C"]})
+        family_2b = self.storage.getFamilyId("family_2b")
+        self.assertIsNotNone(family_2b)
+        self.assertTrue(self.storage.modifyFamily(family_2b, {"actors": []}))
+        self.assertEqual([], self.storage.getFamily(family_2b).actors)
+        self.assertFalse(self.storage.modifyFamily(4242, {"actors": ["x"]}))
 
     def testSampleHandling(self):
         self.storage.clearStorage()

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -119,6 +119,16 @@ class MemoryStorageTest(TestCase):
         self.assertTrue(self.storage.modifyFamily(family_2b, {"actors": []}))
         self.assertEqual([], self.storage.getFamily(family_2b).actors)
         self.assertFalse(self.storage.modifyFamily(4242, {"actors": ["x"]}))
+        # a rename keeps the actors, and a rename onto an existing family merges both lists
+        self.storage.modifyFamily(family_2b, {"actors": ["Actor D"]})
+        self.storage.modifyFamily(family_2b, {"family_name": "family_2c"})
+        family_2c = self.storage.getFamilyId("family_2c")
+        self.assertEqual(["Actor D"], self.storage.getFamily(family_2c).actors)
+        self.assertEqual(None, self.storage.getFamilyId("family_2b"))
+        other = self.storage.addFamily("family_2d")
+        self.storage.modifyFamily(other, {"actors": ["Actor E", "Actor D"]})
+        self.storage.modifyFamily(family_2c, {"family_name": "family_2d"})
+        self.assertEqual(["Actor E", "Actor D"], self.storage.getFamily(other).actors)
 
     def testSampleHandling(self):
         self.storage.clearStorage()


### PR DESCRIPTION
Closes #57 (consider adding actors field to families).

## Changes

- `FamilyEntry` carries `actors`, a list of names, in `toDict()`/`fromDict()`; families stored before this read as an empty list, so no migration. `FamilyEntry.normalizeActors()` strips, drops empties and duplicates, keeps the order given.
- Both storage backends accept `actors` in `modifyFamily()`; the MongoDB one sets the field on the family document.
- `PUT /families/{id}` accepts `actors` as a list of names (1 to 64 characters of letters, digits, spaces, dots, dashes, underscores; a comma separated string is accepted too); anything else is a 400 without touching the family.
- `McritClient.modifyFamily(family_id, actors=[...])`; an empty list clears them. The client now sends the update as JSON, since a list does not survive form encoding; the route reads `req.media` and takes both.
- Exports carry `family_actors` (family id to names, only for families that have any); imports merge them into what the target instance already knows for the remapped family. An importer without the key ignores it, an export without the key imports as before.

## Verification

- `tests/testFamilyActors.py` (5 tests): entry round trip and legacy default; normalisation; route validation and pass-through, including the comma separated form and two rejected shapes; the client's JSON body with and without actors.
- `tests/testStorage.py` (both backends): set, normalised, kept through a rename, cleared, unknown family refused.
- `tests/testMinHashIndex.py`: an export carries the actors and an import through JSON merges them with the target's own.
- Full suite: 209 passed; `ruff check`, `ruff format --check`, `ty check` clean.
- Live verification on the MongoDB-backed instance follows in a comment.

