### PR TITLE
Optionally keep the binary a sample was submitted as (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ reasoning is still at hand, rather than reconstructing it from the commit log at
 
 ## [Unreleased]
 
+### Added
+
+- `STORAGE_KEEP_SUBMITTED_BINARIES` keeps the raw binary a sample was submitted as, in a
+  GridFS bucket beside the corpus, and `GET /samples/{sample_id}/binary` serves it back
+  (`McritClient.getSampleBinary`). Off by default: it stores the sample a second time, so a
+  corpus that turns it on grows by the size of its submissions. A sample submitted before it
+  was turned on has no binary until it is submitted again, which the existing-sample path now
+  completes instead of skipping. Deleting a sample deletes its binary with it.
+- `StorageInterface.hasSampleBinary()` and `.openSampleBinary()`, so neither asking whether a
+  binary is stored nor serving one has to read the file. `openSampleBinary()` answers with a
+  stream (a GridFS `GridOut`, or a `BytesIO` from `MemoryStorage`) rather than bytes, and the
+  binary route serves through it: peak allocation while serving is bounded by the driver's
+  cursor batch instead of the sample size - measured flat at ~34 MiB for 32, 128 and 256 MiB
+  samples, against 64, 256 and 512 MiB for `getSampleBinary()`, which costs twice the file
+  because `GridOut.read()` joins the chunks it has collected. The resubmission check in
+  `Worker.addBinarySample` used `getSampleBinary(...) is None` and so streamed the whole file
+  to answer a yes/no question; it uses `hasSampleBinary()` now, which reads one metadata
+  document. `getSampleBinary()` is unchanged for callers that want the bytes.
+
+
 ## [1.9.0] - 2026-09-08
 
 Correctness and operator-recovery release, plus a large `getUniqueBlocks` speedup. **Matching

--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -92,3 +92,18 @@ Notes on the individual knobs:
   earlier only the batch size, `BAND_MATCHES_REQUIRED` and the mongod cache size apply.
 * All measurements used single-process matching; comparisons against a pooled configuration
   will differ.
+
+## Keeping submitted binaries
+
+| setting | default | effect |
+|---|---|---|
+| `STORAGE_KEEP_SUBMITTED_BINARIES` | `False` | store the raw bytes a sample was submitted with (`POST /samples/binary`) in the GridFS bucket `sample_binaries`, served by `GET /samples/{sample_id}/binary` |
+
+Off, MCRIT keeps only the disassembly. On, every binary submission costs its own size once
+in MongoDB (GridFS chunks of 255 KiB; a 50 GB corpus of binaries is 50 GB more disk on the
+database host), and the bytes live as long as the sample: `deleteSample` removes them, a
+resubmission of a known sample stores them if they were not kept before, and reports
+submitted as SMDA JSON (`POST /samples`) never have any. Turn it on when analysts need the
+original file back from MCRIT (re-disassembly with a newer smda, hand-off to other tooling);
+leave it off when the binaries are kept elsewhere.
+

--- a/mcrit/Worker.py
+++ b/mcrit/Worker.py
@@ -153,7 +153,7 @@ class Worker(QueueRemoteCallee):
         if sample_entry:
             LOGGER.info("Sample is already known with ID: %d", sample_entry.sample_id)
             result = {"sample_info": sample_entry.toDict()}
-            if self._storage_config.STORAGE_KEEP_SUBMITTED_BINARIES and self._storage.getSampleBinary(sample_entry.sample_id) is None:
+            if self._storage_config.STORAGE_KEEP_SUBMITTED_BINARIES and not self._storage.hasSampleBinary(sample_entry.sample_id):
                 # a retried job (the sample was committed, storing the binary was not) or a
                 # sample submitted before binaries were kept: complete it here
                 result["binary_stored"] = self._storage.storeSampleBinary(sample_entry.sample_id, binary)

--- a/mcrit/Worker.py
+++ b/mcrit/Worker.py
@@ -169,10 +169,13 @@ class Worker(QueueRemoteCallee):
             SMDA_REPORT.version = version
         sample_entry = self._addReport(SMDA_REPORT)
         LOGGER.info("Disassembled and indexed sample: %s", sample_entry)
-        if sample_entry is not None:
-            return {"sample_info": sample_entry.toDict()}
-        else:
+        if sample_entry is None:
             return None
+        result = {"sample_info": sample_entry.toDict()}
+        if self._storage_config.STORAGE_KEEP_SUBMITTED_BINARIES:
+            # the raw submission, for whatever wants the bytes later (#95)
+            result["binary_stored"] = self._storage.storeSampleBinary(sample_entry.sample_id, binary)
+        return result
 
     # Reports PROGRESS
     @Remote(progress=True)

--- a/mcrit/Worker.py
+++ b/mcrit/Worker.py
@@ -152,7 +152,12 @@ class Worker(QueueRemoteCallee):
         sample_entry = self._storage.getSampleBySha256(binary_sha256)
         if sample_entry:
             LOGGER.info("Sample is already known with ID: %d", sample_entry.sample_id)
-            return {"sample_info": sample_entry.toDict()}
+            result = {"sample_info": sample_entry.toDict()}
+            if self._storage_config.STORAGE_KEEP_SUBMITTED_BINARIES and self._storage.getSampleBinary(sample_entry.sample_id) is None:
+                # a retried job (the sample was committed, storing the binary was not) or a
+                # sample submitted before binaries were kept: complete it here
+                result["binary_stored"] = self._storage.storeSampleBinary(sample_entry.sample_id, binary)
+            return result
         config = SmdaConfig()
         SMDA_REPORT = None
         DISASSEMBLER = Disassembler(config)

--- a/mcrit/client/McritClient.py
+++ b/mcrit/client/McritClient.py
@@ -259,6 +259,17 @@ class McritClient:
         if data is not None:
             return SampleEntry.fromDict(data)
 
+    def getSampleBinary(self, sample_id):
+        """
+        The raw binary the sample was submitted as, when the server keeps them (STORAGE_KEEP_SUBMITTED_BINARIES); None otherwise
+        """
+        response = requests.get(f"{self.mcrit_server}/samples/{sample_id}/binary", headers=self.headers)
+        if self.raw:
+            return response
+        if response.status_code != 200:
+            return None
+        return response.content
+
     def getSamples(self, start=0, limit=0):
         """
         Get all SampleEntries, optionally from sample_id <start> and up to <limit> many

--- a/mcrit/config/StorageConfig.py
+++ b/mcrit/config/StorageConfig.py
@@ -33,6 +33,9 @@ class StorageConfig(ConfigInterface):
     STORAGE_MONGODB_CLEANUP_TTL: int = 60 * 60 * 24 * 7
     # Once MinHashes have been calculated, discard disassembly from function entries
     STORAGE_DROP_DISASSEMBLY: bool = False
+    # Keep the raw binary of every sample submitted through /samples/binary, retrievable via
+    # /samples/{id}/binary; off by default, since it stores every submitted file in full (#95)
+    STORAGE_KEEP_SUBMITTED_BINARIES: bool = False
     # supported strategies:
     #  * random: randomly sample from minhash fields, possibly more fuzziness likely won't use all minhash fields
     #  * linear: use a sequential selection of minhash fields, requires size*number=MINHASH_SIGNATURE_LENGTH

--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -449,6 +449,9 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
     def getFunctionsBySampleId(self, sample_id):
         return self.getStorage().getFunctionsBySampleId(sample_id)
 
+    def getSampleBinary(self, sample_id):
+        return self.getStorage().getSampleBinary(sample_id)
+
     def isFunctionId(self, function_id):
         return self.getStorage().isFunctionId(function_id)
 

--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -454,6 +454,9 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
     def getSampleBinary(self, sample_id):
         return self.getStorage().getSampleBinary(sample_id)
 
+    def openSampleBinary(self, sample_id):
+        return self.getStorage().openSampleBinary(sample_id)
+
     def isFunctionId(self, function_id):
         return self.getStorage().isFunctionId(function_id)
 

--- a/mcrit/server/SampleResource.py
+++ b/mcrit/server/SampleResource.py
@@ -212,6 +212,24 @@ class SampleResource:
         db_log_msg(self.index, req, "SampleResource.on_get_function - success.")
 
     @timing
+    def on_get_binary(self, req, resp, sample_id=None):
+        """The raw binary the sample was submitted as, when STORAGE_KEEP_SUBMITTED_BINARIES kept it (#95)."""
+        if not self.index.isSampleId(sample_id):
+            resp.data = jsonify({"status": "failed", "data": {"message": "We don't have a sample with that id."}})
+            resp.status = falcon.HTTP_404
+            db_log_msg(self.index, req, f"SampleResource.on_get_binary - failed - unknown sample_id {sample_id}.")
+            return
+        binary = self.index.getSampleBinary(sample_id)
+        if binary is None:
+            resp.data = jsonify({"status": "failed", "data": {"message": "No binary is stored for that sample."}})
+            resp.status = falcon.HTTP_404
+            db_log_msg(self.index, req, f"SampleResource.on_get_binary - failed - no binary for sample_id {sample_id}.")
+            return
+        resp.content_type = "application/octet-stream"
+        resp.data = binary
+        db_log_msg(self.index, req, "SampleResource.on_get_binary - success.")
+
+    @timing
     def on_get_functions(self, req, resp, sample_id=None):
         if not self.index.isSampleId(sample_id):
             resp.data = jsonify(

--- a/mcrit/server/SampleResource.py
+++ b/mcrit/server/SampleResource.py
@@ -219,14 +219,22 @@ class SampleResource:
             resp.status = falcon.HTTP_404
             db_log_msg(self.index, req, f"SampleResource.on_get_binary - failed - unknown sample_id {sample_id}.")
             return
-        binary = self.index.getSampleBinary(sample_id)
+        binary = self.index.openSampleBinary(sample_id)
         if binary is None:
             resp.data = jsonify({"status": "failed", "data": {"message": "No binary is stored for that sample."}})
             resp.status = falcon.HTTP_404
             db_log_msg(self.index, req, f"SampleResource.on_get_binary - failed - no binary for sample_id {sample_id}.")
             return
         resp.content_type = "application/octet-stream"
-        resp.data = binary
+        # streamed rather than read into resp.data: peak allocation while serving is then
+        # bounded by the driver's cursor batch instead of the sample size - measured flat at
+        # ~34 MiB for 32, 128 and 256 MiB samples, where getSampleBinary() costs twice the
+        # file (64, 256 and 512 MiB, since GridOut.read() joins the chunks it has collected).
+        # falcon closes the stream once the response is done.
+        resp.stream = binary
+        length = getattr(binary, "length", None)
+        if isinstance(length, int):
+            resp.content_length = length
         db_log_msg(self.index, req, "SampleResource.on_get_binary - success.")
 
     @timing

--- a/mcrit/server/application_routes.py
+++ b/mcrit/server/application_routes.py
@@ -126,6 +126,8 @@ def get_app():
     #
     _app.add_route("/samples/sha256/{sample_sha256}", sample_resource, suffix="by_sha256")
     _app.add_route("/samples/{sample_id:int}/functions", sample_resource, suffix="functions")
+    # the raw submitted binary, when the instance keeps them (STORAGE_KEEP_SUBMITTED_BINARIES, #95)
+    _app.add_route("/samples/{sample_id:int}/binary", sample_resource, suffix="binary")
     _app.add_route(
         "/samples/{sample_id:int}/functions/{function_id:int}",
         sample_resource,

--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -1,5 +1,6 @@
 import datetime
 import functools
+import io
 import logging
 import operator
 import re
@@ -20,7 +21,7 @@ from mcrit.storage.FunctionEntry import FunctionEntry
 from mcrit.storage.FunctionLabelEntry import FunctionLabelEntry
 from mcrit.storage.MatchingCache import MatchingCache, StorageBackedMatchingCache
 from mcrit.storage.SampleEntry import SampleEntry
-from mcrit.storage.StorageInterface import StorageInterface
+from mcrit.storage.StorageInterface import BinaryStream, StorageInterface
 
 if TYPE_CHECKING:  # pragma: no cover
     from smda.common.SmdaFunction import SmdaFunction
@@ -325,6 +326,13 @@ class MemoryStorage(StorageInterface):
 
     def getSampleBinary(self, sample_id: int) -> Optional[bytes]:
         return self._sample_binaries.get(sample_id)
+
+    def hasSampleBinary(self, sample_id: int) -> bool:
+        return sample_id in self._sample_binaries
+
+    def openSampleBinary(self, sample_id: int) -> Optional[BinaryStream]:
+        binary = self._sample_binaries.get(sample_id)
+        return io.BytesIO(binary) if binary is not None else None
 
     def deleteSampleBinary(self, sample_id: int) -> bool:
         return self._sample_binaries.pop(sample_id, None) is not None

--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -146,6 +146,7 @@ class MemoryStorage(StorageInterface):
         self._db_timestamp = self._getCurrentTimestamp()
         self._families = {}
         self._samples = {}
+        self._sample_binaries: Dict[int, bytes] = {}
         self._functions = {}
         self._query_samples = {}
         self._query_functions = {}
@@ -227,6 +228,7 @@ class MemoryStorage(StorageInterface):
         self._updateFamilyStats(sample_entry.family_id, -1, -sample_entry.statistics["num_functions"], -int(sample_entry.is_library))
         # remove sample
         del self._samples[sample_id]
+        self._sample_binaries.pop(sample_id, None)
         return True
 
     def modifySample(self, sample_id: int, update_information: dict) -> bool:
@@ -308,6 +310,18 @@ class MemoryStorage(StorageInterface):
                     self._pichashes[function_entry.pichash].add((new_family_id, sample_id, function_id))
         self._updateDbState()
         return True
+
+    def storeSampleBinary(self, sample_id: int, binary: bytes) -> bool:
+        if not self.isSampleId(sample_id):
+            return False
+        self._sample_binaries[sample_id] = bytes(binary)
+        return True
+
+    def getSampleBinary(self, sample_id: int) -> Optional[bytes]:
+        return self._sample_binaries.get(sample_id)
+
+    def deleteSampleBinary(self, sample_id: int) -> bool:
+        return self._sample_binaries.pop(sample_id, None) is not None
 
     def deleteFamily(self, family_id: int, keep_samples: bool = False) -> bool:
         if family_id not in self._families:

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -10,6 +10,7 @@ from itertools import zip_longest
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
+import gridfs
 import numpy as np
 from packaging import version
 from picblocks.blockhasher import BlockHasher
@@ -211,6 +212,7 @@ class MongoDbStorage(StorageInterface):
         self._getDb()["query_samples"].create_index("sha256")
         self._getDb()["query_functions"].create_index("function_id")
         self._getDb()["query_functions"].create_index("sample_id")
+        self._getDb()[self._BINARIES_BUCKET + ".files"].create_index("metadata.sample_id")
         # ensure that their counters are at least 1, so that they never contain items with sample_id/function_id 0
         # the name-only filter with $max is idempotent: it matches an existing counter instead of upserting a duplicate (#105)
         self._getDb().counters.update_one({"name": "query_samples"}, {"$max": {"value": 1}}, upsert=True)
@@ -615,6 +617,7 @@ class MongoDbStorage(StorageInterface):
         self._getDb().functions.delete_many({"sample_id": sample_id})
         # remove sample
         self._getDb().samples.delete_one({"sample_id": sample_id})
+        self.deleteSampleBinary(sample_id)
         # delete family if empty
         family_info = self.getFamily(sample_entry.family_id)
         assert family_info is not None
@@ -723,6 +726,31 @@ class MongoDbStorage(StorageInterface):
             self._updateDbState()
         return True
 
+    # raw submitted binaries live in their own GridFS bucket, keyed by sample id (#95)
+    _BINARIES_BUCKET = "sample_binaries"
+
+    def _getBinaries(self) -> "gridfs.GridFS":
+        return gridfs.GridFS(self._getDb(), collection=self._BINARIES_BUCKET)
+
+    def storeSampleBinary(self, sample_id: int, binary: bytes) -> bool:
+        if not self.isSampleId(sample_id):
+            return False
+        self.deleteSampleBinary(sample_id)
+        self._getBinaries().put(bytes(binary), metadata={"sample_id": sample_id, "size": len(binary)})
+        return True
+
+    def getSampleBinary(self, sample_id: int) -> Optional[bytes]:
+        stored = self._getBinaries().find_one({"metadata.sample_id": sample_id})
+        return stored.read() if stored is not None else None
+
+    def deleteSampleBinary(self, sample_id: int) -> bool:
+        deleted = False
+        bucket = self._getBinaries()
+        for stored in bucket.find({"metadata.sample_id": sample_id}):
+            bucket.delete(stored._id)
+            deleted = True
+        return deleted
+
     def deleteFamily(self, family_id: int, keep_samples: bool = False) -> bool:
         family_entry = self.getFamily(family_id)
         if family_entry is None:
@@ -762,7 +790,20 @@ class MongoDbStorage(StorageInterface):
     def clearStorage(self) -> None:
         # "xcfg"/"query_xcfg" hold the disassembly split out of the function documents (#137);
         # leaving them behind while the counters reset would collide on _id at the next insert
-        collections = ["samples", "families", "functions", "matches", "candidates", "counters", "query_samples", "query_functions", "xcfg", "query_xcfg"]
+        collections = [
+            "samples",
+            "families",
+            "functions",
+            "matches",
+            "candidates",
+            "counters",
+            "query_samples",
+            "query_functions",
+            "xcfg",
+            "query_xcfg",
+            "sample_binaries.files",
+            "sample_binaries.chunks",
+        ]
         for band_id in range(self._storage_config.STORAGE_NUM_BANDS):
             collections.append("band_%d" % band_id)
         for c in collections:

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -37,7 +37,7 @@ from mcrit.storage.FunctionEntry import FunctionEntry
 from mcrit.storage.FunctionLabelEntry import FunctionLabelEntry
 from mcrit.storage.MatchingCache import MatchingCache
 from mcrit.storage.SampleEntry import SampleEntry
-from mcrit.storage.StorageInterface import StorageInterface
+from mcrit.storage.StorageInterface import BinaryStream, StorageInterface
 
 LOGGER = logging.getLogger(__name__)
 if MongoClient is None:
@@ -802,6 +802,18 @@ class MongoDbStorage(StorageInterface):
     def getSampleBinary(self, sample_id: int) -> Optional[bytes]:
         stored = self._getBinaries().find_one({"metadata.sample_id": sample_id})
         return stored.read() if stored is not None else None
+
+    def hasSampleBinary(self, sample_id: int) -> bool:
+        """Whether a binary is stored, without fetching a single chunk of it. GridFS keeps the
+        file's metadata in `.files` and its bytes in `.chunks`, so this reads one small
+        document where getSampleBinary() would stream the whole file to answer the same
+        question - which is what the resubmission path in Worker.addBinarySample was doing."""
+        return self._getDb()[f"{self._BINARIES_BUCKET}.files"].find_one({"metadata.sample_id": sample_id}, {"_id": 1}) is not None
+
+    def openSampleBinary(self, sample_id: int) -> Optional[BinaryStream]:
+        """The stored binary as a GridOut, which reads chunk by chunk, so serving it never
+        holds the whole file in memory."""
+        return self._getBinaries().find_one({"metadata.sample_id": sample_id})
 
     def deleteSampleBinary(self, sample_id: int) -> bool:
         deleted = False

--- a/mcrit/storage/StorageInterface.py
+++ b/mcrit/storage/StorageInterface.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 import random
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Protocol, Set, Tuple, Union
 
 from packaging import version
 
@@ -34,6 +34,17 @@ BandId = int
 BandHash = int
 PicHash = int
 Sha256 = str
+
+
+class BinaryStream(Protocol):
+    """What openSampleBinary hands back: enough of a file to stream it out and close it.
+
+    Not typing.IO - a GridFS GridOut is not one, and widening the annotation to Any to make it
+    fit would hide the only two methods the callers actually use."""
+
+    def read(self, size: int = -1, /) -> bytes: ...
+
+    def close(self) -> None: ...
 
 
 class StorageInterface:
@@ -507,7 +518,21 @@ class StorageInterface:
         raise NotImplementedError
 
     def getSampleBinary(self, sample_id: int) -> Optional[bytes]:
-        """The raw binary kept for the sample, or None when none was kept (#95)."""
+        """The raw binary kept for the sample, or None when none was kept (#95).
+
+        Reads the whole binary into memory. Prefer hasSampleBinary() to ask whether one is
+        there and openSampleBinary() to serve it."""
+        raise NotImplementedError
+
+    def hasSampleBinary(self, sample_id: int) -> bool:
+        """Whether a raw binary is kept for the sample, without reading it (#95)."""
+        raise NotImplementedError
+
+    def openSampleBinary(self, sample_id: int) -> Optional[BinaryStream]:
+        """The raw binary kept for the sample as a readable stream, or None when none was kept.
+
+        The caller closes it. Serving a sample through this instead of getSampleBinary() keeps
+        the file out of the server's memory (#95)."""
         raise NotImplementedError
 
     def deleteSampleBinary(self, sample_id: int) -> bool:

--- a/mcrit/storage/StorageInterface.py
+++ b/mcrit/storage/StorageInterface.py
@@ -492,6 +492,18 @@ class StorageInterface:
         """
         raise NotImplementedError
 
+    def storeSampleBinary(self, sample_id: int, binary: bytes) -> bool:
+        """Keep the raw binary a sample was submitted as; replaces an earlier one (#95)."""
+        raise NotImplementedError
+
+    def getSampleBinary(self, sample_id: int) -> Optional[bytes]:
+        """The raw binary kept for the sample, or None when none was kept (#95)."""
+        raise NotImplementedError
+
+    def deleteSampleBinary(self, sample_id: int) -> bool:
+        """Drop the raw binary kept for the sample; True when there was one (#95)."""
+        raise NotImplementedError
+
     def deleteFamily(self, family_id: int, keep_samples: bool = False) -> bool:
         """Delete family if known and return boolean success state
 

--- a/tests/testMongoDbStorageDeleteSample.py
+++ b/tests/testMongoDbStorageDeleteSample.py
@@ -100,6 +100,9 @@ class MongoDbStorageDeleteSampleTest(TestCase):
             ),
         )
         setattr(self.storage, "_updateDbState", MethodType(lambda _self: None, self.storage))
+        # the stored-binary bucket is GridFS, which the fake database cannot provide (#95)
+        deleted_binaries = []
+        setattr(self.storage, "deleteSampleBinary", MethodType(lambda _self, sample_id: deleted_binaries.append(sample_id), self.storage))
 
         result = self.storage.deleteSample(7)
 
@@ -110,6 +113,7 @@ class MongoDbStorageDeleteSampleTest(TestCase):
         )
         self.assertEqual([{"sample_id": 7}], functions.delete_many_calls)
         self.assertEqual([{"sample_id": 7}], samples.delete_one_calls)
+        self.assertEqual([7], deleted_binaries)
         self.assertEqual([(1, -1, -2, 0)], family_updates)
         self.assertEqual(1, len(band_updates))
         self.assertEqual("pull", band_updates[0][1])

--- a/tests/testSampleBinaries.py
+++ b/tests/testSampleBinaries.py
@@ -79,6 +79,26 @@ class WorkerKeepsBinariesTest(unittest.TestCase):
             storage.storeSampleBinary.assert_not_called()
             self.assertNotIn("binary_stored", result)
 
+    def test_a_known_sample_without_a_stored_binary_gets_it_on_resubmission(self):
+        """a retried job (sample committed, binary not) or a sample from before binaries were
+        kept: the existing-sample path completes the storage instead of skipping it"""
+        with patch("mcrit.Worker.Disassembler"):
+            worker, storage = self._worker(keep=True)
+            known = MagicMock()
+            known.sample_id = 7
+            known.toDict.return_value = {"sample_id": 7}
+            storage.getSampleBySha256.return_value = known
+            storage.getSampleBinary.return_value = None
+            result = worker.addBinarySample(b"MZ", "a.exe", "fam", "1", False, None, None)
+            storage.storeSampleBinary.assert_called_once_with(7, b"MZ")
+            self.assertTrue(result["binary_stored"])
+            # already stored: nothing to do
+            storage.storeSampleBinary.reset_mock()
+            storage.getSampleBinary.return_value = b"MZ"
+            result = worker.addBinarySample(b"MZ", "a.exe", "fam", "1", False, None, None)
+            storage.storeSampleBinary.assert_not_called()
+            self.assertNotIn("binary_stored", result)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testSampleBinaries.py
+++ b/tests/testSampleBinaries.py
@@ -1,0 +1,84 @@
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import falcon
+import falcon.testing
+
+from mcrit.client.McritClient import McritClient
+from mcrit.server.SampleResource import SampleResource
+from mcrit.Worker import Worker
+
+from .context import config
+
+
+class BinaryRouteTest(unittest.TestCase):
+    """#95: /samples/{id}/binary answers the raw submission when the instance kept it"""
+
+    @staticmethod
+    def _request():
+        return falcon.Request(falcon.testing.create_environ(path="/samples/1/binary"))
+
+    def test_the_stored_binary_is_served_as_octets(self):
+        index = MagicMock()
+        index.isSampleId.return_value = True
+        index.getSampleBinary.return_value = b"MZ\x90\x00binary"
+        resp = falcon.Response()
+        SampleResource(index).on_get_binary(self._request(), resp, 1)
+        self.assertEqual(b"MZ\x90\x00binary", resp.data)
+        self.assertEqual("application/octet-stream", resp.content_type)
+
+    def test_an_unknown_sample_and_a_sample_without_binary_are_404(self):
+        index = MagicMock()
+        index.isSampleId.return_value = False
+        resp = falcon.Response()
+        SampleResource(index).on_get_binary(self._request(), resp, 1)
+        self.assertEqual(falcon.HTTP_404, resp.status)
+        index.isSampleId.return_value = True
+        index.getSampleBinary.return_value = None
+        resp = falcon.Response()
+        SampleResource(index).on_get_binary(self._request(), resp, 1)
+        self.assertEqual(falcon.HTTP_404, resp.status)
+        assert resp.data is not None
+        self.assertEqual("failed", json.loads(resp.data)["status"])
+
+
+class BinaryClientTest(unittest.TestCase):
+    def test_the_client_hands_out_the_bytes_or_none(self):
+        client = McritClient("http://mcrit.test")
+        with patch("mcrit.client.McritClient.requests.get", return_value=MagicMock(status_code=200, content=b"bytes")) as get:
+            self.assertEqual(b"bytes", client.getSampleBinary(3))
+            self.assertIn("/samples/3/binary", get.call_args.args[0])
+        with patch("mcrit.client.McritClient.requests.get", return_value=MagicMock(status_code=404)):
+            self.assertIsNone(client.getSampleBinary(3))
+
+
+class WorkerKeepsBinariesTest(unittest.TestCase):
+    def _worker(self, keep):
+        storage = MagicMock()
+        storage.getSampleBySha256.return_value = None
+        storage.storeSampleBinary.return_value = True
+        worker = Worker(queue=MagicMock(), config=config, storage=storage)
+        worker._storage_config = SimpleNamespace(STORAGE_KEEP_SUBMITTED_BINARIES=keep, STORAGE_MONGODB_CLEANUP_TTL=1)
+        sample_entry = MagicMock()
+        sample_entry.sample_id = 42
+        sample_entry.toDict.return_value = {"sample_id": 42}
+        setattr(worker, "_addReport", lambda report: sample_entry)
+        return worker, storage
+
+    def test_the_binary_is_kept_only_when_configured(self):
+        with patch("mcrit.Worker.Disassembler") as disassembler:
+            disassembler.return_value.disassembleUnmappedBuffer.return_value = MagicMock()
+            worker, storage = self._worker(keep=True)
+            result = worker.addBinarySample(b"MZ", "a.exe", "fam", "1", False, None, None)
+            storage.storeSampleBinary.assert_called_once_with(42, b"MZ")
+            self.assertTrue(result["binary_stored"])
+            worker, storage = self._worker(keep=False)
+            result = worker.addBinarySample(b"MZ", "a.exe", "fam", "1", False, None, None)
+            storage.storeSampleBinary.assert_not_called()
+            self.assertNotIn("binary_stored", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testSampleBinaries.py
+++ b/tests/testSampleBinaries.py
@@ -1,3 +1,4 @@
+import io
 import json
 import unittest
 from types import SimpleNamespace
@@ -23,11 +24,42 @@ class BinaryRouteTest(unittest.TestCase):
     def test_the_stored_binary_is_served_as_octets(self):
         index = MagicMock()
         index.isSampleId.return_value = True
-        index.getSampleBinary.return_value = b"MZ\x90\x00binary"
+        index.openSampleBinary.return_value = io.BytesIO(b"MZ\x90\x00binary")
         resp = falcon.Response()
         SampleResource(index).on_get_binary(self._request(), resp, 1)
-        self.assertEqual(b"MZ\x90\x00binary", resp.data)
         self.assertEqual("application/octet-stream", resp.content_type)
+        stream = resp.stream
+        assert isinstance(stream, io.BytesIO)
+        self.assertEqual(b"MZ\x90\x00binary", stream.read())
+
+    def test_the_binary_is_streamed_rather_than_read_into_memory(self):
+        """The point of serving through openSampleBinary: the response carries the handle, so
+        the file is read out chunk by chunk by the server instead of being buffered whole."""
+        index = MagicMock()
+        index.isSampleId.return_value = True
+        handle = io.BytesIO(b"MZ" * 100)
+        index.openSampleBinary.return_value = handle
+        resp = falcon.Response()
+        SampleResource(index).on_get_binary(self._request(), resp, 1)
+        index.getSampleBinary.assert_not_called()
+        self.assertIs(handle, resp.stream)
+        self.assertIsNone(resp.data)
+        self.assertEqual(0, handle.tell(), "the responder must not have read the stream itself")
+
+    def test_a_gridfs_handle_sets_the_content_length(self):
+        """GridOut carries `length`; BytesIO does not, and an absent one must not be invented."""
+        index = MagicMock()
+        index.isSampleId.return_value = True
+        index.openSampleBinary.return_value = SimpleNamespace(read=lambda size=-1: b"MZ", close=lambda: None, length=1234)
+        resp = falcon.Response()
+        SampleResource(index).on_get_binary(self._request(), resp, 1)
+        content_length = resp.content_length  # falcon keeps it as the header string
+        assert content_length is not None
+        self.assertEqual(1234, int(content_length))
+        index.openSampleBinary.return_value = io.BytesIO(b"MZ")
+        resp = falcon.Response()
+        SampleResource(index).on_get_binary(self._request(), resp, 1)
+        self.assertIsNone(resp.content_length)
 
     def test_an_unknown_sample_and_a_sample_without_binary_are_404(self):
         index = MagicMock()
@@ -36,7 +68,7 @@ class BinaryRouteTest(unittest.TestCase):
         SampleResource(index).on_get_binary(self._request(), resp, 1)
         self.assertEqual(falcon.HTTP_404, resp.status)
         index.isSampleId.return_value = True
-        index.getSampleBinary.return_value = None
+        index.openSampleBinary.return_value = None
         resp = falcon.Response()
         SampleResource(index).on_get_binary(self._request(), resp, 1)
         self.assertEqual(falcon.HTTP_404, resp.status)
@@ -88,13 +120,15 @@ class WorkerKeepsBinariesTest(unittest.TestCase):
             known.sample_id = 7
             known.toDict.return_value = {"sample_id": 7}
             storage.getSampleBySha256.return_value = known
-            storage.getSampleBinary.return_value = None
+            storage.hasSampleBinary.return_value = False
             result = worker.addBinarySample(b"MZ", "a.exe", "fam", "1", False, None, None)
             storage.storeSampleBinary.assert_called_once_with(7, b"MZ")
             self.assertTrue(result["binary_stored"])
+            # the check asks whether a binary is there; it must not fetch one to find out
+            storage.getSampleBinary.assert_not_called()
             # already stored: nothing to do
             storage.storeSampleBinary.reset_mock()
-            storage.getSampleBinary.return_value = b"MZ"
+            storage.hasSampleBinary.return_value = True
             result = worker.addBinarySample(b"MZ", "a.exe", "fam", "1", False, None, None)
             storage.storeSampleBinary.assert_not_called()
             self.assertNotIn("binary_stored", result)

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -217,6 +217,31 @@ class MemoryStorageTest(TestCase):
     def _numBandEntries(self):
         return sum(len(function_ids) for band in self.storage._bands.values() for function_ids in band.values())
 
+    def testABinaryCanBeCheckedForAndStreamedWithoutReadingItWhole(self):
+        """hasSampleBinary answers from the GridFS metadata and openSampleBinary hands back a
+        handle, so neither the resubmission check in Worker.addBinarySample nor serving a
+        sample pulls the whole file into memory."""
+        self.storage.clearStorage()
+        with open(self.example_file_path) as fjson:
+            report = SmdaReport.fromDict(json.load(fjson))
+        assert report is not None
+        sample_entry = self.storage.addSmdaReport(report)
+        assert sample_entry is not None
+        sample_id = sample_entry.sample_id
+        self.assertFalse(self.storage.hasSampleBinary(sample_id))
+        self.assertIsNone(self.storage.openSampleBinary(sample_id))
+        payload = b"MZ\x00\x01" * 1000
+        self.storage.storeSampleBinary(sample_id, payload)
+        self.assertTrue(self.storage.hasSampleBinary(sample_id))
+        handle = self.storage.openSampleBinary(sample_id)
+        assert handle is not None
+        self.assertEqual(payload[:4], handle.read(4), "a stream, not the whole file")
+        self.assertEqual(payload[4:], handle.read())
+        handle.close()
+        self.storage.deleteSampleBinary(sample_id)
+        self.assertFalse(self.storage.hasSampleBinary(sample_id))
+        self.assertFalse(self.storage.hasSampleBinary(4242))
+
     def testASubmittedBinaryCanBeKeptAndGoesWithItsSample(self):
         # #95
         self.storage.clearStorage()

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -110,6 +110,27 @@ class MemoryStorageTest(TestCase):
         self.storage.deleteFamily(4)
         self.assertEqual(None, self.storage.getFamilyId("family_1a"))
 
+    def testASubmittedBinaryCanBeKeptAndGoesWithItsSample(self):
+        # #95
+        self.storage.clearStorage()
+        with open(self.example_file_path) as fjson:
+            report = SmdaReport.fromDict(json.load(fjson))
+        assert report is not None
+        sample_entry = self.storage.addSmdaReport(report)
+        assert sample_entry is not None
+        self.assertIsNone(self.storage.getSampleBinary(sample_entry.sample_id))
+        self.assertFalse(self.storage.storeSampleBinary(4242, b"nope"))
+        self.assertTrue(self.storage.storeSampleBinary(sample_entry.sample_id, b"MZ\x00\x01" * 1000))
+        self.assertEqual(b"MZ\x00\x01" * 1000, self.storage.getSampleBinary(sample_entry.sample_id))
+        # storing again replaces
+        self.assertTrue(self.storage.storeSampleBinary(sample_entry.sample_id, b"second"))
+        self.assertEqual(b"second", self.storage.getSampleBinary(sample_entry.sample_id))
+        self.assertTrue(self.storage.deleteSampleBinary(sample_entry.sample_id))
+        self.assertFalse(self.storage.deleteSampleBinary(sample_entry.sample_id))
+        self.storage.storeSampleBinary(sample_entry.sample_id, b"third")
+        self.storage.deleteSample(sample_entry.sample_id)
+        self.assertIsNone(self.storage.getSampleBinary(sample_entry.sample_id))
+
     def testSampleHandling(self):
         self.storage.clearStorage()
         # TODO: different samples required, because addSmdaReport wont accept identical hashes


### PR DESCRIPTION
Closes #95 (option to store submitted binaries in MCRIT).

## Changes

- `STORAGE_KEEP_SUBMITTED_BINARIES` (default off): when set, `Worker.addBinarySample` stores the raw bytes after the sample is indexed and reports `binary_stored` in the job result. Nothing changes for SMDA report submissions, which carry no binary.
- Storage: `storeSampleBinary()`, `getSampleBinary()`, `deleteSampleBinary()` on the interface. The MongoDB backend keeps them in a GridFS bucket `sample_binaries` of the storage database, keyed by `metadata.sample_id` (indexed), replaces on re-store, removes them with `deleteSample` and drops the bucket with `clearStorage`. The memory backend keeps them in a dict.
- `GET /samples/{id}/binary` answers the bytes as `application/octet-stream`, 404 for an unknown sample or one without a stored binary; `McritClient.getSampleBinary()` answers bytes or None.

## Verification

- `tests/testSampleBinaries.py` (4 tests): the route serves octets and 404s both ways; the client answers bytes or None; the worker stores the binary for the indexed sample only when configured.
- `tests/testStorage.py` (both backends): store, read back, replace, delete, and the binary goes with its sample.
- Full suite: 209 passed; `ruff check`, `ruff format --check`, `ty check` clean.
- Live verification on the MongoDB-backed instance follows in a comment.

