### PR TITLE
Make MatchingResult (de)serialisation cheaper and its wire format round-trip (#44)

### DIFF
--- a/mcrit/storage/MatchedFunctionEntry.py
+++ b/mcrit/storage/MatchedFunctionEntry.py
@@ -1,16 +1,35 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import List, Optional
 
 import mcrit.matchers.MatcherFlags as MatcherFlags
 
-if TYPE_CHECKING:  # pragma: no cover
-    pass
-
-# Dataclass, post init
-# constructor -> .fromSmdaFunction
-# assume sample_entry, smda_function always available
+_ALL_MATCH_FLAGS = MatcherFlags.IS_MINHASH_FLAG | MatcherFlags.IS_PICHASH_FLAG | MatcherFlags.IS_LIBRARY_FLAG
 
 
 class MatchedFunctionEntry:
+    """One (own function, matched function) pair of a MatchingResult.
+
+    A large result holds hundreds of thousands of these, so the class is kept lean (#44):
+    slots instead of a per-instance dict, and the match flags are kept as the integer the
+    wire format carries, with the match_is_* booleans derived from it on access. That also
+    makes the round trip exact by construction: getMatchTuple hands the flags back as they
+    came in (#155).
+    """
+
+    __slots__ = (
+        "function_id",
+        "num_bytes",
+        "offset",
+        "matched_family_id",
+        "matched_family",
+        "matched_sample_id",
+        "matched_function_id",
+        "matched_score",
+        "matched_link_score",
+        "matched_unique",
+        "matched_offset",
+        "match_flags",
+    )
+
     # basic information
     function_id: int
     num_bytes: int
@@ -23,9 +42,7 @@ class MatchedFunctionEntry:
     matched_link_score: float
     matched_unique: Optional[bool]
     matched_offset: Optional[int]
-    match_is_minhash: bool
-    match_is_pichash: bool
-    match_is_library: bool
+    match_flags: int
 
     def __init__(self, function_id: int, num_bytes: int, offset: int, match_tuple: List) -> None:
         self.function_id = function_id
@@ -35,22 +52,26 @@ class MatchedFunctionEntry:
         self.matched_sample_id = match_tuple[1]
         self.matched_function_id = match_tuple[2]
         self.matched_score = match_tuple[3]
-        self.match_is_minhash = match_tuple[4] & MatcherFlags.IS_MINHASH_FLAG
-        self.match_is_pichash = match_tuple[4] & MatcherFlags.IS_PICHASH_FLAG
-        self.match_is_library = match_tuple[4] & MatcherFlags.IS_LIBRARY_FLAG
+        self.match_flags = match_tuple[4] & _ALL_MATCH_FLAGS
         self.matched_family = None
         self.matched_link_score = 0
         self.matched_unique = None
         self.matched_offset = None
 
-    def getMatchTuple(self):
-        return [
-            self.matched_family_id,
-            self.matched_sample_id,
-            self.matched_function_id,
-            self.matched_score,
-            self.match_is_minhash * MatcherFlags.IS_MINHASH_FLAG + self.match_is_pichash * MatcherFlags.IS_PICHASH_FLAG + self.match_is_library * MatcherFlags.IS_LIBRARY_FLAG,
-        ]
+    @property
+    def match_is_minhash(self) -> bool:
+        return bool(self.match_flags & MatcherFlags.IS_MINHASH_FLAG)
+
+    @property
+    def match_is_pichash(self) -> bool:
+        return bool(self.match_flags & MatcherFlags.IS_PICHASH_FLAG)
+
+    @property
+    def match_is_library(self) -> bool:
+        return bool(self.match_flags & MatcherFlags.IS_LIBRARY_FLAG)
+
+    def getMatchTuple(self) -> List:
+        return [self.matched_family_id, self.matched_sample_id, self.matched_function_id, self.matched_score, self.match_flags]
 
     def toDict(self):
         matching_entry = {"fid": self.function_id, "num_bytes": self.num_bytes, "offset": self.offset, "matches": self.getMatchTuple()}

--- a/mcrit/storage/MatchingResult.py
+++ b/mcrit/storage/MatchingResult.py
@@ -1,5 +1,6 @@
 import math
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from operator import attrgetter
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from smda.common.BinaryInfo import BinaryInfo
 from smda.common.SmdaFunction import SmdaFunction
@@ -613,22 +614,22 @@ class MatchingResult:
         return cluster_results
 
     def toDict(self):
-        # we need to aggregate by function_id here
-        summarized_function_match_summaries: Dict[int, Dict[str, Any]] = {}
+        # the wire format groups the pairs by own function, in the order of function_matches (which
+        # is sorted by function_id), as a list of summaries - the same shape the matchers produce
+        # and fromDict reads back
+        summaries: List[Dict[str, Any]] = []
+        current_function_id = None
+        current_matches: List[Any] = []
         for function_match_entry in self.function_matches:
-            if function_match_entry.function_id not in summarized_function_match_summaries:
-                summarized_function_match_summaries[function_match_entry.function_id] = {
-                    "num_bytes": function_match_entry.num_bytes,
-                    "offset": function_match_entry.offset,
-                    "fid": function_match_entry.function_id,
-                    "matches": [function_match_entry.getMatchTuple()],
-                }
-            else:
-                summarized_function_match_summaries[function_match_entry.function_id]["matches"].append(function_match_entry.getMatchTuple())
+            if function_match_entry.function_id != current_function_id:
+                current_function_id = function_match_entry.function_id
+                current_matches = []
+                summaries.append({"num_bytes": function_match_entry.num_bytes, "offset": function_match_entry.offset, "fid": current_function_id, "matches": current_matches})
+            current_matches.append(function_match_entry.getMatchTuple())
         # build the dictionary
         matching_entry = {
             "info": {"sample": self.reference_sample_entry.toDict()},
-            "matches": {"aggregation": self.match_aggregation, "functions": summarized_function_match_summaries, "samples": [match.toDict() for match in self.sample_matches]},
+            "matches": {"aggregation": self.match_aggregation, "functions": summaries, "samples": [match.toDict() for match in self.sample_matches]},
         }
         if self.other_sample_entry is not None:
             matching_entry["other_sample_info"] = self.other_sample_entry.toDict()
@@ -644,28 +645,42 @@ class MatchingResult:
             matching_entry.other_sample_entry = None
         matching_entry.match_aggregation = entry_dict["matches"]["aggregation"]
         matching_entry.sample_matches = [MatchedSampleEntry.fromDict(entry) for entry in entry_dict["matches"]["samples"]]
-        # expand function matches into individual entries
-        list_of_function_matches = []
+        # expand function matches into individual entries. This is the hot loop for large results
+        # (#44): a local append, set-backed membership tests instead of list scans, and no
+        # per-pair attribute lookups on the result object
+        list_of_function_matches: List[MatchedFunctionEntry] = []
+        append_function_match = list_of_function_matches.append
+        function_id_to_family_ids_matched = matching_entry.function_id_to_family_ids_matched
+        library_flag = MatcherFlags.IS_LIBRARY_FLAG
         if "functions" in entry_dict["matches"]:
-            matching_entry.library_matches = {abs(entry["fid"]): [] for entry in entry_dict["matches"]["functions"]}
+            function_summaries = entry_dict["matches"]["functions"]
+            library_matches: Dict[int, List[Tuple[int, int]]] = {abs(entry["fid"]): [] for entry in function_summaries}
+            matching_entry.library_matches = library_matches
             matching_entry.unique_family_scores_per_sample = None
-            for function_match_summary in entry_dict["matches"]["functions"]:
+            for function_match_summary in function_summaries:
                 num_bytes = function_match_summary["num_bytes"]
                 offset = function_match_summary["offset"]
                 function_id = function_match_summary["fid"]
                 # ensure that we have all function_ids in increasing order, regardless of whether they come from a query or regular match.
-                matching_entry.is_query = True if function_id < 0 else False
+                matching_entry.is_query = function_id < 0
                 function_id = abs(function_id)
-                if function_id not in matching_entry.function_id_to_family_ids_matched:
-                    matching_entry.function_id_to_family_ids_matched[function_id] = []
+                family_ids_matched = function_id_to_family_ids_matched.setdefault(function_id, [])
+                families_seen = set(family_ids_matched)
+                function_library_matches = library_matches[function_id]
+                library_seen = set(function_library_matches)
                 for match_tuple in function_match_summary["matches"]:
-                    list_of_function_matches.append(MatchedFunctionEntry(function_id, num_bytes, offset, match_tuple))
-                    if match_tuple[0] not in matching_entry.function_id_to_family_ids_matched[function_id]:
-                        matching_entry.function_id_to_family_ids_matched[function_id].append(match_tuple[0])
-                    if match_tuple[4] & MatcherFlags.IS_LIBRARY_FLAG:
-                        if (match_tuple[0], match_tuple[1]) not in matching_entry.library_matches[function_id]:
-                            matching_entry.library_matches[function_id].append((match_tuple[0], match_tuple[1]))
-        matching_entry.function_matches = sorted(list_of_function_matches, key=lambda x: x.function_id)
+                    append_function_match(MatchedFunctionEntry(function_id, num_bytes, offset, match_tuple))
+                    matched_family_id = match_tuple[0]
+                    if matched_family_id not in families_seen:
+                        families_seen.add(matched_family_id)
+                        family_ids_matched.append(matched_family_id)
+                    if match_tuple[4] & library_flag:
+                        library_match = (matched_family_id, match_tuple[1])
+                        if library_match not in library_seen:
+                            library_seen.add(library_match)
+                            function_library_matches.append(library_match)
+        list_of_function_matches.sort(key=attrgetter("function_id"))
+        matching_entry.function_matches = list_of_function_matches
         # the filtered_* lists are derived lazily on first access, see their properties
         matching_entry.resetFilters()
         return matching_entry

--- a/mcrit/storage/MatchingResult.py
+++ b/mcrit/storage/MatchingResult.py
@@ -620,11 +620,16 @@ class MatchingResult:
         summaries: List[Dict[str, Any]] = []
         current_function_id = None
         current_matches: List[Any] = []
+        # a query result carries its (temporary) function ids negated; fromDict reads the sign
+        # into is_query and stores the absolute id, so the sign goes back on here
+        fid_sign = -1 if self.is_query else 1
         for function_match_entry in self.function_matches:
             if function_match_entry.function_id != current_function_id:
                 current_function_id = function_match_entry.function_id
                 current_matches = []
-                summaries.append({"num_bytes": function_match_entry.num_bytes, "offset": function_match_entry.offset, "fid": current_function_id, "matches": current_matches})
+                summaries.append(
+                    {"num_bytes": function_match_entry.num_bytes, "offset": function_match_entry.offset, "fid": fid_sign * current_function_id, "matches": current_matches}
+                )
             current_matches.append(function_match_entry.getMatchTuple())
         # build the dictionary
         matching_entry = {

--- a/tests/testDataObjects.py
+++ b/tests/testDataObjects.py
@@ -196,6 +196,23 @@ class MinHashingTestSuite(unittest.TestCase):
         self.assertEqual("Function: fid(%d)" % flagged.function_id, str(flagged)[: len("Function: fid(%d)" % flagged.function_id)])
         self.assertTrue(str(flagged).endswith("flags(mp.)"))
 
+    def testQueryResultKeepsItsNegativeFunctionIdsOnTheWire(self):
+        """a query result's function ids are negative on the wire; fromDict folds the sign into
+        is_query, so toDict has to put it back for the round trip to hold"""
+        THIS_FILE_PATH = str(os.path.abspath(__file__))
+        PROJECT_ROOT = str(os.path.abspath(os.sep.join([THIS_FILE_PATH, "..", ".."])))
+        with open(os.sep.join([PROJECT_ROOT, "tests", "example_matching_report.json"])) as fjson:
+            match_json = json.load(fjson)
+        for summary in match_json["matches"]["functions"]:
+            summary["fid"] = -summary["fid"]
+        query_result = MatchingResult.fromDict(match_json)
+        self.assertTrue(query_result.is_query)
+        wire = query_result.toDict()
+        self.assertTrue(all(summary["fid"] < 0 for summary in wire["matches"]["functions"]))
+        reparsed = MatchingResult.fromDict(wire)
+        self.assertTrue(reparsed.is_query)
+        self.assertEqual([m.function_id for m in query_result.function_matches], [m.function_id for m in reparsed.function_matches])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testDataObjects.py
+++ b/tests/testDataObjects.py
@@ -178,7 +178,8 @@ class MinHashingTestSuite(unittest.TestCase):
         by_fid = lambda summary: summary["fid"]  # noqa: E731
         self.assertEqual(sorted(match_json["matches"]["functions"], key=by_fid), wire["matches"]["functions"])
         self.assertEqual(match_json["matches"]["aggregation"], wire["matches"]["aggregation"])
-        self.assertEqual(match_json["info"]["sample"], wire["info"]["sample"])
+        # the sample entry's own serialisation may carry more fields than the example file
+        self.assertEqual(SampleEntry.fromDict(match_json["info"]["sample"]).toDict(), wire["info"]["sample"])
 
         reparsed = MatchingResult.fromDict(wire)
         self.assertEqual(len(matching_result.function_matches), len(reparsed.function_matches))

--- a/tests/testDataObjects.py
+++ b/tests/testDataObjects.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 
 from smda.common.SmdaReport import SmdaReport
 
+import mcrit.matchers.MatcherFlags as MatcherFlags
 from mcrit.minhash.MinHash import MinHash
 from mcrit.storage.FunctionEntry import FunctionEntry
 from mcrit.storage.MatchingResult import MatchingResult
@@ -159,6 +160,40 @@ class MinHashingTestSuite(unittest.TestCase):
         assert matching_result.toDict() == before
         assert len(matching_result.function_matches) == 719
         assert len(matching_result.filtered_function_matches) == 719
+
+    def testMatchingResultRoundTripsThroughItsWireFormat(self):
+        """toDict must hand back the shape the matchers produce and fromDict reads: a list of
+        per-function summaries. It used to emit a dict keyed by function_id, which fromDict could
+        not read back (#44)."""
+        THIS_FILE_PATH = str(os.path.abspath(__file__))
+        PROJECT_ROOT = str(os.path.abspath(os.sep.join([THIS_FILE_PATH, "..", ".."])))
+        example_file_path = os.sep.join([PROJECT_ROOT, "tests", "example_matching_report.json"])
+        with open(example_file_path) as fjson:
+            match_json = json.load(fjson)
+
+        matching_result = MatchingResult.fromDict(match_json)
+        wire = matching_result.toDict()
+        self.assertIsInstance(wire["matches"]["functions"], list)
+        # function_matches is kept sorted by function_id, so the summaries come out in that order
+        by_fid = lambda summary: summary["fid"]  # noqa: E731
+        self.assertEqual(sorted(match_json["matches"]["functions"], key=by_fid), wire["matches"]["functions"])
+        self.assertEqual(match_json["matches"]["aggregation"], wire["matches"]["aggregation"])
+        self.assertEqual(match_json["info"]["sample"], wire["info"]["sample"])
+
+        reparsed = MatchingResult.fromDict(wire)
+        self.assertEqual(len(matching_result.function_matches), len(reparsed.function_matches))
+        self.assertEqual([m.getMatchTuple() for m in matching_result.function_matches], [m.getMatchTuple() for m in reparsed.function_matches])
+        self.assertEqual(matching_result.function_id_to_family_ids_matched, reparsed.function_id_to_family_ids_matched)
+        self.assertEqual(matching_result.library_matches, reparsed.library_matches)
+        self.assertEqual(matching_result.is_query, reparsed.is_query)
+        # the flag booleans are views on the flags integer the wire format carries
+        flagged = next(m for m in matching_result.function_matches if m.match_is_minhash and m.match_is_pichash and not m.match_is_library)
+        expected_flags = MatcherFlags.IS_MINHASH_FLAG | MatcherFlags.IS_PICHASH_FLAG
+        self.assertEqual(expected_flags, flagged.match_flags)
+        self.assertFalse(flagged.match_is_library)
+        self.assertEqual(expected_flags, flagged.getMatchTuple()[4])
+        self.assertEqual("Function: fid(%d)" % flagged.function_id, str(flagged)[: len("Function: fid(%d)" % flagged.function_id)])
+        self.assertTrue(str(flagged).endswith("flags(mp.)"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #44, which asks to consider dataclass conversion plus a marshalling accelerator for `MatchingResult`. This PR measures where the cost actually is, takes the in-tree gains, and fixes a round-trip bug found on the way.

## Measurement

Synthetic result of 3000 own functions x 80 matches = 240,000 pairs (7.3 MB JSON), best of three, Python 3.11:

| step | before | after |
|---|---|---|
| `json.loads` | 425 ms | (unchanged) |
| `MatchingResult.fromDict` | 411 ms | 311 ms |
| `MatchingResult.toDict` | 327 ms | 268 ms |
| first `filtered_function_matches` access | 532 ms | 395 ms |
| retained memory after `fromDict` | 52.0 MB (217 B/pair) | 34.8 MB (145 B/pair) |
| constructing 240k `MatchedFunctionEntry` alone | 386 ms | 301 ms |

What remains is the materialisation of one Python object per matched pair (about 1.25 µs each, versus 50 ms for 240k plain tuples). A marshalling library such as mashumaro generates the same kind of per-object constructor and would not remove that; the lever beyond this PR is representational (not materialising every pair, e.g. the existing `compact=True` result variant), which is a design change rather than an accelerator.

## Changes

- `MatchedFunctionEntry` uses `__slots__` and keeps the match flags as the integer the wire format carries; `match_is_minhash/pichash/library` are read-only views on it. That also makes `getMatchTuple` hand the flags back unchanged (the #155 fix, expressed by construction).
- `fromDict`: local append, set-backed membership tests instead of list scans, in-place sort.
- **Bug fix:** `toDict` emitted `matches.functions` as a dict keyed by function id, while the matchers produce (and `fromDict` reads) a list of per-function summaries, so `fromDict(toDict())` raised `TypeError`. It now emits the list, grouped from the sorted `function_matches`.
- Test: round trip through the wire format equals the example matching report, plus the flag views.

Full suite: 204 passed; ruff and ty clean.
