### PR TITLE
Rehash only the samples an older smda escaper hashed (#142)

### DIFF
--- a/mcrit/Worker.py
+++ b/mcrit/Worker.py
@@ -303,9 +303,22 @@ class Worker(QueueRemoteCallee):
             "num_functions_dropped": 0,
             "num_functions_rehashed": 0,
         }
+        report["num_samples_skipped"] = 0
         for sample_id in stale_sample_ids:
+            # hash first, drop second: a sample whose disassembly is gone (STORAGE_DROP_DISASSEMBLY)
+            # cannot be rehashed, and its old minhashes are still better than none
+            function_entries = self._storage.getFunctionsBySampleId(sample_id) or []
+            hashable = [function_entry for function_entry in function_entries if function_entry.xcfg]
+            minhashes = self.calculateMinHashes(hashable) if hashable else []
+            if not minhashes:
+                LOGGER.warning("Repairing MinHashes: sample %d has no disassembly to rehash from, keeping its minhashes.", sample_id)
+                report["num_samples_skipped"] += 1
+                progress_reporter.step()
+                continue
             report["num_functions_dropped"] += self._storage.deleteMinHashesForSample(sample_id)
-            report["num_functions_rehashed"] += self.updateMinHashesForSample(sample_id) or 0
+            self._storage.addMinHashes(minhashes)
+            self._storage.setMinHashVersionForSamples(SmdaConfig().VERSION, [sample_id])
+            report["num_functions_rehashed"] += len(minhashes)
             report["num_samples_repaired"] += 1
             progress_reporter.step()
         return report

--- a/mcrit/Worker.py
+++ b/mcrit/Worker.py
@@ -271,7 +271,44 @@ class Worker(QueueRemoteCallee):
     @Remote(progress=True)
     def recalculateMinHashes(self, progress_reporter=NoProgressReporter()):
         self._storage.deleteAllMinHashes(progress_reporter=progress_reporter)
-        return self.updateMinHashes(None, progress_reporter=progress_reporter)
+        num_updated = self.updateMinHashes(None, progress_reporter=progress_reporter)
+        self._storage.setMinHashVersionForSamples(SmdaConfig().VERSION)
+        return num_updated
+
+    @staticmethod
+    def getMinHashCompatibilityThreshold() -> str:
+        """The oldest smda whose escaper produces the same minhashes as the running one."""
+        smda_config = SmdaConfig()
+        return getattr(smda_config, "ESCAPER_DOWNWARD_COMPATIBILITY", None) or smda_config.VERSION
+
+    # Reports PROGRESS
+    @Remote(progress=True)
+    def repairMinHashes(self, progress_reporter=NoProgressReporter()):
+        """Rehash only the samples whose minhashes an older smda escaper produced (#142).
+
+        recalculateMinHashes drops every band collection and rehashes everything; this walks
+        the samples whose recorded minhash smda version is older than the escaper compatibility
+        threshold (or unrecorded), pulls their band entries, rehashes them and records the
+        running version, so the index stays serving throughout and a killed run costs one sample.
+        """
+        threshold = self.getMinHashCompatibilityThreshold()
+        stale_sample_ids = self._storage.getSamplesWithStaleMinHashes(threshold)
+        LOGGER.info("Repairing MinHashes: %d samples are stale against escaper compatibility %s.", len(stale_sample_ids), threshold)
+        progress_reporter.set_total(len(stale_sample_ids))
+        report = {
+            "compatibility_threshold": threshold,
+            "smda_version": SmdaConfig().VERSION,
+            "num_samples_stale": len(stale_sample_ids),
+            "num_samples_repaired": 0,
+            "num_functions_dropped": 0,
+            "num_functions_rehashed": 0,
+        }
+        for sample_id in stale_sample_ids:
+            report["num_functions_dropped"] += self._storage.deleteMinHashesForSample(sample_id)
+            report["num_functions_rehashed"] += self.updateMinHashesForSample(sample_id) or 0
+            report["num_samples_repaired"] += 1
+            progress_reporter.step()
+        return report
 
     # Reports PROGRESS
     @Remote(progress=True)
