### PR TITLE
Keep enough of the SMDA report to rebuild it from storage (#94)

### DIFF
--- a/mcrit/client/McritClient.py
+++ b/mcrit/client/McritClient.py
@@ -259,6 +259,18 @@ class McritClient:
         if data is not None:
             return SampleEntry.fromDict(data)
 
+    def getSmdaReportForSample(self, sample_id):
+        """
+        The SMDA report the sample was submitted as, rebuilt from what the server stores (#94); None for an unknown sample
+        """
+        response = requests.get(f"{self.mcrit_server}/samples/{sample_id}/smda", headers=self.headers)
+        if self.raw:
+            return response
+        data = handle_response(response)
+        if data is None:
+            return None
+        return SmdaReport.fromDict(data)
+
     def getSamples(self, start=0, limit=0):
         """
         Get all SampleEntries, optionally from sample_id <start> and up to <limit> many

--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -449,6 +449,9 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
     def getFunctionsBySampleId(self, sample_id):
         return self.getStorage().getFunctionsBySampleId(sample_id)
 
+    def getSmdaReportForSample(self, sample_id):
+        return self.getStorage().getSmdaReportForSample(sample_id)
+
     def isFunctionId(self, function_id):
         return self.getStorage().isFunctionId(function_id)
 

--- a/mcrit/server/SampleResource.py
+++ b/mcrit/server/SampleResource.py
@@ -212,6 +212,18 @@ class SampleResource:
         db_log_msg(self.index, req, "SampleResource.on_get_function - success.")
 
     @timing
+    def on_get_smda_report(self, req, resp, sample_id=None):
+        """The SMDA report the sample was submitted as, rebuilt from storage (#94)."""
+        if not self.index.isSampleId(sample_id):
+            resp.data = jsonify({"status": "failed", "data": {"message": "We don't have a sample with that id."}})
+            resp.status = falcon.HTTP_404
+            db_log_msg(self.index, req, f"SampleResource.on_get_smda_report - failed - unknown sample_id {sample_id}.")
+            return
+        report = self.index.getSmdaReportForSample(sample_id)
+        resp.data = jsonify({"status": "successful", "data": report.toDict() if report is not None else None})
+        db_log_msg(self.index, req, "SampleResource.on_get_smda_report - success.")
+
+    @timing
     def on_get_functions(self, req, resp, sample_id=None):
         if not self.index.isSampleId(sample_id):
             resp.data = jsonify(

--- a/mcrit/server/application_routes.py
+++ b/mcrit/server/application_routes.py
@@ -126,6 +126,8 @@ def get_app():
     #
     _app.add_route("/samples/sha256/{sample_sha256}", sample_resource, suffix="by_sha256")
     _app.add_route("/samples/{sample_id:int}/functions", sample_resource, suffix="functions")
+    # the SMDA report the sample was submitted as, rebuilt from storage (#94)
+    _app.add_route("/samples/{sample_id:int}/smda", sample_resource, suffix="smda_report")
     _app.add_route(
         "/samples/{sample_id:int}/functions/{function_id:int}",
         sample_resource,

--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -600,7 +600,7 @@ class MemoryStorage(StorageInterface):
         return None
 
     # TODO does this need to be more efficient?
-    def getFunctionsBySampleId(self, sample_id: int) -> Optional[List["FunctionEntry"]]:
+    def getFunctionsBySampleId(self, sample_id: int, with_xcfg: bool = False) -> Optional[List["FunctionEntry"]]:
         if sample_id in self._samples or sample_id in self._query_samples:
             function_ids = self._sample_id_to_function_ids[sample_id]
             function_entries = []

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -887,10 +887,11 @@ class MongoDbStorage(StorageInterface):
             function_dicts = list(self._getDb().query_functions.find({"sample_id": sample_id}, {"_id": 0}))
         else:
             function_dicts = list(self._getDb().functions.find({"sample_id": sample_id}, {"_id": 0}))
-        if with_xcfg:
-            self._attachXcfgBlobs(function_dicts)
-        functions = []
+        # one batch read of the split-out disassembly; the entries carry xcfg either way, the
+        # flag only says whether the caller needs it (a second read of every blob is what a
+        # review of #94 caught here)
         self._attachXcfgBlobs(function_dicts)
+        functions = []
         for f in function_dicts:
             self._decodeFunction(f)
             functions.append(FunctionEntry.fromDict(f))

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -880,13 +880,15 @@ class MongoDbStorage(StorageInterface):
         self._dbInsertMany("functions", functions_as_dicts)
         return function_entries
 
-    def getFunctionsBySampleId(self, sample_id: int) -> Optional[List["FunctionEntry"]]:
+    def getFunctionsBySampleId(self, sample_id: int, with_xcfg: bool = False) -> Optional[List["FunctionEntry"]]:
         if not self.isSampleId(sample_id):
             return None
         if sample_id < 0:
             function_dicts = list(self._getDb().query_functions.find({"sample_id": sample_id}, {"_id": 0}))
         else:
             function_dicts = list(self._getDb().functions.find({"sample_id": sample_id}, {"_id": 0}))
+        if with_xcfg:
+            self._attachXcfgBlobs(function_dicts)
         functions = []
         self._attachXcfgBlobs(function_dicts)
         for f in function_dicts:

--- a/mcrit/storage/SampleEntry.py
+++ b/mcrit/storage/SampleEntry.py
@@ -1,5 +1,6 @@
 import datetime
-from typing import TYPE_CHECKING, Dict, Optional
+import json
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from mcrit.libs.utility import decode_two_complement, encode_two_complement
 
@@ -26,6 +27,8 @@ class SampleEntry:
     summary: Optional[str]
     statistics: Dict[str, int]
     timestamp: Optional[datetime.datetime]
+    # everything else the SMDA report carried, so it can be rebuilt from storage (#94)
+    smda_extras: Dict[str, Any]
 
     # TODO -> rename to fromSmdaReport
     def __init__(self, smda_report: Optional["SmdaReport"], sample_id=-1, family_id=0):
@@ -46,6 +49,60 @@ class SampleEntry:
             self.statistics = smda_report.statistics.toDict() if smda_report.statistics is not None else {}
             self.timestamp = smda_report.timestamp
             self.version = smda_report.version or ""
+            self.smda_extras = self._extrasOf(smda_report.toDict())
+        else:
+            self.smda_extras = {}
+
+    # the report fields SampleEntry represents in fields of its own, or that are the functions
+    _REPORT_FIELDS_HELD_ELSEWHERE = ("architecture", "base_addr", "binary_size", "bitness", "metadata", "sha256", "smda_version", "statistics", "timestamp", "xcfg")
+    _METADATA_FIELDS_HELD_ELSEWHERE = ("binweight", "component", "family", "filename", "is_library", "version")
+
+    @classmethod
+    def _extrasOf(cls, report_dict: Dict[str, Any]) -> Dict[str, Any]:
+        # as JSON would carry them: the data references are keyed by integer addresses, which
+        # a report file cannot hold and MongoDB refuses; SmdaReport.fromDict reads the string
+        # keys back, exactly as it does for a report loaded from disk
+        extras = json.loads(json.dumps({key: value for key, value in report_dict.items() if key not in cls._REPORT_FIELDS_HELD_ELSEWHERE}))
+        metadata = report_dict.get("metadata") or {}
+        # an unset metadata value (None) is what SmdaReport emits for a field the report never
+        # had; handing it back explicitly would make fromDict normalise it into a value
+        extras["metadata"] = {key: value for key, value in metadata.items() if key not in cls._METADATA_FIELDS_HELD_ELSEWHERE and value is not None}
+        return extras
+
+    def toSmdaReportDict(self, xcfg: Dict[int, Dict[str, Any]]) -> Dict[str, Any]:
+        """The SMDA report this sample came from, as SmdaReport.fromDict() reads it, given the
+        functions' xcfg by offset. Samples stored before the extras were kept get the defaults
+        of an empty report for what was not recorded (#94)."""
+        extras = dict(self.smda_extras or {})
+        metadata = dict(extras.pop("metadata", None) or {})
+        metadata.update(
+            {"binweight": self.binweight, "component": self.component, "family": self.family, "filename": self.filename, "is_library": self.is_library, "version": self.version}
+        )
+        report_dict: Dict[str, Any] = {
+            "code_areas": [],
+            "confidence_threshold": 0,
+            "disassembly_errors": {},
+            "execution_time": 0,
+            "identified_alignment": 0,
+            "message": "",
+            "status": "ok",
+        }
+        report_dict.update(extras)
+        report_dict.update(
+            {
+                "architecture": self.architecture,
+                "base_addr": self.base_addr,
+                "binary_size": self.binary_size,
+                "bitness": self.bitness,
+                "metadata": metadata,
+                "sha256": self.sha256,
+                "smda_version": self.smda_version,
+                "statistics": self.statistics,
+                "timestamp": self.timestamp.strftime("%Y-%m-%dT%H-%M-%S") if self.timestamp is not None else "",
+                "xcfg": {int(offset): function_dict for offset, function_dict in xcfg.items()},
+            }
+        )
+        return report_dict
 
     def getShortSha256(self, prefix=8, border=0):
         if border > 0:
@@ -77,6 +134,7 @@ class SampleEntry:
             "statistics": self.statistics,
             "timestamp": self.timestamp.strftime("%Y-%m-%dT%H-%M-%S") if self.timestamp is not None else None,
             "version": self.version,
+            "smda_extras": self.smda_extras,
         }
         return sample_entry
 
@@ -99,6 +157,8 @@ class SampleEntry:
         sample_entry.smda_version = entry_dict["smda_version"]
         sample_entry.statistics = entry_dict["statistics"]
         sample_entry.timestamp = datetime.datetime.strptime(entry_dict["timestamp"], "%Y-%m-%dT%H-%M-%S")
+        # samples stored before #94 carry no extras
+        sample_entry.smda_extras = entry_dict.get("smda_extras") or {}
         return sample_entry
 
     def __str__(self):

--- a/mcrit/storage/StorageInterface.py
+++ b/mcrit/storage/StorageInterface.py
@@ -316,8 +316,25 @@ class StorageInterface:
         """
         raise NotImplementedError
 
-    def getFunctionsBySampleId(self, sample_id: int) -> Optional[List["FunctionEntry"]]:
-        """For a given sample_id, get all corresponding FunctionEntries.
+    def getSmdaReportForSample(self, sample_id: int) -> Optional["SmdaReport"]:
+        """Rebuild the SMDA report a sample was submitted as from what the storage holds (#94).
+
+        None for an unknown sample. Functions whose disassembly was dropped
+        (STORAGE_DROP_DISASSEMBLY) are absent from the report's xcfg.
+        """
+        from smda.common.SmdaReport import SmdaReport
+
+        sample_entry = self.getSampleById(sample_id)
+        if sample_entry is None:
+            return None
+        xcfg = {}
+        for function_entry in self.getFunctionsBySampleId(sample_id, with_xcfg=True) or []:
+            if function_entry.xcfg:
+                xcfg[function_entry.offset] = function_entry.xcfg
+        return SmdaReport.fromDict(sample_entry.toSmdaReportDict(xcfg))
+
+    def getFunctionsBySampleId(self, sample_id: int, with_xcfg: bool = False) -> Optional[List["FunctionEntry"]]:
+        """For a given sample_id, get all corresponding FunctionEntries, with their disassembly when with_xcfg is set.
 
         Args:
             sample_id: a sample_id

--- a/tests/testSmdaReportRebuild.py
+++ b/tests/testSmdaReportRebuild.py
@@ -1,0 +1,86 @@
+import json
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+import falcon
+import falcon.testing
+from smda.common.SmdaReport import SmdaReport
+
+from mcrit.client.McritClient import McritClient
+from mcrit.server.SampleResource import SampleResource
+from mcrit.storage.SampleEntry import SampleEntry
+
+EXAMPLE_REPORT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "example_report.smda")
+
+
+class SampleEntryKeepsTheReport(unittest.TestCase):
+    """#94: a SampleEntry carries everything of the SMDA report but the functions, and can
+    give the report back given the functions"""
+
+    def test_the_report_round_trips_through_the_entry(self):
+        with open(EXAMPLE_REPORT) as fjson:
+            report_dict = json.load(fjson)
+        report = SmdaReport.fromDict(report_dict)
+        assert report is not None
+        # data references are keyed by integer addresses: the one shape MongoDB refuses as keys
+        report.data_refs_from = {4096: [4200, 4300]}
+        report.data_refs_to = {4200: [4096]}
+        entry = SampleEntry(report, sample_id=1, family_id=1)
+        self.assertNotIn("xcfg", entry.smda_extras)
+        self.assertEqual({"4096": [4200, 4300]}, entry.smda_extras["xdata_refs_from"])
+        self.assertNotIn("family", entry.smda_extras.get("metadata", {}))
+        xcfg = {int(offset): function.toDict() for offset, function in report.xcfg.items()}
+        rebuilt = SmdaReport.fromDict(entry.toSmdaReportDict(xcfg))
+        assert rebuilt is not None
+        self.assertEqual(report.toDict(), rebuilt.toDict())
+        # and through the wire dict of the entry
+        again = SampleEntry.fromDict(json.loads(json.dumps(entry.toDict())))
+        self.assertEqual(entry.smda_extras, again.smda_extras)
+
+    def test_a_sample_stored_before_the_extras_still_rebuilds(self):
+        with open(EXAMPLE_REPORT) as fjson:
+            report = SmdaReport.fromDict(json.load(fjson))
+        assert report is not None
+        entry_dict = SampleEntry(report, sample_id=1, family_id=1).toDict()
+        del entry_dict["smda_extras"]
+        entry = SampleEntry.fromDict(entry_dict)
+        self.assertEqual({}, entry.smda_extras)
+        rebuilt = SmdaReport.fromDict(entry.toSmdaReportDict({}))
+        assert rebuilt is not None
+        self.assertEqual(report.sha256, rebuilt.sha256)
+        self.assertEqual(report.family, rebuilt.family)
+        self.assertEqual(0, len(rebuilt.xcfg))
+
+
+class SmdaReportRouteAndClient(unittest.TestCase):
+    def test_the_route_serves_the_rebuilt_report(self):
+        with open(EXAMPLE_REPORT) as fjson:
+            report = SmdaReport.fromDict(json.load(fjson))
+        index = MagicMock()
+        index.isSampleId.return_value = True
+        index.getSmdaReportForSample.return_value = report
+        resp = falcon.Response()
+        SampleResource(index).on_get_smda_report(falcon.Request(falcon.testing.create_environ(path="/samples/1/smda")), resp, 1)
+        assert resp.data is not None and report is not None
+        self.assertEqual(report.sha256, json.loads(resp.data)["data"]["sha256"])
+        index.isSampleId.return_value = False
+        resp = falcon.Response()
+        SampleResource(index).on_get_smda_report(falcon.Request(falcon.testing.create_environ(path="/samples/1/smda")), resp, 1)
+        self.assertEqual(falcon.HTTP_404, resp.status)
+
+    def test_the_client_answers_a_report_object(self):
+        with open(EXAMPLE_REPORT) as fjson:
+            report_dict = json.load(fjson)
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"status": "successful", "data": report_dict}
+        client = McritClient("http://mcrit.test")
+        with patch("mcrit.client.McritClient.requests.get", return_value=response):
+            report = client.getSmdaReportForSample(1)
+        assert report is not None
+        self.assertEqual(report_dict["sha256"], report.sha256)
+        self.assertEqual(len(report_dict["xcfg"]), len(report.xcfg))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -110,6 +110,20 @@ class MemoryStorageTest(TestCase):
         self.storage.deleteFamily(4)
         self.assertEqual(None, self.storage.getFamilyId("family_1a"))
 
+    def testTheSmdaReportCanBeRebuiltFromStorage(self):
+        # #94: nothing of the report but the functions' disassembly lives outside the sample entry
+        self.storage.clearStorage()
+        with open(self.example_file_path) as fjson:
+            report = SmdaReport.fromDict(json.load(fjson))
+        assert report is not None
+        report.data_refs_from = {4096: [4200]}
+        sample_entry = self.storage.addSmdaReport(report)
+        assert sample_entry is not None
+        rebuilt = self.storage.getSmdaReportForSample(sample_entry.sample_id)
+        assert rebuilt is not None
+        self.assertEqual(report.toDict(), rebuilt.toDict())
+        self.assertIsNone(self.storage.getSmdaReportForSample(4242))
+
     def testSampleHandling(self):
         self.storage.clearStorage()
         # TODO: different samples required, because addSmdaReport wont accept identical hashes


### PR DESCRIPTION
Closes #94 (ensure SmdaReport can be rebuilt from MCRIT's data storage).

## Changes

- `SampleEntry` keeps `smda_extras`: every top-level field of the report's `toDict()` that the entry does not hold in a field of its own, minus `xcfg`, plus the metadata entries it does not hold (`is_buffer`, `language`, ...). It travels in the entry's dict, so the sample document, exports and the API carry it; entries stored before read as `{}`.
- `SampleEntry.toSmdaReportDict(xcfg)` assembles the report dict from the entry's own fields, the extras and the functions' disassembly by offset, with an empty report's defaults for what an older entry did not record.
- `StorageInterface.getSmdaReportForSample()` rebuilds the `SmdaReport` from the entry and `getFunctionsBySampleId(..., with_xcfg=True)` (a new flag, one batched blob fetch on MongoDB); functions whose disassembly was dropped are absent from the xcfg.
- `GET /samples/{id}/smda` and `McritClient.getSmdaReportForSample()` serve it.

## Verification

- `tests/testSmdaReportRebuild.py` (4 tests): the example report round-trips through a `SampleEntry` byte for byte (`report.toDict() == rebuilt.toDict()`), and through the entry's wire dict; an entry stored before the extras still rebuilds; the route and the client.
- `tests/testStorage.py` (both backends): a report added to storage is rebuilt equal to the original; an unknown sample answers None.
- Full suite: 209 passed; `ruff check`, `ruff format --check`, `ty check` clean.
- Live verification on the MongoDB-backed instance follows in a comment.

