### PR TITLE
Store pichashes zero-padded so that hex order is numeric order (#145)

### DIFF
--- a/mcrit/index/MinHashIndex.py
+++ b/mcrit/index/MinHashIndex.py
@@ -503,6 +503,9 @@ class MinHashIndex(QueueRemoteCaller(Worker)):
                 "num_families": storage_stats["num_families"],
                 "num_functions": storage_stats["num_functions"],
                 "num_pichashes": storage_stats["num_pichashes"],
+                # False on an instance created before pichashes were stored zero-padded and not yet
+                # migrated (migrate_pichash_padding); range conditions and sorting by pichash need True (#145)
+                "pichash_padded": storage_stats.get("pichash_padded", True),
                 # minhashes are only comparable across functions escaped by the same smda; see
                 # mcrit/minhash/EscaperFingerprint.py for why this is worth surfacing
                 "smda_version": SMDA_VERSION,

--- a/mcrit/migrations/migrate_pichash_padding.py
+++ b/mcrit/migrations/migrate_pichash_padding.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Store pichashes zero-padded so that their hex order is their numeric order (#145).
+
+`functions._pichash` and `functions._picblockhashes[].hash` (and the same fields of
+`query_functions`) hold 64 bit values as hex strings. Written with `hex()`, they have a
+variable width ("0x4d2"), so a range condition or a sort on them orders "0x99" after
+"0x1000". Padding every value to 16 digits ("0x00000000000004d2") makes string order numeric
+order; the storage then allows range operators and sorting by pichash, which the search
+cursor needs to page a pichash-sorted function search.
+
+Modes:
+  pad     - the migration: rewrite every unpadded value in place, batched by function_id
+            (resumable: progress is a keyset cursor in a state document, a killed run costs
+            one batch). A final sweep catches documents the walk did not see, then the
+            settings flag `pichash_padded` is set, which switches every reader and writer
+            of the instance to the padded shape.
+  verify  - count the values that are still unpadded and check the flag against them;
+            exits 1 when the flag says padded but unpadded values remain.
+  unpad   - rollback: rewrite every value with `hex()` again and clear the flag.
+
+Stop the mcrit server and its workers before `pad`: while the flag is unset they keep
+writing unpadded values, which `pad` would have to be re-run for (it is idempotent, and
+`verify` reports leftovers). Storage reads the flag once per process, so restart them
+afterwards. Until the flag is set, all readers accept both widths, so the instance keeps
+answering correctly during the walk; only range and sort by pichash stay rejected.
+
+Usage:
+    python -m mcrit.migrations.migrate_pichash_padding --mode pad
+    python -m mcrit.migrations.migrate_pichash_padding --mode verify
+    python -m mcrit.migrations.migrate_pichash_padding --mode unpad
+"""
+
+import argparse
+import json
+import sys
+import time
+from datetime import UTC, datetime
+from typing import Any, Dict, List, Optional
+
+from pymongo import ASCENDING, MongoClient, UpdateOne
+
+from mcrit.config.McritConfig import McritConfig
+from mcrit.storage.MongoDbStorage import PICHASH_HEX_DIGITS, encode_pichash_value
+
+STATE_COLLECTION = "pichash_padding_state"
+COLLECTIONS = ("functions", "query_functions")
+PROJECTION = {"function_id": 1, "_pichash": 1, "_picblockhashes.hash": 1, "_id": 0}
+
+
+def log(message):
+    print("%s %s" % (datetime.now(UTC).strftime("%H:%M:%S"), message), flush=True)
+
+
+def unpadded_query(prefix: str = "") -> Dict[str, Any]:
+    """Values of fewer than 16 digits; anchored, so the index on the field serves it."""
+    return {prefix + "_pichash": {"$regex": "^0x[0-9a-f]{1,%d}$" % (PICHASH_HEX_DIGITS - 1)}}
+
+
+def unpadded_block_query() -> Dict[str, Any]:
+    return {"_picblockhashes.hash": {"$regex": "^0x[0-9a-f]{1,%d}$" % (PICHASH_HEX_DIGITS - 1)}}
+
+
+def padded_query() -> Dict[str, Any]:
+    return {"_pichash": {"$regex": "^0x[0-9a-f]{%d}$" % PICHASH_HEX_DIGITS}}
+
+
+def padded_block_query() -> Dict[str, Any]:
+    return {"_picblockhashes.hash": {"$regex": "^0x[0-9a-f]{%d}$" % PICHASH_HEX_DIGITS}}
+
+
+def rewrite(document: Dict[str, Any], padded: bool) -> Optional[UpdateOne]:
+    """The update that brings one document to the requested width, or None if it is there."""
+    update: Dict[str, Any] = {}
+    pichash = document.get("_pichash")
+    if isinstance(pichash, str):
+        wanted = encode_pichash_value(int(pichash, 16), padded)
+        if wanted != pichash:
+            update["_pichash"] = wanted
+    block_entries = document.get("_picblockhashes")
+    if block_entries:
+        wanted_hashes = [encode_pichash_value(int(entry["hash"], 16), padded) if isinstance(entry.get("hash"), str) else entry.get("hash") for entry in block_entries]
+        if wanted_hashes != [entry.get("hash") for entry in block_entries]:
+            # positional per-element $set keeps offset/length untouched and the array order stable
+            for position, wanted in enumerate(wanted_hashes):
+                if wanted != block_entries[position].get("hash"):
+                    update["_picblockhashes.%d.hash" % position] = wanted
+    if not update:
+        return None
+    return UpdateOne({"function_id": document["function_id"]}, {"$set": update})
+
+
+def get_state(db, key):
+    return db[STATE_COLLECTION].find_one({"_id": key}) or {"_id": key, "last_function_id": None, "seen": 0, "rewritten": 0, "started_at": None}
+
+
+def put_state(db, state):
+    db[STATE_COLLECTION].replace_one({"_id": state["_id"]}, state, upsert=True)
+
+
+def walk(db, collection_name: str, padded: bool, batch_size: int) -> Dict[str, Any]:
+    mode = "pad" if padded else "unpad"
+    state = get_state(db, "%s:%s" % (mode, collection_name))
+    if state["started_at"] is None:
+        state["started_at"] = datetime.now(UTC).isoformat()
+    last_function_id = state["last_function_id"]
+    seen, rewritten = state["seen"], state["rewritten"]
+    started = time.perf_counter()
+    log("%s %s from function_id > %s" % (mode, collection_name, last_function_id))
+    while True:
+        query = {} if last_function_id is None else {"function_id": {"$gt": last_function_id}}
+        documents = list(db[collection_name].find(query, PROJECTION).sort("function_id", ASCENDING).limit(batch_size))
+        if not documents:
+            break
+        updates = [update for update in (rewrite(document, padded) for document in documents) if update is not None]
+        if updates:
+            db[collection_name].bulk_write(updates, ordered=False)
+        last_function_id = documents[-1]["function_id"]
+        seen += len(documents)
+        rewritten += len(updates)
+        state.update({"last_function_id": last_function_id, "seen": seen, "rewritten": rewritten})
+        put_state(db, state)
+        if seen % (batch_size * 10) == 0:
+            elapsed = time.perf_counter() - started
+            log("  %d seen, %d rewritten, %.0f docs/s" % (seen, rewritten, seen / max(elapsed, 1e-9)))
+    # documents the keyset walk did not see: written below the cursor by a server that was
+    # still running, or left by an interrupted earlier run
+    leftover_query = {"$or": [unpadded_query(), unpadded_block_query()]} if padded else {"$or": [padded_query(), padded_block_query()]}
+    swept = 0
+    while True:
+        documents = list(db[collection_name].find(leftover_query, PROJECTION).limit(batch_size))
+        updates = [update for update in (rewrite(document, padded) for document in documents) if update is not None]
+        if not updates:
+            break
+        db[collection_name].bulk_write(updates, ordered=False)
+        swept += len(updates)
+    state["finished_at"] = datetime.now(UTC).isoformat()
+    put_state(db, state)
+    elapsed = time.perf_counter() - started
+    log("done %s: %d seen, %d rewritten, %d swept, %.1f s" % (collection_name, seen, rewritten, swept, elapsed))
+    return {"seen": seen, "rewritten": rewritten, "swept": swept, "seconds": elapsed}
+
+
+def set_flag(db, padded: bool) -> None:
+    db.settings.update_one({}, {"$set": {"pichash_padded": padded}}, upsert=True)
+    # clear the walk state so a later run of the other mode starts from the top
+    db[STATE_COLLECTION].delete_many({})
+    log("settings.pichash_padded = %s" % padded)
+
+
+def verify(db) -> Dict[str, Any]:
+    settings = db.settings.find_one({}, {"pichash_padded": 1, "_id": 0}) or {}
+    flag = bool(settings.get("pichash_padded", False))
+    report: Dict[str, Any] = {"pichash_padded": flag, "collections": {}, "problems": []}
+    for collection_name in COLLECTIONS:
+        counts = {
+            "documents": db[collection_name].count_documents({}),
+            "unpadded_pichashes": db[collection_name].count_documents(unpadded_query()),
+            "padded_pichashes": db[collection_name].count_documents(padded_query()),
+            "documents_with_unpadded_blockhashes": db[collection_name].count_documents(unpadded_block_query()),
+            "documents_with_padded_blockhashes": db[collection_name].count_documents(padded_block_query()),
+        }
+        report["collections"][collection_name] = counts
+        # only one direction is a problem: a 16-digit value is legitimate under either encoding
+        # (most 64 bit pichashes have no leading zero), an unpadded one only while the flag is unset
+        if flag and (counts["unpadded_pichashes"] or counts["documents_with_unpadded_blockhashes"]):
+            report["problems"].append("%s: flag says padded but unpadded values remain; re-run --mode pad" % collection_name)
+    return report
+
+
+def run(db, mode: str, batch_size: int = 2000) -> Dict[str, Any]:
+    result: Dict[str, Any] = {"mode": mode, "utc": datetime.now(UTC).isoformat()}
+    if mode == "verify":
+        result.update(verify(db))
+        return result
+    padded = mode == "pad"
+    for collection_name in COLLECTIONS:
+        result[collection_name] = walk(db, collection_name, padded, batch_size)
+    set_flag(db, padded)
+    result.update(verify(db))
+    return result
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=["pad", "verify", "unpad"], required=True)
+    storage_config = McritConfig().STORAGE_CONFIG
+    parser.add_argument("--host", default=storage_config.STORAGE_SERVER)
+    parser.add_argument("--port", type=int, default=int(storage_config.STORAGE_PORT))
+    parser.add_argument("--db", default=storage_config.STORAGE_MONGODB_DBNAME)
+    parser.add_argument("--batch", type=int, default=2000)
+    parser.add_argument("--out", default=None)
+    args = parser.parse_args(argv)
+
+    db = MongoClient("mongodb://%s:%d" % (args.host, args.port), connect=True)[args.db]
+    result = run(db, args.mode, args.batch)
+    print(json.dumps(result, indent=2, default=str))
+    if args.out:
+        with open(args.out, "w") as handle:
+            json.dump(result, handle, indent=2, default=str)
+    return 1 if result.get("problems") else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mcrit/migrations/migrate_pichash_padding.py
+++ b/mcrit/migrations/migrate_pichash_padding.py
@@ -36,6 +36,7 @@ import sys
 import time
 from datetime import UTC, datetime
 from typing import Any, Dict, List, Optional
+from urllib.parse import quote_plus
 
 from pymongo import ASCENDING, MongoClient, UpdateOne
 
@@ -45,6 +46,12 @@ from mcrit.storage.MongoDbStorage import PICHASH_HEX_DIGITS, encode_pichash_valu
 STATE_COLLECTION = "pichash_padding_state"
 COLLECTIONS = ("functions", "query_functions")
 PROJECTION = {"function_id": 1, "_pichash": 1, "_picblockhashes.hash": 1, "_id": 0}
+
+
+def build_mongo_uri(host: str, port: int, db_name: str, username: Optional[str], password: Optional[str], flags: Optional[str]) -> str:
+    credentials = "%s:%s@" % (quote_plus(username), quote_plus(password)) if username and password else ""
+    query = "?%s" % flags if flags else ""
+    return "mongodb://%s%s:%d/%s%s" % (credentials, host, port, db_name, query)
 
 
 def log(message):
@@ -187,11 +194,17 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--host", default=storage_config.STORAGE_SERVER)
     parser.add_argument("--port", type=int, default=int(storage_config.STORAGE_PORT))
     parser.add_argument("--db", default=storage_config.STORAGE_MONGODB_DBNAME)
+    parser.add_argument("--uri", default=None, help="complete MongoDB URI; overrides host/port and the configured credentials and flags")
     parser.add_argument("--batch", type=int, default=2000)
     parser.add_argument("--out", default=None)
     args = parser.parse_args(argv)
 
-    db = MongoClient("mongodb://%s:%d" % (args.host, args.port), connect=True)[args.db]
+    # the same credentials and connection flags MongoDbStorage connects with (STORAGE_MONGODB_*),
+    # so a secured deployment needs nothing beyond its mcrit configuration
+    uri = args.uri or build_mongo_uri(
+        args.host, args.port, args.db, storage_config.STORAGE_MONGODB_USERNAME, storage_config.STORAGE_MONGODB_PASSWORD, storage_config.STORAGE_MONGODB_FLAGS
+    )
+    db = MongoClient(uri, connect=True)[args.db]
     result = run(db, args.mode, args.batch)
     print(json.dumps(result, indent=2, default=str))
     if args.out:

--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -811,6 +811,8 @@ class MemoryStorage(StorageInterface):
             "num_bands": len(self._bands),
             # None signals "not computed", so that consumers can distinguish it from an actual count of 0
             "num_pichashes": len(self._pichashes) if with_pichash else None,
+            # pichashes are kept as integers here, so their order is always numeric (#145)
+            "pichash_padded": True,
         }
         return stats
 

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -50,11 +50,31 @@ if TYPE_CHECKING:  # pragma: no cover
     from mcrit.config.McritConfig import McritConfig
 
 
+# pichashes and picblockhashes are 64 bit values stored as hex strings. Written zero-padded to
+# 16 digits, their string order is their numeric order, which is what range conditions and
+# cursor paging by pichash need (#145). Instances created before this carry variable-width
+# values ("0x4d2") until migrate_pichash_padding has run; the settings flag "pichash_padded"
+# says which shape an instance holds, and every reader below honours both until it is set.
+PICHASH_HEX_DIGITS = 16
+
+
+def encode_pichash_value(value: int, padded: bool) -> str:
+    return "0x%0*x" % (PICHASH_HEX_DIGITS, value) if padded else hex(value)
+
+
+def pichash_value_variants(value: int) -> List[str]:
+    """Both encodings a value may be stored under while an instance is not (yet) padded."""
+    return sorted({hex(value), encode_pichash_value(value, padded=True)})
+
+
 class MongoSearchTranspiler(BaseVisitor):
     """
     Converts a tree to a MongoDB query.
     The input tree MUST NOT contain Not or SearchTerm nodes.
     """
+
+    def __init__(self, pichash_padded: bool = False) -> None:
+        self.pichash_padded = pichash_padded
 
     @staticmethod
     def _or_query(*conditions):
@@ -101,9 +121,9 @@ class MongoSearchTranspiler(BaseVisitor):
             except Exception:
                 pass
         mongo_operator = operator_to_mongo[node.operator]
-        if node.field == "pichash" and mongo_operator in ("$lt", "$lte", "$gt", "$gte"):
-            # pichashes are stored as hex strings, on which range comparisons are not meaningful
-            raise ValueError("Range operators are not supported for the field 'pichash'.")
+        if node.field == "pichash" and mongo_operator in ("$lt", "$lte", "$gt", "$gte") and not self.pichash_padded:
+            # on variable-width hex strings a range comparison answers a plausible but wrong set
+            raise ValueError("Range operators on the field 'pichash' need zero-padded pichashes; run migrate_pichash_padding first.")
         if mongo_operator is None:
             condition = {node.field: value}
         else:
@@ -113,8 +133,13 @@ class MongoSearchTranspiler(BaseVisitor):
                 # a substring search is a regex, which cannot be hex-encoded - it is matched against
                 # the stored representation instead, so only the field has to be renamed
                 condition = {"_pichash": condition.pop("pichash")}
+            elif self.pichash_padded or not isinstance(value, int):
+                MongoDbStorage._encodePichash(condition, padded=self.pichash_padded)
+            elif mongo_operator is None:
+                # an instance that is not padded may hold either width (a migration in flight)
+                condition = {"_pichash": {"$in": pichash_value_variants(value)}}
             else:
-                MongoDbStorage._encodePichash(condition)
+                condition = {"_pichash": {"$nin": pichash_value_variants(value)}}
         return condition
 
 
@@ -127,6 +152,7 @@ class MongoDbStorage(StorageInterface):
         super().__init__(config)  # sets config
         self.blockhasher = BlockHasher()
         self._database = None
+        self._pichash_padded: Optional[bool] = None
         # guards the lazy initialisation in _getDb(); a threading.Lock is per-process, which is
         # what we want: forking servers (gunicorn) fork before the first request, so every child
         # inherits an unlocked copy and synchronises its own threads independently
@@ -193,7 +219,9 @@ class MongoDbStorage(StorageInterface):
 
     def _ensureIndexAndUnknownFamily(self) -> None:
         if "settings" not in self._getDb().list_collection_names():
-            self._getDb()["settings"].insert_one({"mcrit_db_id": str(uuid.uuid4()), "db_state": 0})
+            # a fresh instance stores pichashes zero-padded from the start (#145)
+            self._getDb()["settings"].insert_one({"mcrit_db_id": str(uuid.uuid4()), "db_state": 0, "pichash_padded": True})
+            self._pichash_padded = None
         self._getDb()["samples"].create_index("sample_id")
         self._getDb()["samples"].create_index("sha256")
         self._getDb()["samples"].create_index("family_id")
@@ -479,21 +507,21 @@ class MongoDbStorage(StorageInterface):
                 self._getDb()[collection].delete_many({"_id": {"$in": ids}})
 
     @staticmethod
-    def _encodePichash(function_dict: Dict, delete_old: bool = True) -> None:
+    def _encodePichash(function_dict: Dict, delete_old: bool = True, padded: bool = False) -> None:
         if "pichash" in function_dict:
             value = function_dict["pichash"]
             # search conditions wrap the value in an operator dict, e.g. {"$ne": 0x1234}
             if isinstance(value, dict):
-                function_dict["_pichash"] = {k: hex(v) if isinstance(v, int) else v for k, v in value.items()}
+                function_dict["_pichash"] = {k: encode_pichash_value(v, padded) if isinstance(v, int) else v for k, v in value.items()}
             else:
-                function_dict["_pichash"] = hex(value)
+                function_dict["_pichash"] = encode_pichash_value(value, padded)
             if delete_old:
                 del function_dict["pichash"]
         if "picblockhashes" in function_dict:
             converted_entries = []
             for entry in function_dict["picblockhashes"]:
                 converted_entry = dict(**entry)
-                converted_entry["hash"] = hex(converted_entry["hash"])
+                converted_entry["hash"] = encode_pichash_value(converted_entry["hash"], padded)
                 # use two-complement to convert unit64 to int64 and vice versa
                 converted_entry["offset"] = encode_two_complement(converted_entry["offset"])
                 converted_entries.append(converted_entry)
@@ -523,10 +551,21 @@ class MongoDbStorage(StorageInterface):
             if delete_old:
                 del function_dict["_picblockhashes"]
 
-    @staticmethod
-    def _encodeFunction(function_dict: Dict, delete_old: bool = True) -> None:
-        MongoDbStorage._encodePichash(function_dict, delete_old=delete_old)
+    def _encodeFunction(self, function_dict: Dict, delete_old: bool = True) -> None:
+        MongoDbStorage._encodePichash(function_dict, delete_old=delete_old, padded=self.isPichashPadded())
         MongoDbStorage._encodeXcfg(function_dict, delete_old=delete_old)
+
+    def isPichashPadded(self) -> bool:
+        """Whether this instance stores pichashes zero-padded (#145); read once per process."""
+        if self._pichash_padded is None:
+            settings = self._getDb().settings.find_one({}, {"pichash_padded": 1, "_id": 0}) or {}
+            self._pichash_padded = bool(settings.get("pichash_padded", False))
+        return self._pichash_padded
+
+    def _pichashLookupCondition(self, field: str, value: int) -> Dict[str, Any]:
+        if self.isPichashPadded():
+            return {field: encode_pichash_value(value, padded=True)}
+        return {field: {"$in": pichash_value_variants(value)}}
 
     @staticmethod
     def _decodeFunction(function_dict: Dict, delete_old: bool = True) -> None:
@@ -1268,13 +1307,11 @@ class MongoDbStorage(StorageInterface):
         return None
 
     def isPicHash(self, pichash: int) -> bool:
-        query = {"pichash": pichash}
-        self._encodePichash(query)
-        return self._getDb().functions.find_one(query) is not None
+        query = self._pichashLookupCondition("_pichash", pichash)
+        return self._getDb().functions.find_one(query, {"_id": 1}) is not None
 
     def getMatchesForPicHash(self, pichash: int) -> Set[Tuple[int, int, int]]:
-        query = {"pichash": pichash}
-        self._encodePichash(query)
+        query = self._pichashLookupCondition("_pichash", pichash)
         return set(
             map(
                 lambda x: (x["family_id"], x["sample_id"], x["function_id"]),
@@ -1283,7 +1320,7 @@ class MongoDbStorage(StorageInterface):
         )
 
     def getMatchesForPicBlockHash(self, picblockhash: int) -> Set[Tuple[int, int, int, int]]:
-        query = {"_picblockhashes.hash": hex(picblockhash)}
+        query = self._pichashLookupCondition("_picblockhashes.hash", picblockhash)
         result = self._getDb().functions.aggregate(
             [
                 {"$match": query},
@@ -1499,6 +1536,7 @@ class MongoDbStorage(StorageInterface):
             "num_functions": 0,
             "num_bands": self._storage_config.STORAGE_NUM_BANDS,
             "num_pichashes": num_unique_pichashes,
+            "pichash_padded": self.isPichashPadded(),
         }
         for family_document in self._getDb().families.find():
             stats["num_families"] += 1
@@ -1646,7 +1684,7 @@ class MongoDbStorage(StorageInterface):
                     update_document["picblockhashes"] = picblockhashes
                 # prepare single function entry update
                 if update_document:
-                    self._encodePichash(update_document)
+                    self._encodePichash(update_document, padded=self.isPichashPadded())
                     update_command = {"$set": update_document}
                     pic_hash_updates.append(UpdateOne({"function_id": function_document["function_id"]}, update_command, upsert=True))
             # batch insert updates for function_entries
@@ -1753,27 +1791,25 @@ class MongoDbStorage(StorageInterface):
 
     ##### helpers for search ######
 
-    # pichashes are stored hex-encoded, in a differently named field ("_pichash") and with a
-    # variable width, so sorting on them would neither order numerically nor let the search cursor
-    # page - its tree compares the sort field with a range operator, which the transpiler rejects.
-    # Zero-padding the stored value would lift this and the range rejection alike (#145).
-    _UNSORTABLE_FIELDS = ("pichash",)
+    # pichashes are stored hex-encoded in a differently named field ("_pichash"). Sorting on them
+    # orders numerically only once the instance stores them zero-padded, and the search cursor
+    # pages by comparing the sort field with a range operator, which the transpiler only allows
+    # then (#145); an instance that has not been migrated keeps rejecting the sort by name.
+    _SORT_FIELD_TO_STORED = {"pichash": "_pichash"}
 
-    @staticmethod
-    def _assert_sortable_fields(full_cursor: Optional[FullSearchCursor]) -> None:
-        if full_cursor is None:
+    def _assert_sortable_fields(self, full_cursor: Optional[FullSearchCursor]) -> None:
+        if full_cursor is None or self.isPichashPadded():
             return
         for field in full_cursor.sort_fields:
-            if field in MongoDbStorage._UNSORTABLE_FIELDS:
-                raise ValueError(f"Sorting by the field '{field}' is not supported by the MongoDB backend.")
+            if field == "pichash":
+                raise ValueError("Sorting by the field 'pichash' needs zero-padded pichashes; run migrate_pichash_padding first.")
 
-    @staticmethod
-    def _get_sort_list_from_cursor(full_cursor: Optional[FullSearchCursor]):
-        MongoDbStorage._assert_sortable_fields(full_cursor)
+    def _get_sort_list_from_cursor(self, full_cursor: Optional[FullSearchCursor]):
+        self._assert_sortable_fields(full_cursor)
         if full_cursor is None:
             return None
         is_backward_search = not full_cursor.is_forward_search
-        sort_list = [(key, 1 if direction ^ is_backward_search else -1) for key, direction in full_cursor.sort_by_list]
+        sort_list = [(self._SORT_FIELD_TO_STORED.get(key, key), 1 if direction ^ is_backward_search else -1) for key, direction in full_cursor.sort_by_list]
         return sort_list
 
     def _get_search_query(self, search_fields: List[str], search_tree: NodeType, cursor: Optional[FullSearchCursor], conditional_search_fields=None):
@@ -1788,7 +1824,7 @@ class MongoDbStorage(StorageInterface):
         full_tree = SearchFieldResolver(search_fields, conditional_search_fields=conditional_search_fields).visit(full_tree)
         full_tree = FilterSingleElementLists().visit(full_tree)
         full_tree = PropagateNot().visit(full_tree)
-        query = MongoSearchTranspiler().visit(full_tree)
+        query = MongoSearchTranspiler(pichash_padded=self.isPichashPadded()).visit(full_tree)
         return query
 
     ##### search ####

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # values ("0x4d2") until migrate_pichash_padding has run; the settings flag "pichash_padded"
 # says which shape an instance holds, and every reader below honours both until it is set.
 PICHASH_HEX_DIGITS = 16
+PICHASH_MAX_VALUE = (1 << (4 * PICHASH_HEX_DIGITS)) - 1
 
 
 def encode_pichash_value(value: int, padded: bool) -> str:
@@ -121,9 +122,13 @@ class MongoSearchTranspiler(BaseVisitor):
             except Exception:
                 pass
         mongo_operator = operator_to_mongo[node.operator]
-        if node.field == "pichash" and mongo_operator in ("$lt", "$lte", "$gt", "$gte") and not self.pichash_padded:
-            # on variable-width hex strings a range comparison answers a plausible but wrong set
-            raise ValueError("Range operators on the field 'pichash' need zero-padded pichashes; run migrate_pichash_padding first.")
+        if node.field == "pichash" and mongo_operator in ("$lt", "$lte", "$gt", "$gte"):
+            if not self.pichash_padded:
+                # on variable-width hex strings a range comparison answers a plausible but wrong set
+                raise ValueError("Range operators on the field 'pichash' need zero-padded pichashes; run migrate_pichash_padding first.")
+            if not isinstance(value, int) or not 0 <= value <= PICHASH_MAX_VALUE:
+                # a bound outside the 64 bit domain formats wider than 16 digits and would not compare
+                raise ValueError("A pichash bound must be an integer between 0 and 0xffffffffffffffff.")
         if mongo_operator is None:
             condition = {node.field: value}
         else:
@@ -998,7 +1003,6 @@ class MongoDbStorage(StorageInterface):
         if query_result is None or "_pichash" not in query_result:
             return None
         self._decodePichash(query_result, delete_old=False)
-        encoded_pichash = query_result["_pichash"]
         decoded_pichash = query_result["pichash"]
         if decoded_pichash is None:
             return None
@@ -1006,7 +1010,7 @@ class MongoDbStorage(StorageInterface):
         sample_and_function_ids = set(
             map(
                 lambda x: (x["family_id"], x["sample_id"], x["function_id"]),
-                list(self._getDb().functions.find({"_pichash": encoded_pichash}, {"family_id": 1, "sample_id": 1, "function_id": 1, "_id": 0})),
+                list(self._getDb().functions.find(self._pichashLookupCondition("_pichash", decoded_pichash), {"family_id": 1, "sample_id": 1, "function_id": 1, "_id": 0})),
             )
         )
 
@@ -1030,8 +1034,15 @@ class MongoDbStorage(StorageInterface):
         # one $in over all distinct pichashes instead of one query per pichash (N+1, #111);
         # grouping client-side by the returned _pichash reproduces the per-query sets exactly
         if encoded_to_decoded:
+            # while the instance is not padded, either spelling of a value may be stored (#145)
+            lookup = set(encoded_to_decoded)
+            if not self.isPichashPadded():
+                for decoded_pichash in list(encoded_to_decoded.values()):
+                    for variant in pichash_value_variants(decoded_pichash):
+                        encoded_to_decoded[variant] = decoded_pichash
+                        lookup.add(variant)
             fields_to_fetch = {"_pichash": 1, "family_id": 1, "sample_id": 1, "function_id": 1, "_id": 0}
-            for hit in self._getDb().functions.find({"_pichash": {"$in": list(encoded_to_decoded)}}, fields_to_fetch):
+            for hit in self._getDb().functions.find({"_pichash": {"$in": sorted(lookup)}}, fields_to_fetch):
                 decoded_pichash = encoded_to_decoded[hit.get("_pichash")]
                 pichashes[decoded_pichash].add((hit["family_id"], hit["sample_id"], hit["function_id"]))
         return pichashes

--- a/tests/testMongoSearchTranspiler.py
+++ b/tests/testMongoSearchTranspiler.py
@@ -28,6 +28,13 @@ class TestMongoSearchTranspiler(unittest.TestCase):
         self.assertEqual(self._visit("pichash", "<", "0x99", padded=True), {"_pichash": {"$lt": "0x0000000000000099"}})
         self.assertEqual(self._visit("pichash", ">=", "0x99", padded=True), {"_pichash": {"$gte": "0x0000000000000099"}})
 
+    def test_pichash_bounds_outside_64_bits_are_rejected(self):
+        # a wider bound would format to more than 16 digits and not compare lexicographically
+        for value in ("0x10000000000000000", "-1"):
+            with self.assertRaises(ValueError):
+                self._visit("pichash", "<", value, padded=True)
+        self.assertEqual({"_pichash": {"$lte": "0xffffffffffffffff"}}, self._visit("pichash", "<=", "0xffffffffffffffff", padded=True))
+
     def test_padded_hex_orders_like_the_numbers(self):
         values = [0x99, 0x1000, 0x4D2, 0xFFFFFFFFFFFFFFFF, 0]
         encoded = [self._visit("pichash", "=", str(v), padded=True)["_pichash"] for v in values]

--- a/tests/testMongoSearchTranspiler.py
+++ b/tests/testMongoSearchTranspiler.py
@@ -6,23 +6,32 @@ from mcrit.storage.MongoDbStorage import MongoDbStorage, MongoSearchTranspiler
 
 
 class TestMongoSearchTranspiler(unittest.TestCase):
-    def _visit(self, field, operator, value):
-        return MongoSearchTranspiler().visit(SearchConditionNode(field, operator, value))
+    def _visit(self, field, operator, value, padded=False):
+        return MongoSearchTranspiler(pichash_padded=padded).visit(SearchConditionNode(field, operator, value))
 
-    def test_pichash_equality_is_encoded(self):
-        # pichashes are stored hex-encoded in the "_pichash" field
-        self.assertEqual(self._visit("pichash", "=", "0x1234"), {"_pichash": "0x1234"})
+    def test_pichash_equality_on_a_padded_instance_is_encoded_zero_padded(self):
+        # pichashes are stored hex-encoded in the "_pichash" field, 16 digits wide once migrated (#145)
+        self.assertEqual(self._visit("pichash", "=", "0x1234", padded=True), {"_pichash": "0x0000000000001234"})
+        self.assertEqual(self._visit("pichash", "!=", "0x1234", padded=True), {"_pichash": {"$ne": "0x0000000000001234"}})
+        self.assertEqual(self._visit("pichash", "=", "4660", padded=True), {"_pichash": "0x0000000000001234"})
 
-    def test_pichash_inequality_is_encoded(self):
-        self.assertEqual(self._visit("pichash", "!=", "0x1234"), {"_pichash": {"$ne": "0x1234"}})
+    def test_pichash_equality_on_an_unpadded_instance_accepts_both_widths(self):
+        # a migration in flight leaves both shapes in the collection, so neither may be missed
+        self.assertEqual(self._visit("pichash", "=", "0x1234"), {"_pichash": {"$in": ["0x0000000000001234", "0x1234"]}})
+        self.assertEqual(self._visit("pichash", "!=", "0x1234"), {"_pichash": {"$nin": ["0x0000000000001234", "0x1234"]}})
+        self.assertEqual(self._visit("pichash", "=", "4660"), {"_pichash": {"$in": ["0x0000000000001234", "0x1234"]}})
 
-    def test_pichash_decimal_value_is_encoded_as_hex(self):
-        self.assertEqual(self._visit("pichash", "=", "4660"), {"_pichash": "0x1234"})
-
-    def test_pichash_range_operators_are_rejected(self):
+    def test_pichash_range_operators_need_a_padded_instance(self):
         for operator in ("<", "<=", ">", ">="):
             with self.assertRaises(ValueError):
                 self._visit("pichash", operator, "0x1234")
+        self.assertEqual(self._visit("pichash", "<", "0x99", padded=True), {"_pichash": {"$lt": "0x0000000000000099"}})
+        self.assertEqual(self._visit("pichash", ">=", "0x99", padded=True), {"_pichash": {"$gte": "0x0000000000000099"}})
+
+    def test_padded_hex_orders_like_the_numbers(self):
+        values = [0x99, 0x1000, 0x4D2, 0xFFFFFFFFFFFFFFFF, 0]
+        encoded = [self._visit("pichash", "=", str(v), padded=True)["_pichash"] for v in values]
+        self.assertEqual(sorted(encoded), [self._visit("pichash", "=", str(v), padded=True)["_pichash"] for v in sorted(values)])
 
     def test_pichash_substring_search_matches_the_encoded_field(self):
         # "?" produces a regex, which cannot be hex-encoded (and used to raise a TypeError here),
@@ -30,6 +39,7 @@ class TestMongoSearchTranspiler(unittest.TestCase):
         condition = self._visit("pichash", "?", "1234")
         self.assertEqual(["_pichash"], list(condition))
         self.assertTrue(condition["_pichash"].search("0x1234"))
+        self.assertTrue(condition["_pichash"].search("0x0000000000001234"))
         self.assertIsNone(condition["_pichash"].search("0x5678"))
 
     def test_pichash_negated_substring_search_matches_the_encoded_field(self):
@@ -43,19 +53,33 @@ class TestMongoSearchTranspiler(unittest.TestCase):
         self.assertEqual(self._visit("family", "=", "somefamily"), {"family": "somefamily"})
 
 
+class _StorageWithPadding(MongoDbStorage):
+    """The sort helpers without a database: only the padding flag is consulted."""
+
+    def __init__(self, padded):  # noqa: D107 - deliberately skips MongoDbStorage.__init__
+        self._padded = padded
+
+    def isPichashPadded(self):
+        return self._padded
+
+
 class TestMongoSortableFields(unittest.TestCase):
     def _cursor(self, *sort_fields):
         return FullSearchCursor(None, [(field, True) for field in sort_fields])
 
-    def test_pichash_cannot_be_sorted_by(self):
-        # the cursor pages by comparing the sort field, which the hex-encoded pichash does not allow
+    def test_pichash_cannot_be_sorted_by_on_an_unpadded_instance(self):
+        # the cursor pages by comparing the sort field, which variable-width hex does not allow
+        storage = _StorageWithPadding(False)
         with self.assertRaises(ValueError):
-            MongoDbStorage._assert_sortable_fields(self._cursor("pichash", "function_id"))
+            storage._assert_sortable_fields(self._cursor("pichash", "function_id"))
+        storage._assert_sortable_fields(None)
+        storage._assert_sortable_fields(self._cursor("function_id"))
+        storage._assert_sortable_fields(self._cursor("function_name", "function_id"))
 
-    def test_regular_fields_can_be_sorted_by(self):
-        MongoDbStorage._assert_sortable_fields(None)
-        MongoDbStorage._assert_sortable_fields(self._cursor("function_id"))
-        MongoDbStorage._assert_sortable_fields(self._cursor("function_name", "function_id"))
+    def test_pichash_sorts_by_the_stored_field_on_a_padded_instance(self):
+        storage = _StorageWithPadding(True)
+        self.assertEqual([("_pichash", 1), ("function_id", 1)], storage._get_sort_list_from_cursor(self._cursor("pichash", "function_id")))
+        self.assertIsNone(storage._get_sort_list_from_cursor(None))
 
 
 if __name__ == "__main__":

--- a/tests/testPichashPadding.py
+++ b/tests/testPichashPadding.py
@@ -101,7 +101,9 @@ class PichashPaddingTest(TestCase):
         self.storage._pichash_padded = None
 
     def test_a_fresh_instance_stores_padded_values_and_says_so(self):
-        self.assertTrue(self.db.settings.find_one({})["pichash_padded"])
+        settings = self.db.settings.find_one({})
+        assert settings is not None
+        self.assertTrue(settings["pichash_padded"])
         self.assertTrue(self.storage.isPichashPadded())
         self.assertTrue(self.storage.getStats(with_pichash=False)["pichash_padded"])
         self.assertTrue(all(is_padded(value) for value in self._stored_pichashes()))

--- a/tests/testPichashPadding.py
+++ b/tests/testPichashPadding.py
@@ -131,6 +131,27 @@ class PichashPaddingTest(TestCase):
             self.assertFalse(self.storage.isPicHash(0x1234567))
             self.assertEqual(set(), self.storage.getMatchesForPicHash(0x1234567))
 
+    def test_the_aggregation_readers_see_both_widths_while_unpadded(self):
+        """getPicHashMatchesByFunctionId(s) group functions by equal pichash; during a migration
+        the same value may be stored in either width and must still land in one group"""
+        self._make_legacy()
+        first, second = self.differing[0]["function_id"], self.differing[1]["function_id"]
+        # give both functions the same pichash, one in each width
+        value = 0x4D2
+        self.db.functions.update_one({"function_id": first}, {"$set": {"_pichash": hex(value)}})
+        self.db.functions.update_one({"function_id": second}, {"$set": {"_pichash": encode_pichash_value(value, padded=True)}})
+        by_one = self.storage.getPicHashMatchesByFunctionId(first)
+        self.assertEqual({first, second}, {t[2] for t in by_one[value]})
+        by_many = self.storage.getPicHashMatchesByFunctionIds([first, second])
+        self.assertEqual({first, second}, {t[2] for t in by_many[value]})
+        self.assertEqual(1, len(by_many))
+
+    def test_the_migration_connects_with_the_configured_credentials(self):
+        self.assertEqual("mongodb://h:27017/db", migrate_pichash_padding.build_mongo_uri("h", 27017, "db", None, None, ""))
+        self.assertEqual(
+            "mongodb://u%40x:p%3Aw@h:27017/db?authSource=admin&tls=true", migrate_pichash_padding.build_mongo_uri("h", 27017, "db", "u@x", "p:w", "authSource=admin&tls=true")
+        )
+
     def test_a_legacy_instance_in_the_middle_of_a_migration_misses_nothing(self):
         self._make_legacy()
         # half the documents padded by hand: a `pad` run that was interrupted before the flag

--- a/tests/testPichashPadding.py
+++ b/tests/testPichashPadding.py
@@ -1,0 +1,233 @@
+import json
+import logging
+import os
+from unittest import TestCase
+
+import pymongo
+import pytest
+from smda.common.SmdaReport import SmdaReport
+
+from mcrit.config.McritConfig import McritConfig
+from mcrit.config.MinHashConfig import MinHashConfig
+from mcrit.config.QueueConfig import QueueConfig
+from mcrit.config.ShinglerConfig import ShinglerConfig
+from mcrit.config.StorageConfig import StorageConfig
+from mcrit.index.MinHashIndex import MinHashIndex
+from mcrit.index.SearchCursor import FullSearchCursor, MinimalSearchCursor
+from mcrit.index.SearchQueryParser import SearchQueryParser
+from mcrit.migrations import migrate_pichash_padding
+from mcrit.storage.MongoDbStorage import PICHASH_HEX_DIGITS, encode_pichash_value
+from mcrit.storage.StorageFactory import StorageFactory
+
+from .context import getTestMongoServerAndPort
+
+logging.disable(logging.CRITICAL)
+
+THIS_FILE_PATH = str(os.path.abspath(__file__))
+PROJECT_ROOT = str(os.path.abspath(os.sep.join([THIS_FILE_PATH, "..", ".."])))
+EXAMPLE_REPORT = os.sep.join([PROJECT_ROOT, "tests", "example_report.smda"])
+DB_NAME = "test_pichash_padding_mcrit"
+
+
+def build_config():
+    server, port = getTestMongoServerAndPort()
+    mcrit_config = McritConfig()
+    mcrit_config.STORAGE_CONFIG = StorageConfig(
+        STORAGE_METHOD=StorageFactory.STORAGE_METHOD_MONGODB,
+        STORAGE_SERVER=server,
+        STORAGE_PORT=port,
+        STORAGE_MONGODB_DBNAME=DB_NAME,
+        STORAGE_DROP_DISASSEMBLY=False,
+    )
+    mcrit_config.MINHASH_CONFIG = MinHashConfig()
+    mcrit_config.MINHASH_CONFIG.MINHASH_SIGNATURE_LENGTH = 10
+    mcrit_config.MINHASH_CONFIG.MINHASH_SIGNATURE_BITS = 8
+    mcrit_config.SHINGLER_CONFIG = ShinglerConfig()
+    mcrit_config.QUEUE_CONFIG = QueueConfig()
+    return mcrit_config
+
+
+def is_padded(value):
+    return isinstance(value, str) and value.startswith("0x") and len(value) == 2 + PICHASH_HEX_DIGITS
+
+
+def short_form(value):
+    """The pre-#145 encoding; identical to the padded one unless the value has a leading zero."""
+    return hex(int(value, 16))
+
+
+@pytest.mark.mongo
+class PichashPaddingTest(TestCase):
+    """#145: pichashes are stored 16 digits wide so that their hex order is their numeric order"""
+
+    def setUp(self):
+        server, port = getTestMongoServerAndPort()
+        self.client = pymongo.MongoClient(server, int(port))
+        # a dropped database makes the storage create its settings from scratch: a fresh instance
+        self.client.drop_database(DB_NAME)
+        self.db = self.client[DB_NAME]
+        self.config = build_config()
+        self.storage = StorageFactory.getStorage(self.config)
+        with open(EXAMPLE_REPORT) as fjson:
+            report = SmdaReport.fromDict(json.load(fjson))
+        assert report is not None
+        sample_entry = self.storage.addSmdaReport(report)
+        assert sample_entry is not None
+        self.sample_id = sample_entry.sample_id
+        # the example report's pichashes all use 16 digits; give two of them leading zeros so
+        # that the two encodings differ for pichashes as well as for block hashes
+        first, second = [d["function_id"] for d in self.db.functions.find({}, {"function_id": 1}).sort("function_id", 1).limit(2)]
+        self.db.functions.update_one({"function_id": first}, {"$set": {"_pichash": encode_pichash_value(0x4D2, padded=True)}})
+        self.db.functions.update_one({"function_id": second}, {"$set": {"_pichash": encode_pichash_value(0x99, padded=True)}})
+        self.functions = list(self.db.functions.find({}, {"_id": 0, "function_id": 1, "_pichash": 1, "_picblockhashes": 1}))
+        self.assertGreaterEqual(len(self.functions), 10)
+        # the documents whose values differ between the two encodings (a leading zero somewhere)
+        self.differing = [d for d in self.functions if short_form(d["_pichash"]) != d["_pichash"] or any(short_form(e["hash"]) != e["hash"] for e in d.get("_picblockhashes", []))]
+        self.assertGreater(len(self.differing), 0)
+        self.assertLess(len(self.differing), len(self.functions))
+
+    def tearDown(self):
+        self.client.drop_database(DB_NAME)
+
+    def _stored_pichashes(self):
+        return [document["_pichash"] for document in self.db.functions.find({}, {"_pichash": 1})]
+
+    def _stored_blockhashes(self):
+        return [entry["hash"] for document in self.db.functions.find({}, {"_picblockhashes": 1}) for entry in document.get("_picblockhashes", [])]
+
+    def _make_legacy(self):
+        """Turn the instance into one created before #145: unpadded values, flag unset."""
+        migrate_pichash_padding.run(self.db, "unpad")
+        self.storage._pichash_padded = None
+
+    def test_a_fresh_instance_stores_padded_values_and_says_so(self):
+        self.assertTrue(self.db.settings.find_one({})["pichash_padded"])
+        self.assertTrue(self.storage.isPichashPadded())
+        self.assertTrue(self.storage.getStats(with_pichash=False)["pichash_padded"])
+        self.assertTrue(all(is_padded(value) for value in self._stored_pichashes()))
+        self.assertGreater(len(self._stored_blockhashes()), 0)
+        self.assertTrue(all(is_padded(value) for value in self._stored_blockhashes()))
+        self.assertTrue(MinHashIndex(self.config).getStatus(with_pichash=False)["status"]["pichash_padded"])
+
+    def test_lookups_by_value_work_on_both_shapes(self):
+        function_entries = self.storage.getFunctionsBySampleId(self.sample_id)
+        with_blocks = next(fe for fe in function_entries if fe.picblockhashes)
+        for legacy in (False, True):
+            if legacy:
+                self._make_legacy()
+                self.assertFalse(self.storage.isPichashPadded())
+                self.assertTrue(all(value == short_form(value) for value in self._stored_pichashes()))
+            for function_entry in function_entries:
+                self.assertTrue(self.storage.isPicHash(function_entry.pichash), (legacy, function_entry.function_id))
+                self.assertIn((function_entry.family_id, self.sample_id, function_entry.function_id), self.storage.getMatchesForPicHash(function_entry.pichash))
+                self.assertEqual(
+                    {function_entry.pichash: {(function_entry.family_id, self.sample_id, function_entry.function_id)}},
+                    self.storage.getPicHashMatchesByFunctionId(function_entry.function_id),
+                )
+            block = with_blocks.picblockhashes[0]
+            self.assertIn((with_blocks.family_id, self.sample_id, with_blocks.function_id, block["offset"]), self.storage.getMatchesForPicBlockHash(block["hash"]))
+            self.assertFalse(self.storage.isPicHash(0x1234567))
+            self.assertEqual(set(), self.storage.getMatchesForPicHash(0x1234567))
+
+    def test_a_legacy_instance_in_the_middle_of_a_migration_misses_nothing(self):
+        self._make_legacy()
+        # half the documents padded by hand: a `pad` run that was interrupted before the flag
+        # one of the two leading-zero pichashes padded, the other still short
+        rewritten = [d for d in self.differing if short_form(d["_pichash"]) != d["_pichash"]][:1]
+        for document in rewritten:
+            self.db.functions.update_one({"function_id": document["function_id"]}, {"$set": {"_pichash": encode_pichash_value(int(document["_pichash"], 16), padded=True)}})
+        stored = self._stored_pichashes()
+        self.assertTrue(any(value != short_form(value) for value in stored))
+        self.assertTrue(any(value == short_form(value) and not is_padded(value) for value in stored))
+        parser = SearchQueryParser()
+        for function_entry in self.storage.getFunctionsBySampleId(self.sample_id):
+            self.assertTrue(self.storage.isPicHash(function_entry.pichash))
+            found = self.storage.findFunctionByString(parser.parse("pichash:%s" % hex(function_entry.pichash)))
+            self.assertIn(function_entry.function_id, found)
+        # ... but the answers that would be wrong on mixed widths stay refused
+        with self.assertRaises(ValueError):
+            self.storage.findFunctionByString(parser.parse("pichash:>0x10"))
+        with self.assertRaises(ValueError):
+            self.storage.findFunctionByString(parser.parse("function_id:>0"), cursor=FullSearchCursor(None, [("pichash", True), ("function_id", True)]))
+
+    def test_range_conditions_answer_the_numeric_set_when_padded(self):
+        parser = SearchQueryParser()
+        pichashes = {document["function_id"]: int(document["_pichash"], 16) for document in self.functions}
+        pivot = sorted(pichashes.values())[len(pichashes) // 2]
+        expected_below = {function_id for function_id, pichash in pichashes.items() if pichash < pivot}
+        self.assertGreater(len(expected_below), 0)
+        found = self.storage.findFunctionByString(parser.parse("pichash:<%s" % hex(pivot)), max_num_results=1000)
+        self.assertEqual(expected_below, set(found))
+        # a small bound that variable-width strings would have ordered a wrong set for
+        self.assertEqual(set(), set(self.storage.findFunctionByString(parser.parse("pichash:<0x99"), max_num_results=1000)))
+        self.assertEqual(set(pichashes), set(self.storage.findFunctionByString(parser.parse("pichash:>=0x0"), max_num_results=1000)))
+
+    def test_a_pichash_sorted_function_search_pages_in_numeric_order(self):
+        index = MinHashIndex(self.config)
+        expected = [document["function_id"] for document in sorted(self.functions, key=lambda d: (int(d["_pichash"], 16), d["function_id"]))]
+        pages = []
+        cursor = None
+        for _ in range(100):
+            result = index.getFunctionSearchResults("function_id:>=0", sort_by="pichash", is_ascending=True, cursor=cursor, limit=4)
+            page = [entry["function_id"] for entry in result["search_results"].values()]
+            self.assertLessEqual(len(page), 4)
+            pages.append(page)
+            cursor = result["cursor"]["forward"]
+            if cursor is None:
+                break
+        self.assertEqual(expected, [function_id for page in pages for function_id in page])
+        self.assertGreater(len(pages), 2)
+        # the backward cursor of the last page reproduces the page before it
+        last_backward = MinimalSearchCursor.fromStr(result["cursor"]["backward"])
+        self.assertFalse(last_backward.is_forward_search)
+        previous = index.getFunctionSearchResults("function_id:>=0", sort_by="pichash", is_ascending=True, cursor=result["cursor"]["backward"], limit=4)
+        self.assertEqual(pages[-2], [entry["function_id"] for entry in previous["search_results"].values()])
+        # descending order is the reverse walk
+        descending = index.getFunctionSearchResults("function_id:>=0", sort_by="pichash", is_ascending=False, limit=1000)
+        self.assertEqual(list(reversed(expected)), [entry["function_id"] for entry in descending["search_results"].values()])
+
+    def test_the_migration_round_trips_and_verify_spots_leftovers(self):
+        report = migrate_pichash_padding.run(self.db, "verify")
+        self.assertTrue(report["pichash_padded"])
+        self.assertEqual([], report["problems"])
+        self.assertEqual(0, report["collections"]["functions"]["unpadded_pichashes"])
+        # rollback
+        report = migrate_pichash_padding.run(self.db, "unpad")
+        self.assertFalse(report["pichash_padded"])
+        self.assertEqual([], report["problems"])
+        self.assertEqual(len(self.differing), report["functions"]["rewritten"])
+        self.assertTrue(all(value == short_form(value) for value in self._stored_pichashes() + self._stored_blockhashes()))
+        self.assertEqual([short_form(document["_pichash"]) for document in self.functions], self._stored_pichashes())
+        # migrate: every value padded, flag set, values unchanged
+        report = migrate_pichash_padding.run(self.db, "pad", batch_size=5)
+        self.assertTrue(report["pichash_padded"])
+        self.assertEqual([], report["problems"])
+        self.assertEqual(len(self.differing), report["functions"]["rewritten"])
+        self.assertTrue(all(is_padded(value) for value in self._stored_pichashes() + self._stored_blockhashes()))
+        self.assertEqual(
+            {document["function_id"]: document["_pichash"] for document in self.functions},
+            {document["function_id"]: document["_pichash"] for document in self.db.functions.find({}, {"function_id": 1, "_pichash": 1})},
+        )
+        self.assertEqual(
+            {document["function_id"]: document.get("_picblockhashes") for document in self.functions},
+            {document["function_id"]: document.get("_picblockhashes") for document in self.db.functions.find({}, {"function_id": 1, "_picblockhashes": 1})},
+        )
+        # re-running is a no-op
+        report = migrate_pichash_padding.run(self.db, "pad")
+        self.assertEqual(0, report["functions"]["rewritten"] + report["functions"]["swept"])
+        # a value a still-running server wrote unpadded after the flag: verify names it, pad sweeps it
+        leading_zero = next(d for d in self.differing if short_form(d["_pichash"]) != d["_pichash"])
+        self.db.functions.update_one({"function_id": leading_zero["function_id"]}, {"$set": {"_pichash": short_form(leading_zero["_pichash"])}})
+        report = migrate_pichash_padding.run(self.db, "verify")
+        self.assertEqual(1, len(report["problems"]))
+        self.assertEqual(1, report["collections"]["functions"]["unpadded_pichashes"])
+        report = migrate_pichash_padding.run(self.db, "pad")
+        self.assertEqual([], report["problems"])
+        self.assertEqual(1, report["functions"]["rewritten"] + report["functions"]["swept"])
+
+    def test_the_command_line_entry_point(self):
+        server, port = getTestMongoServerAndPort()
+        self.assertEqual(0, migrate_pichash_padding.main(["--mode", "verify", "--host", server, "--port", str(port), "--db", DB_NAME]))
+        self.db.settings.update_one({}, {"$set": {"pichash_padded": True}})
+        self.db.functions.update_one({"function_id": self.functions[0]["function_id"]}, {"$set": {"_pichash": "0x1"}})
+        self.assertEqual(1, migrate_pichash_padding.main(["--mode", "verify", "--host", server, "--port", str(port), "--db", DB_NAME]))


### PR DESCRIPTION
Closes #145.

`_pichash` and `_picblockhashes[].hash` hold 64 bit values as variable-width hex strings (`hex()`), so `pichash:<0x99` answered a plausible but wrong set and a pichash-sorted function search could not page: the search cursor compares the sort field with a range operator, which the transpiler rejected for exactly that reason. Written 16 digits wide, string order is numeric order.

## What changes

- **Instance flag** `settings.pichash_padded`. Fresh instances get it at creation; it is reported through `getStats()` and `/status`. The storage reads it once per process.
- **Width-aware encoding.** `_encodePichash(..., padded=)`; `_encodeFunction` and `recalculateAllPicHashes` write in the instance's width. Import goes through `FunctionEntry` integers, so it follows the instance too.
- **Range and sort by pichash** are allowed only on a padded instance (sort key mapped to `_pichash`); an unpadded one rejects both with a message naming the migration, instead of answering a wrong set.
- **Dual-width reads while unpadded.** Search conditions, `isPicHash`, `getMatchesForPicHash` and `getMatchesForPicBlockHash` match both encodings (`$in` on the indexed field), so a migration in flight misses nothing. On a padded instance the point lookups are single-value again.
- **Migration** `python -m mcrit.migrations.migrate_pichash_padding --mode pad|verify|unpad`: resumable keyset walk over `functions` and `query_functions` with positional `$set` per changed value, a leftover sweep for documents a still-running server wrote below the cursor, then the flag. `verify` counts unpadded values and exits 1 when the flag says padded but some remain (a 16-digit value is legitimate under either encoding, so only that direction is a problem). `unpad` rolls back.

Operationally: stop server and workers, run `pad`, restart. Range/sort by pichash on an unmigrated instance keep failing the same way as before, just with a clearer message; everything else behaves as it did.

## Verification

- `tests/testPichashPadding.py` (MongoDB): fresh instance is padded; lookups by value on both shapes; a half-migrated instance misses nothing and still refuses range/sort; range conditions answer the numeric set (`pichash:<0x99` is empty); a pichash-sorted function search pages forward and backward in numeric order; migration round trip, idempotent re-run, leftover detection and CLI exit codes.
- `tests/testMongoSearchTranspiler.py` covers both widths and the sort helpers.
- Full suite: 210 passed. ruff and ty clean.
- Live migration of the running instance follows in a comment.