@@ -321,6 +358,10 @@ class Worker(QueueRemoteCallee):
             update_result = self.updateMinHashes([fe.function_id for fe in function_entries], progress_reporter=progress_reporter)
         else:
             LOGGER.info("Sample %d did not have any functions, proceeding.", sample_id)
+            update_result = 0
+        # which escaper produced them, so a later smda can tell whether they are stale (#142)
+        self._storage.setMinHashVersionForSamples(SmdaConfig().VERSION, [sample_id])
+        if not function_entries:
             return 0
         if self.config.STORAGE_CONFIG.STORAGE_DROP_DISASSEMBLY:
             self._storage.deleteXcfgForSampleId(sample_id)

--- a/mcrit/client/McritClient.py
+++ b/mcrit/client/McritClient.py
@@ -105,6 +105,15 @@ class McritClient:
             return response
         return handle_response(response)
 
+    def repairMinHashes(self):
+        """
+        Schedule a job that rehashes only the samples whose minhashes an older smda escaper produced (#142); answers the job id
+        """
+        response = requests.post(f"{self.mcrit_server}/repair_minhashes", headers=self.headers)
+        if self.raw:
+            return response
+        return handle_response(response)
+
     def recomputeFamilyStats(self):
         """
         Schedule a job that sets every family's sample/function counters from the collections (#151); answers the job id

--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -342,6 +342,7 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
     def recomputeFamilyStats(self):
     def recalculatePicHashes(self):
     def recalculateMinHashes(self):
+    def repairMinHashes(self):
     def getMatchesForReport(self, report):
     def getMatchesForSmdaReport(self, report_json, minhash_threshold=None):
     def getMatchesForMappedBinary(self, binary, base_address, minhash_threshold=None):
@@ -517,6 +518,10 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
         inline_xcfg_remaining = storage.hasInlineXcfgRemaining()
         if inline_xcfg_remaining is not None:
             status["status"]["inline_xcfg_remaining"] = inline_xcfg_remaining
+        # how many samples' minhashes an older escaper produced; repairMinHashes rehashes them (#142)
+        threshold = Worker.getMinHashCompatibilityThreshold()
+        status["status"]["minhash_compatibility_threshold"] = threshold
+        status["status"]["num_samples_with_stale_minhashes"] = storage.countSamplesWithStaleMinHashes(threshold)
         return status
 
     def getVersion(self):

--- a/mcrit/server/StatusResource.py
+++ b/mcrit/server/StatusResource.py
@@ -110,6 +110,13 @@ class StatusResource:
         return
 
     @timing
+    def on_post_repair_minhashes(self, req, resp):
+        job_id = self.index.repairMinHashes(force_recalculation=True)
+        resp.data = jsonify({"status": "successful", "data": job_id})
+        db_log_msg(self.index, req, "StatusResource.on_post_repair_minhashes - success.")
+        return
+
+    @timing
     def on_get_recalculate_minhashes(self, req, resp):
         index_report = self.index.recalculateMinHashes(force_recalculation=True)
         resp.data = jsonify({"status": "successful", "data": index_report})

--- a/mcrit/server/StatusResource.py
+++ b/mcrit/server/StatusResource.py
@@ -111,6 +111,7 @@ class StatusResource:
 
     @timing
     def on_post_repair_minhashes(self, req, resp):
+        """Schedule a job that rehashes only the samples whose minhashes an older smda escaper produced (see ``num_samples_with_stale_minhashes`` in the status). Answers the job id."""
         job_id = self.index.repairMinHashes(force_recalculation=True)
         resp.data = jsonify({"status": "successful", "data": job_id})
         db_log_msg(self.index, req, "StatusResource.on_post_repair_minhashes - success.")

--- a/mcrit/server/application_routes.py
+++ b/mcrit/server/application_routes.py
@@ -107,6 +107,8 @@ def get_app():
     _app.add_route("/recompute_family_stats", status_resource, suffix="recompute_family_stats")  # post
     # schedule a job that updates all function_entries where the pichash was possibly calculated with an outdated SMDA version
     _app.add_route("/recalculate_pichashes", status_resource, suffix="recalculate_pichashes")  # get
+    # schedule a job that rehashes only the samples whose minhashes an older smda escaper produced (#142)
+    _app.add_route("/repair_minhashes", status_resource, suffix="repair_minhashes")  # post
     # schedule a job that updates all function_entries where the minhash was possibly calculated with an outdated SMDA version
     _app.add_route("/recalculate_minhashes", status_resource, suffix="recalculate_minhashes")  # get
 

--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from itertools import zip_longest
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
+from packaging import version as packaging_version
 from picblocks.blockhasher import BlockHasher
 
 from mcrit.index.SearchCursor import FullSearchCursor
@@ -151,6 +152,7 @@ class MemoryStorage(StorageInterface):
         self._query_functions = {}
         self._pichashes = {}
         self._bands = {band_number: {} for band_number in range(self._storage_config.STORAGE_NUM_BANDS)}
+        self._minhash_versions: Dict[int, str] = {}
         self._counters = defaultdict(lambda: 0)
         # initialize query sample/function ids
         if self._counters["query_samples"] == 0:
@@ -333,6 +335,42 @@ class MemoryStorage(StorageInterface):
                 report["num_families_corrected"] += 1
                 report["corrections"][family_id] = {"before": stored, "after": actual}
         return report
+
+    def deleteMinHashesForSample(self, sample_id: int) -> int:
+        if not self.isSampleId(sample_id) or sample_id < 0:
+            return 0
+        num_hashed = 0
+        for function_id in self._sample_id_to_function_ids[sample_id]:
+            function_entry = self._functions[function_id]
+            minhash = function_entry.getMinHash(self._minhash_config.MINHASH_SIGNATURE_BITS)
+            if not minhash or not minhash.hasMinHash():
+                continue
+            num_hashed += 1
+            for band_number, band_hash in sorted(self.getBandHashesForMinHash(minhash).items()):
+                if band_hash in self._bands[band_number]:
+                    self._bands[band_number][band_hash] = [fid for fid in self._bands[band_number][band_hash] if fid != function_id]
+                    if not self._bands[band_number][band_hash]:
+                        del self._bands[band_number][band_hash]
+            function_entry.minhash = b""
+            function_entry.shingler_composition = {}
+        self._minhash_versions.pop(sample_id, None)
+        return num_hashed
+
+    def deleteAllMinHashes(self, progress_reporter=None) -> int:
+        num_deleted = 0
+        for sample_id in list(self._samples):
+            num_deleted += self.deleteMinHashesForSample(sample_id)
+        self._bands = {band_number: {} for band_number in self._bands}
+        return num_deleted
+
+    def setMinHashVersionForSamples(self, smda_version: str, sample_ids: Optional[List[int]] = None) -> None:
+        for sample_id in list(self._samples) if sample_ids is None else sample_ids:
+            if sample_id in self._samples:
+                self._minhash_versions[sample_id] = smda_version
+
+    def getSamplesWithStaleMinHashes(self, threshold_version: str) -> List[int]:
+        threshold = packaging_version.parse(threshold_version)
+        return sorted(sample_id for sample_id in self._samples if self._isStaleMinHashVersion(self._minhash_versions.get(sample_id), threshold))
 
     def deleteFamily(self, family_id: int, keep_samples: bool = False) -> bool:
         if family_id not in self._families:

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -197,6 +197,8 @@ class MongoDbStorage(StorageInterface):
         self._getDb()["samples"].create_index("sample_id")
         self._getDb()["samples"].create_index("sha256")
         self._getDb()["samples"].create_index("family_id")
+        # the stale-minhash count on /status is a distinct plus a count over this field (#142)
+        self._getDb()["samples"].create_index("minhash_smda_version")
         self._getDb()["families"].create_index("family_id")
         self._getDb()["families"].create_index("family_name")
         self._getDb()["functions"].create_index("function_id")

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -592,21 +592,7 @@ class MongoDbStorage(StorageInterface):
             self._getDb().query_samples.delete_one({"sample_id": sample_id})
             return True
         function_minhashes = self._getFunctionMinHashesBySampleId(sample_id)
-
-        # collect all band entries that need updating and pull all function_ids at once.
-        # might need to batch this into slices of function_ids again
-        minhashes_to_remove = {band_number: {} for band_number in range(self._storage_config.STORAGE_NUM_BANDS)}
-        for function_minhash in function_minhashes:
-            minhash = self._getMinHashFromStorage(function_minhash)
-            # remove minhash entries, if necessary
-            if not minhash or not minhash.hasMinHash():
-                continue
-            band_hashes = self.getBandHashesForMinHash(minhash)
-            for band_number, band_hash in sorted(band_hashes.items()):
-                if band_hash not in minhashes_to_remove[band_number]:
-                    minhashes_to_remove[band_number][band_hash] = []
-                minhashes_to_remove[band_number][band_hash].append(function_minhash["function_id"])
-        self._updateBands(minhashes_to_remove, method="pull")
+        self._pullBandEntries(function_minhashes)
 
         # remove functions
         self._deleteXcfgForFunctionIds([function_minhash["function_id"] for function_minhash in function_minhashes])
@@ -637,6 +623,53 @@ class MongoDbStorage(StorageInterface):
         )
         # the id came from elsewhere (an import): the counter must never hand it out again
         self._getDb().counters.update_one({"name": "families"}, {"$max": {"value": family_id + 1}}, upsert=True)
+
+    def _pullBandEntries(self, function_minhashes: List[Dict[str, Any]]) -> int:
+        """Take the given functions' minhashes out of the band index; how many had one."""
+        # collect all band entries that need updating and pull all function_ids at once.
+        # might need to batch this into slices of function_ids again
+        minhashes_to_remove: Dict[int, Dict[int, List[int]]] = {band_number: {} for band_number in range(self._storage_config.STORAGE_NUM_BANDS)}
+        num_hashed = 0
+        for function_minhash in function_minhashes:
+            minhash = self._getMinHashFromStorage(function_minhash)
+            # remove minhash entries, if necessary
+            if not minhash or not minhash.hasMinHash():
+                continue
+            num_hashed += 1
+            band_hashes = self.getBandHashesForMinHash(minhash)
+            for band_number, band_hash in sorted(band_hashes.items()):
+                if band_hash not in minhashes_to_remove[band_number]:
+                    minhashes_to_remove[band_number][band_hash] = []
+                minhashes_to_remove[band_number][band_hash].append(function_minhash["function_id"])
+        self._updateBands(minhashes_to_remove, method="pull")
+        return num_hashed
+
+    def deleteMinHashesForSample(self, sample_id: int) -> int:
+        if not self.isSampleId(sample_id) or sample_id < 0:
+            return 0
+        function_minhashes = self._getFunctionMinHashesBySampleId(sample_id)
+        num_hashed = self._pullBandEntries(function_minhashes)
+        self._getDb().functions.update_many({"sample_id": sample_id, "minhash": {"$ne": ""}}, {"$set": {"minhash": "", "minhash_shingle_composition": {}}})
+        self._getDb().samples.update_one({"sample_id": sample_id}, {"$unset": {"minhash_smda_version": ""}})
+        return num_hashed
+
+    def setMinHashVersionForSamples(self, smda_version: str, sample_ids: Optional[List[int]] = None) -> None:
+        query = {} if sample_ids is None else {"sample_id": {"$in": list(sample_ids)}}
+        self._getDb().samples.update_many(query, {"$set": {"minhash_smda_version": smda_version}})
+
+    def _staleMinHashVersionQuery(self, threshold_version: str) -> Dict[str, Any]:
+        """Samples carry few distinct recorded versions, so compare those instead of every document."""
+        threshold = version.parse(threshold_version)
+        recorded = self._getDb().samples.distinct("minhash_smda_version")
+        stale_values = [value for value in recorded if self._isStaleMinHashVersion(value, threshold)]
+        return {"$or": [{"minhash_smda_version": {"$exists": False}}, {"minhash_smda_version": {"$in": stale_values}}]}
+
+    def getSamplesWithStaleMinHashes(self, threshold_version: str) -> List[int]:
+        query = self._staleMinHashVersionQuery(threshold_version)
+        return sorted(document["sample_id"] for document in self._getDb().samples.find(query, {"sample_id": 1, "_id": 0}))
+
+    def countSamplesWithStaleMinHashes(self, threshold_version: str) -> int:
+        return self._getDb().samples.count_documents(self._staleMinHashVersionQuery(threshold_version))
 
     def _updateFamilyStats(self, family_id, num_samples_inc, num_functions_inc, num_library_samples_inc):
         result = self._getDb().families.update_one(

--- a/mcrit/storage/StorageInterface.py
+++ b/mcrit/storage/StorageInterface.py
@@ -2,6 +2,8 @@ import datetime
 import random
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 
+from packaging import version
+
 from mcrit.index.SearchCursor import FullSearchCursor
 from mcrit.index.SearchQueryTree import NodeType
 from mcrit.minhash.MinHash import MinHash
@@ -723,6 +725,35 @@ class StorageInterface:
             the number of minhashes indexed
         """
         raise NotImplementedError
+
+    @staticmethod
+    def _isStaleMinHashVersion(recorded_version: Optional[str], threshold) -> bool:
+        """A sample's minhashes are stale when the smda that escaped them is older than the
+        escaper compatibility threshold, or when no version was recorded at all (#142)."""
+        if not recorded_version:
+            return True
+        try:
+            return version.parse(recorded_version) < threshold
+        except Exception:
+            return True
+
+    def deleteMinHashesForSample(self, sample_id: int) -> int:
+        """Drop the minhashes of one sample's functions and their band entries, without touching
+        the rest of the index; how many functions had one (#142)."""
+        raise NotImplementedError
+
+    def setMinHashVersionForSamples(self, smda_version: str, sample_ids: Optional[List[int]] = None) -> None:
+        """Record which smda escaped the minhashes of the samples (all when None) (#142)."""
+        raise NotImplementedError
+
+    def getSamplesWithStaleMinHashes(self, threshold_version: str) -> List[int]:
+        """The samples whose minhashes were escaped by an smda older than the threshold, or
+        by an unrecorded one (#142)."""
+        raise NotImplementedError
+
+    def countSamplesWithStaleMinHashes(self, threshold_version: str) -> int:
+        """How many samples getSamplesWithStaleMinHashes would answer, for /status (#142)."""
+        return len(self.getSamplesWithStaleMinHashes(threshold_version))
 
     def deleteAllMinHashes(self, progress_reporter=None) -> int:
         """drop every minhash in all function_entries as a preparation for a full rebuild

--- a/tests/testMinHashRepair.py
+++ b/tests/testMinHashRepair.py
@@ -64,6 +64,22 @@ class SelectiveMinHashRepair(unittest.TestCase):
         self.assertEqual([], storage.getSamplesWithStaleMinHashes("4.4.5"))
         self.assertEqual(0, index.getStatus(with_pichash=False)["status"]["num_samples_with_stale_minhashes"])
 
+    def test_a_sample_whose_disassembly_is_gone_keeps_its_minhashes(self):
+        """hash first, drop second: without disassembly nothing could replace the old hashes"""
+        index, sample_entry = self._index_with_report()
+        storage = index.getStorage()
+        hashed_before = self._hashed_function_ids(index, sample_entry.sample_id)
+        storage.setMinHashVersionForSamples("4.0.0", [sample_entry.sample_id])
+        storage.deleteXcfgForSampleId(sample_entry.sample_id)
+        report = index.getResultForJob(index.repairMinHashes(force_recalculation=True))
+        self.assertEqual(1, report["num_samples_stale"])
+        self.assertEqual(1, report["num_samples_skipped"])
+        self.assertEqual(0, report["num_samples_repaired"])
+        self.assertEqual(0, report["num_functions_dropped"])
+        self.assertEqual(hashed_before, self._hashed_function_ids(index, sample_entry.sample_id))
+        # still stale: the next smda with disassembly at hand can repair it
+        self.assertEqual([sample_entry.sample_id], storage.getSamplesWithStaleMinHashes("4.4.5"))
+
     def test_a_sample_without_a_recorded_version_counts_as_stale(self):
         index, sample_entry = self._index_with_report()
         storage = index.getStorage()

--- a/tests/testMinHashRepair.py
+++ b/tests/testMinHashRepair.py
@@ -1,0 +1,102 @@
+import json
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+import falcon
+import falcon.testing
+from smda.common.SmdaReport import SmdaReport
+from smda.SmdaConfig import SmdaConfig
+
+from mcrit.client.McritClient import McritClient
+from mcrit.index.MinHashIndex import MinHashIndex
+from mcrit.server.StatusResource import StatusResource
+from mcrit.Worker import Worker
+
+from .context import config
+
+EXAMPLE_REPORT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "example_report.smda")
+
+
+class SelectiveMinHashRepair(unittest.TestCase):
+    """#142: only the samples an older escaper hashed are rehashed, and /status says how many
+    there are"""
+
+    def _index_with_report(self):
+        index = MinHashIndex(config)
+        with open(EXAMPLE_REPORT) as fjson:
+            report = SmdaReport.fromDict(json.load(fjson))
+        assert report is not None
+        sample_entry = index.getStorage().addSmdaReport(report)
+        assert sample_entry is not None
+        index.updateMinHashesForSample(sample_entry.sample_id, force_recalculation=True)
+        return index, sample_entry
+
+    def _hashed_function_ids(self, index, sample_id):
+        return sorted(f.function_id for f in index.getStorage().getFunctionsBySampleId(sample_id) if f.minhash)
+
+    def test_hashing_records_the_running_smda_and_a_repair_is_a_no_op(self):
+        index, sample_entry = self._index_with_report()
+        storage = index.getStorage()
+        self.assertGreater(len(self._hashed_function_ids(index, sample_entry.sample_id)), 0)
+        self.assertEqual([], storage.getSamplesWithStaleMinHashes(Worker.getMinHashCompatibilityThreshold()))
+        self.assertEqual(0, index.getStatus(with_pichash=False)["status"]["num_samples_with_stale_minhashes"])
+        report = index.getResultForJob(index.repairMinHashes(force_recalculation=True))
+        self.assertEqual(0, report["num_samples_stale"])
+        self.assertEqual(0, report["num_samples_repaired"])
+
+    def test_a_stale_sample_is_rehashed_in_place(self):
+        index, sample_entry = self._index_with_report()
+        storage = index.getStorage()
+        hashed_before = self._hashed_function_ids(index, sample_entry.sample_id)
+        bands_before = {band: dict(hashes) for band, hashes in storage._bands.items()}
+        storage.setMinHashVersionForSamples("4.0.0", [sample_entry.sample_id])
+        self.assertEqual([sample_entry.sample_id], storage.getSamplesWithStaleMinHashes("4.4.5"))
+        self.assertEqual(1, index.getStatus(with_pichash=False)["status"]["num_samples_with_stale_minhashes"])
+        report = index.getResultForJob(index.repairMinHashes(force_recalculation=True))
+        self.assertEqual(1, report["num_samples_repaired"])
+        self.assertEqual(len(hashed_before), report["num_functions_dropped"])
+        self.assertEqual(len(hashed_before), report["num_functions_rehashed"])
+        self.assertEqual(SmdaConfig().VERSION, report["smda_version"])
+        self.assertEqual(hashed_before, self._hashed_function_ids(index, sample_entry.sample_id))
+        # the same escaper gives the same band index back, without a rebuild
+        self.assertEqual(bands_before, {band: dict(hashes) for band, hashes in storage._bands.items()})
+        self.assertEqual([], storage.getSamplesWithStaleMinHashes("4.4.5"))
+        self.assertEqual(0, index.getStatus(with_pichash=False)["status"]["num_samples_with_stale_minhashes"])
+
+    def test_a_sample_without_a_recorded_version_counts_as_stale(self):
+        index, sample_entry = self._index_with_report()
+        storage = index.getStorage()
+        storage._minhash_versions.clear()
+        self.assertEqual([sample_entry.sample_id], storage.getSamplesWithStaleMinHashes("4.4.5"))
+        storage.setMinHashVersionForSamples("garbage", [sample_entry.sample_id])
+        self.assertEqual([sample_entry.sample_id], storage.getSamplesWithStaleMinHashes("4.4.5"))
+
+    def test_the_full_recalculation_records_the_version_for_every_sample(self):
+        index, sample_entry = self._index_with_report()
+        storage = index.getStorage()
+        storage._minhash_versions.clear()
+        index.getResultForJob(index.recalculateMinHashes(force_recalculation=True))
+        self.assertEqual([], storage.getSamplesWithStaleMinHashes("4.4.5"))
+
+
+class RepairRouteAndClient(unittest.TestCase):
+    def test_the_route_schedules_the_job(self):
+        index = MagicMock()
+        index.repairMinHashes.return_value = "0123456789abcdef01234567"
+        resp = falcon.Response()
+        StatusResource(index).on_post_repair_minhashes(falcon.Request(falcon.testing.create_environ(path="/repair_minhashes", method="POST")), resp)
+        assert resp.data is not None
+        self.assertEqual("0123456789abcdef01234567", json.loads(resp.data)["data"])
+        index.repairMinHashes.assert_called_once_with(force_recalculation=True)
+
+    def test_the_client_posts_and_answers_the_job_id(self):
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"status": "successful", "data": "0123456789abcdef01234567"}
+        with patch("mcrit.client.McritClient.requests.post", return_value=response) as post:
+            self.assertEqual("0123456789abcdef01234567", McritClient("http://mcrit.test").repairMinHashes())
+        self.assertIn("/repair_minhashes", post.call_args.args[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -185,6 +185,38 @@ class MemoryStorageTest(TestCase):
         family.num_samples = num_samples
         family.num_functions = num_functions
 
+    def testMinHashesOfOneSampleCanBeDroppedAndTheirVersionTracked(self):
+        # #142
+        self.storage.clearStorage()
+        with open(self.example_file_path) as fjson:
+            report = SmdaReport.fromDict(json.load(fjson))
+        assert report is not None
+        sample_entry = self.storage.addSmdaReport(report)
+        assert sample_entry is not None
+        sample_id = sample_entry.sample_id
+        minhashes = [MinHash(function_id=function_id, minhash_signature=[0x30 + function_id + index for index in range(10)], minhash_bits=8) for function_id in [0, 2, 3, 5, 7, 8]]
+        self.storage.addMinHashes(minhashes)
+        # nothing recorded yet: stale; recorded below the threshold: stale; at or above: current
+        self.assertEqual([sample_id], self.storage.getSamplesWithStaleMinHashes("4.4.5"))
+        self.assertEqual(1, self.storage.countSamplesWithStaleMinHashes("4.4.5"))
+        self.storage.setMinHashVersionForSamples("4.4.0", [sample_id])
+        self.assertEqual([sample_id], self.storage.getSamplesWithStaleMinHashes("4.4.5"))
+        self.storage.setMinHashVersionForSamples("4.4.5", [sample_id])
+        self.assertEqual([], self.storage.getSamplesWithStaleMinHashes("4.4.5"))
+        self.assertEqual(0, self.storage.countSamplesWithStaleMinHashes("4.4.5"))
+        self.storage.setMinHashVersionForSamples("4.9.9")  # all samples
+        self.assertEqual([], self.storage.getSamplesWithStaleMinHashes("4.9.9"))
+        # dropping the sample's minhashes empties its functions and the band index, and forgets the version
+        self.assertEqual(6, self.storage.deleteMinHashesForSample(sample_id))
+        self.assertTrue(all(not f.minhash for f in self.storage.getFunctionsBySampleId(sample_id)))
+        self.assertEqual(0, self._numBandEntries())
+        self.assertEqual([sample_id], self.storage.getSamplesWithStaleMinHashes("4.4.5"))
+        self.assertEqual(0, self.storage.deleteMinHashesForSample(sample_id))
+        self.assertEqual(0, self.storage.deleteMinHashesForSample(4242))
+
+    def _numBandEntries(self):
+        return sum(len(function_ids) for band in self.storage._bands.values() for function_ids in band.values())
+
     def testSampleHandling(self):
         self.storage.clearStorage()
         # TODO: different samples required, because addSmdaReport wont accept identical hashes
@@ -637,6 +669,10 @@ class MongoDbStorageTest(MemoryStorageTest):
             self.storage._updateFamilyStats(4242, 1, 10, 0)
         self.assertIn("has no document", logger.warning.call_args.args[0])
         self.assertEqual(4242, logger.warning.call_args.args[1])
+
+    def _numBandEntries(self):
+        db = self.storage._getDb()
+        return sum(len(d.get("function_ids", [])) for band_id in range(self.storage._storage_config.STORAGE_NUM_BANDS) for d in db["band_%d" % band_id].find({}))
 
     def _createSecondStorage(self):
         mcrit_config = McritConfig()


### PR DESCRIPTION
Closes #142 (the "escaper change" gaps). Gaps 1 and 3 of that issue are already handled by mcrit 1.7.0 and maintainer PR danielplohmann/mcrit#143; this covers the remaining one: a full `recalculateMinHashes` drops every band collection and rehashes the whole corpus, so an escaper change costs a full outage of the index.

## What changes

- Each sample now records which smda version escaped its minhashes (`minhash_smda_version`, set by `updateMinHashesForSample` and by the full recalculation).
- `/status` reports `minhash_compatibility_threshold` (smda's `ESCAPER_DOWNWARD_COMPATIBILITY`, falling back to its version) and `num_samples_with_stale_minhashes`. Samples with no recorded version count as stale, so an existing database shows its whole corpus as stale until one repair or full recalculation has run.
- `POST /repair_minhashes` (McritClient `repairMinHashes()`) schedules a job that walks only the stale samples, pulls their band entries, rehashes them one sample at a time and records the running version. The index keeps serving throughout, and a killed run costs one sample. The job result is a report with the threshold, smda version, samples stale/repaired and functions dropped/rehashed.
- Storage: `deleteMinHashesForSample`, `setMinHashVersionForSamples`, `getSamplesWithStaleMinHashes`, `countSamplesWithStaleMinHashes` on both backends. `deleteSample` shares the new `_pullBandEntries` helper. The Mongo stale query compares the few distinct recorded versions instead of scanning every sample document. `MemoryStorage` gains the `deleteAllMinHashes` the interface declares (its absence made the local-queue full recalculation fail silently).

## Verification

- New `tests/testMinHashRepair.py` (worker job on the local queue, route, client) and storage tests for both backends; full suite: 211 passed.
- ruff check/format and ty clean.
- Live verification against a running MongoDB instance is in the comment below.
