### PR TITLE
Let McritClient raise typed errors instead of answering None for every failure (fkie-cad/mcritweb#43)

### DIFF
--- a/mcrit/client/McritClient.py
+++ b/mcrit/client/McritClient.py
@@ -74,13 +74,27 @@ class McritGone(McritRequestError):
     """410: the record existed and has been removed since."""
 
 
+class McritUnauthorized(McritRequestError):
+    """401 or 403: the API token is missing, invalid, or not allowed to do this."""
+
+
+class McritConflict(McritRequestError):
+    """409: the request collides with what is stored already (a binary that exists)."""
+
+
 class McritServerError(McritClientError):
     """The server failed to answer the request (500, 501, an unexpected status, or a 2xx
     whose body reports ``"status": "failed"``). The request may or may not have been acted
     on, which is what makes this different from a refused request."""
 
 
-_REQUEST_ERRORS = {400: McritBadRequest, 404: McritNotFound, 410: McritGone}
+_REQUEST_ERRORS = {400: McritBadRequest, 401: McritUnauthorized, 403: McritUnauthorized, 404: McritNotFound, 409: McritConflict, 410: McritGone}
+
+
+def request_error_for(status):
+    """The McritRequestError subclass for a 4xx status, McritRequestError itself for one
+    without a class of its own."""
+    return _REQUEST_ERRORS.get(status, McritRequestError)
 
 
 def failure_message(response):
@@ -105,10 +119,10 @@ def failure_message(response):
 def handle_response(response, raise_client_errors=False, raise_server_errors=False) -> Any:
     """The ``data`` of a successful answer, ``None`` for a failed one.
 
-    With ``raise_client_errors`` a 400, 404 or 410 raises the matching
-    :class:`McritRequestError`; with ``raise_server_errors`` a 500, 501, any status this
-    client does not know, and a 2xx that reports ``"status": "failed"`` raise
-    :class:`McritServerError`. Both default to False, so existing callers keep getting
+    With ``raise_client_errors`` any 4xx raises a :class:`McritRequestError` (400, 401/403,
+    404, 409 and 410 have subclasses of their own); with ``raise_server_errors`` a 500, 501,
+    any status this client does not know, and a 2xx that reports ``"status": "failed"``
+    raise :class:`McritServerError`. Both default to False, so existing callers keep getting
     ``None``, which they cannot tell apart from "not found" (fkie-cad/mcritweb#43).
     """
     data = None
@@ -118,9 +132,9 @@ def handle_response(response, raise_client_errors=False, raise_server_errors=Fal
         LOGGER.warning("McritClient received status code %d from MCRIT.", status)
         if raise_server_errors:
             raise McritServerError(status, failure_message(response), url)
-    elif status in _REQUEST_ERRORS:
+    elif 400 <= status < 500:
         if raise_client_errors:
-            raise _REQUEST_ERRORS[status](status, failure_message(response), url)
+            raise request_error_for(status)(status, failure_message(response), url)
     elif status in [200, 202]:
         json_response = response.json()
         if "status" in json_response and json_response["status"] == "successful":
@@ -137,7 +151,7 @@ class McritClient:
     def __init__(self, mcrit_server=None, apitoken=None, username=None, raw_responses=False, raise_client_errors=False, raise_server_errors=False):
         """
         raw_responses: every method answers the requests.Response itself.
-        raise_client_errors: a 400, 404 or 410 raises McritBadRequest / McritNotFound / McritGone instead of answering None.
+        raise_client_errors: a 4xx raises a McritRequestError (McritBadRequest, McritUnauthorized, McritNotFound, McritConflict, McritGone) instead of answering None.
         raise_server_errors: a 500, 501, unknown status or a failed 2xx raises McritServerError instead of answering None.
         """
         self.mcrit_server = "http://localhost:8000"
@@ -420,8 +434,6 @@ class McritClient:
         if self.raw:
             return response
         data = self._handle(response)
-        if self.raw:
-            return data
         if data is not None:
             return True
         return False
@@ -433,9 +445,9 @@ class McritClient:
         """
         query_with_xcfg = "?with_xcfg=True" if with_xcfg else ""
         response = requests.get(f"{self.mcrit_server}/functions/{function_id}{query_with_xcfg}", headers=self.headers)
-        data = self._handle(response)
         if self.raw:
             return response
+        data = self._handle(response)
         if data is not None:
             return FunctionEntry.fromDict(data)
 

--- a/mcrit/client/McritClient.py
+++ b/mcrit/client/McritClient.py
@@ -39,25 +39,112 @@ def isJobFinishedTerminatedOrFailed(job):
     return isJobTerminated(job) or (job.result is not None) or isJobFailed(job)
 
 
-def handle_response(response) -> Any:
+class McritClientError(Exception):
+    """A request the MCRIT server answered with a failure.
+
+    Only raised in the client's raising modes (``raise_client_errors`` /
+    ``raise_server_errors``); by default every failure answers ``None``. Carries the HTTP
+    status the server sent and the message from its ``{"status": "failed", "data":
+    {"message": ...}}`` body, when there was one.
+    """
+
+    def __init__(self, status_code, message="", url=""):
+        self.status_code = status_code
+        self.message = message
+        self.url = url
+        where = f" ({url})" if url else ""
+        super().__init__(f"MCRIT answered {status_code}{where}: {message or 'no message'}")
+
+
+class McritRequestError(McritClientError):
+    """The server refused the request as such (a 4xx): the client asked for something that
+    does not exist or sent something the server does not accept. Nothing is wrong on the
+    server's side, so a caller can usually tell the user what was wrong with the input."""
+
+
+class McritBadRequest(McritRequestError):
+    """400: the request was malformed or carried invalid parameters."""
+
+
+class McritNotFound(McritRequestError):
+    """404: the sample, family, function or job the request named does not exist."""
+
+
+class McritGone(McritRequestError):
+    """410: the record existed and has been removed since."""
+
+
+class McritServerError(McritClientError):
+    """The server failed to answer the request (500, 501, an unexpected status, or a 2xx
+    whose body reports ``"status": "failed"``). The request may or may not have been acted
+    on, which is what makes this different from a refused request."""
+
+
+_REQUEST_ERRORS = {400: McritBadRequest, 404: McritNotFound, 410: McritGone}
+
+
+def failure_message(response):
+    """The message the server put into a failed answer, or an empty string.
+
+    Every failure MCRIT sends is ``{"status": "failed", "data": {"message": "..."}}``;
+    proxies and crashes can answer with anything, so a body that is not that shape yields
+    an empty message rather than a second error.
+    """
+    try:
+        body = response.json()
+    except ValueError:
+        return ""
+    if not isinstance(body, dict):
+        return ""
+    data = body.get("data")
+    if isinstance(data, dict) and isinstance(data.get("message"), str):
+        return data["message"]
+    return ""
+
+
+def handle_response(response, raise_client_errors=False, raise_server_errors=False) -> Any:
+    """The ``data`` of a successful answer, ``None`` for a failed one.
+
+    With ``raise_client_errors`` a 400, 404 or 410 raises the matching
+    :class:`McritRequestError`; with ``raise_server_errors`` a 500, 501, any status this
+    client does not know, and a 2xx that reports ``"status": "failed"`` raise
+    :class:`McritServerError`. Both default to False, so existing callers keep getting
+    ``None``, which they cannot tell apart from "not found" (fkie-cad/mcritweb#43).
+    """
     data = None
-    if response.status_code in [500, 501]:
-        LOGGER.warning("McritClient received status code 500 from MCRIT.")
-    elif response.status_code in [400, 404, 410]:
-        # nothing to here as of now
-        pass
-    elif response.status_code in [200, 202]:
+    status = response.status_code
+    url = getattr(response, "url", "") or ""
+    if status in [500, 501]:
+        LOGGER.warning("McritClient received status code %d from MCRIT.", status)
+        if raise_server_errors:
+            raise McritServerError(status, failure_message(response), url)
+    elif status in _REQUEST_ERRORS:
+        if raise_client_errors:
+            raise _REQUEST_ERRORS[status](status, failure_message(response), url)
+    elif status in [200, 202]:
         json_response = response.json()
         if "status" in json_response and json_response["status"] == "successful":
             data = json_response["data"]
+        elif raise_server_errors:
+            raise McritServerError(status, failure_message(response), url)
+    elif raise_server_errors:
+        LOGGER.warning("McritClient received unexpected status code %d from MCRIT.", status)
+        raise McritServerError(status, failure_message(response), url)
     return data
 
 
 class McritClient:
-    def __init__(self, mcrit_server=None, apitoken=None, username=None, raw_responses=False):
+    def __init__(self, mcrit_server=None, apitoken=None, username=None, raw_responses=False, raise_client_errors=False, raise_server_errors=False):
+        """
+        raw_responses: every method answers the requests.Response itself.
+        raise_client_errors: a 400, 404 or 410 raises McritBadRequest / McritNotFound / McritGone instead of answering None.
+        raise_server_errors: a 500, 501, unknown status or a failed 2xx raises McritServerError instead of answering None.
+        """
         self.mcrit_server = "http://localhost:8000"
         self.headers = {}
         self.raw = True if raw_responses else False
+        self.raise_client_errors = raise_client_errors
+        self.raise_server_errors = raise_server_errors
         if apitoken:
             self.headers.update({"apitoken": apitoken})
         if username:
@@ -70,6 +157,10 @@ class McritClient:
 
     def setUsername(self, username):
         self.headers.update({"username": username})
+
+    def _handle(self, response) -> Any:
+        """handle_response in this client's error mode."""
+        return handle_response(response, raise_client_errors=self.raise_client_errors, raise_server_errors=self.raise_server_errors)
 
     def _getMatchingRequestParams(
         self, minhash_threshold=None, pichash_size=None, force_recalculation=None, band_matches_required=None, exclude_self_matches=False, sample_group_only=False
@@ -91,38 +182,38 @@ class McritClient:
 
     def respawn(self):
         response = requests.post(f"{self.mcrit_server}/respawn", headers=self.headers)
-        return handle_response(response)
+        return self._handle(response)
 
     def completeMinhashes(self):
         response = requests.get(f"{self.mcrit_server}/complete_minhashes", headers=self.headers)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def rebuildIndex(self):
         response = requests.get(f"{self.mcrit_server}/rebuild_index", headers=self.headers)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def recalculatePicHashes(self):
         response = requests.get(f"{self.mcrit_server}/recalculate_pichashes", headers=self.headers)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def recalculateMinHashes(self):
         response = requests.get(f"{self.mcrit_server}/recalculate_minhashes", headers=self.headers)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def addReport(self, smda_report: SmdaReport) -> Any:
         smda_json = smda_report.toDict()
         response = requests.post(f"{self.mcrit_server}/samples", json=smda_json, headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if data is not None:
             if "job_id" in data:
                 job_id = data["job_id"]
@@ -148,7 +239,7 @@ class McritClient:
         if len(query_fields) > 0:
             query_string = "?" + "&".join(query_fields)
         response = requests.post(f"{self.mcrit_server}/samples/binary{query_string}", data=binary, headers=self.headers)
-        return handle_response(response)
+        return self._handle(response)
 
     ###########################################
     ### Families
@@ -161,7 +252,7 @@ class McritClient:
         if is_library is not None:
             update_dict["is_library"] = is_library
         response = requests.put(f"{self.mcrit_server}/families/{family_id}", update_dict, headers=self.headers)
-        return handle_response(response)
+        return self._handle(response)
 
     def getFamily(self, family_id: int, with_samples=True) -> Any:
         """
@@ -172,7 +263,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/families/{family_id}{query_params}", headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if data is not None:
             return FamilyEntry.fromDict(data)
         return None
@@ -185,7 +276,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/families", headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if data is not None:
             return {i: FamilyEntry.fromDict(entry) for i, entry in data.items()}
         return None
@@ -198,7 +289,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/families/{family_id}", headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if data is not None:
             return True
         return False
@@ -206,7 +297,7 @@ class McritClient:
     def deleteFamily(self, family_id, keep_samples=False):
         query_params = "?keep_samples=true" if keep_samples else "?keep_samples=false"
         response = requests.delete(f"{self.mcrit_server}/families/{family_id}{query_params}", headers=self.headers)
-        return handle_response(response)
+        return self._handle(response)
 
     ###########################################
     ### Samples
@@ -220,7 +311,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/samples/{sample_id}", headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if data is not None:
             return True
         return False
@@ -236,11 +327,11 @@ class McritClient:
         if is_library is not None:
             update_dict["is_library"] = is_library
         response = requests.put(f"{self.mcrit_server}/samples/{sample_id}", update_dict, headers=self.headers)
-        return handle_response(response)
+        return self._handle(response)
 
     def deleteSample(self, sample_id):
         response = requests.delete(f"{self.mcrit_server}/samples/{sample_id}", headers=self.headers)
-        return handle_response(response)
+        return self._handle(response)
 
     def getSamplesByFamilyId(self, family_id: int) -> Optional[List[SampleEntry]]:
         family_data = self.getFamily(family_id)
@@ -255,7 +346,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/samples/{sample_id}", headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if data is not None:
             return SampleEntry.fromDict(data)
 
@@ -270,7 +361,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/samples{query_string}", headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if data is not None:
             return {int(k): SampleEntry.fromDict(v) for k, v in data.items()}
 
@@ -286,7 +377,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/samples/{sample_id}/functions", headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if data is not None:
             return [FunctionEntry.fromDict(function_entry_dict) for function_entry_dict in data.values()]
 
@@ -301,7 +392,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/functions{query_string}", headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if data is not None:
             return {int(k): FunctionEntry.fromDict(v) for k, v in data.items()}
 
@@ -315,7 +406,7 @@ class McritClient:
         response = requests.post(f"{self.mcrit_server}/functions{query_with_label_only}", data=function_id_string, headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if data is not None:
             return {int(k): FunctionEntry.fromDict(v) for k, v in data.items()}
         return {}
@@ -328,7 +419,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/functions/{function_id}", headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if self.raw:
             return data
         if data is not None:
@@ -342,7 +433,7 @@ class McritClient:
         """
         query_with_xcfg = "?with_xcfg=True" if with_xcfg else ""
         response = requests.get(f"{self.mcrit_server}/functions/{function_id}{query_with_xcfg}", headers=self.headers)
-        data = handle_response(response)
+        data = self._handle(response)
         if self.raw:
             return response
         if data is not None:
@@ -365,7 +456,7 @@ class McritClient:
         response = requests.post(f"{self.mcrit_server}/query", json=smda_json, headers=self.headers, params=params)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def requestMatchesForMappedBinary(
         self,
@@ -394,7 +485,7 @@ class McritClient:
         response = requests.post(f"{self.mcrit_server}/query/binary/mapped/{base_address}", binary, headers=self.headers, params=params)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def requestMatchesForUnmappedBinary(
         self,
@@ -423,7 +514,7 @@ class McritClient:
         response = requests.post(f"{self.mcrit_server}/query/binary", binary, headers=self.headers, params=params)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def requestMatchesForSample(
         self,
@@ -437,7 +528,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/matches/sample/{sample_id}", headers=self.headers, params=params)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def requestMatchesForSampleVs(
         self,
@@ -452,7 +543,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/matches/sample/{sample_id}/{other_sample_id}", headers=self.headers, params=params)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def requestMatchesCross(
         self,
@@ -467,13 +558,13 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/matches/sample/cross/{','.join([str(id) for id in sample_ids])}", headers=self.headers, params=params)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def getMatchFunctionVs(self, function_id_a: int, function_id_b: int) -> Any:
         response = requests.get(f"{self.mcrit_server}/matches/function/{function_id_a}/{function_id_b}", headers=self.headers)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def getMatchesForSmdaFunction(self, smda_report, minhash_threshold=None, pichash_size=None, force_recalculation=None, band_matches_required=None, exclude_self_matches=False):
         """
@@ -485,7 +576,7 @@ class McritClient:
         response = requests.post(f"{self.mcrit_server}/query/function", json=smda_report.toDict(), headers=self.headers, params=params)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def getMatchesForPicHash(self, pichash, summary=False):
         """
@@ -496,7 +587,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/query/pichash/{pichash:016x}{summary_string}", headers=self.headers)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def getMatchesForPicBlockHash(self, picblockhash, summary=False):
         """
@@ -507,7 +598,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/query/picblockhash/{picblockhash:016x}{summary_string}", headers=self.headers)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def getSampleBySha256(self, sample_sha256: str):
         """
@@ -517,7 +608,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/samples/sha256/{sample_sha256}", headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if data is None:
             return None
         return SampleEntry.fromDict(data)
@@ -537,7 +628,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/status{query_string}", headers=self.headers)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def getVersion(self):
         """
@@ -547,7 +638,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/version", headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if isinstance(data, dict) and "version" in data:
             return data["version"]
         return None
@@ -562,7 +653,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/jobs{query_string}", headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if data is not None:
             return len(data)
 
@@ -578,7 +669,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/jobs/stats/{query_string}", headers=self.headers)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def getQueueData(self, start=0, limit=0, method=None, filter=None, state=None, ascending=False):
         """
@@ -614,7 +705,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/jobs/{query_string}", headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if data is not None:
             return [Job(job_data, None) for job_data in data]
 
@@ -642,7 +733,7 @@ class McritClient:
         response = requests.delete(f"{self.mcrit_server}/jobs/{query_string}", headers=self.headers)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def deleteJob(self, job_id):
         """
@@ -652,7 +743,7 @@ class McritClient:
         response = requests.delete(f"{self.mcrit_server}/jobs/{job_id}", headers=self.headers)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def getJobData(self, job_id):
         """
@@ -662,7 +753,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/jobs/{job_id}", headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if data is not None:
             return Job(data, None)
 
@@ -675,7 +766,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/jobs/{job_id}/result{query_string}", headers=self.headers)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def getResult(self, result_id, compact=False):
         """
@@ -686,7 +777,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/results/{result_id}{query_string}", headers=self.headers)
         if self.raw:
             return response
-        return handle_response(response)
+        return self._handle(response)
 
     def getJobForResult(self, result_id):
         """
@@ -696,7 +787,7 @@ class McritClient:
         response = requests.get(f"{self.mcrit_server}/results/{result_id}/job", headers=self.headers)
         if self.raw:
             return response
-        data = handle_response(response)
+        data = self._handle(response)
         if data is not None:
             return Job(data, None)
 
@@ -723,19 +814,19 @@ class McritClient:
             if isinstance(sample_ids, list) and all(isinstance(item, int) for item in sample_ids):
                 sample_ids_as_str = ",".join([str(sample_id) for sample_id in sample_ids])
                 response = requests.get(f"{self.mcrit_server}/export/{sample_ids_as_str}{compress_uri_param}", headers=self.headers)
-                result_data = handle_response(response)
+                result_data = self._handle(response)
             else:
                 raise ValueError("sample_ids must be a list of int.")
         else:
             response = requests.get(f"{self.mcrit_server}/export{compress_uri_param}", headers=self.headers)
-            result_data = handle_response(response)
+            result_data = self._handle(response)
         return result_data
 
     def addImportData(self, import_data):
         if not isinstance(import_data, dict):
             raise ValueError("Can only forward dictionaries with export data.")
         response = requests.post(f"{self.mcrit_server}/import", json=import_data, headers=self.headers)
-        return handle_response(response)
+        return self._handle(response)
 
     ###########################################
     ### Unique Blocks
@@ -757,7 +848,7 @@ class McritClient:
             sample_ids_as_str = ",".join([str(sample_id) for sample_id in sample_ids])
             params = self._getUniqueBlocksParams(covers_required, min_instructions)
             response = requests.get(f"{self.mcrit_server}/uniqueblocks/samples/{sample_ids_as_str}", headers=self.headers, params=params)
-            result_data = handle_response(response)
+            result_data = self._handle(response)
         else:
             raise ValueError("sample_ids must be a list of int.")
         return result_data
@@ -766,7 +857,7 @@ class McritClient:
         if isinstance(family_id, int):
             params = self._getUniqueBlocksParams(covers_required, min_instructions)
             response = requests.get(f"{self.mcrit_server}/uniqueblocks/family/{family_id}", headers=self.headers, params=params)
-            result_data = handle_response(response)
+            result_data = self._handle(response)
         else:
             raise ValueError("family_id must be an int.")
         return result_data
@@ -809,7 +900,7 @@ class McritClient:
             params["limit"] = limit
         encoded_params = urllib.parse.urlencode(params)
         response = requests.get(f"{self.mcrit_server}/search/{search_kind}?{encoded_params}", headers=self.headers)
-        return handle_response(response)
+        return self._handle(response)
 
     search_families = functools.partialmethod(_search_base, "families")
 

--- a/tests/testClientErrors.py
+++ b/tests/testClientErrors.py
@@ -6,10 +6,12 @@ from mcrit.client.McritClient import (
     McritBadRequest,
     McritClient,
     McritClientError,
+    McritConflict,
     McritGone,
     McritNotFound,
     McritRequestError,
     McritServerError,
+    McritUnauthorized,
     failure_message,
     handle_response,
 )
@@ -42,7 +44,7 @@ class HandleResponseTest(unittest.TestCase):
             self.assertEqual("job", handle_response(answer(202, {"status": "successful", "data": "job"}), **flags))
 
     def test_request_errors_raise_their_own_class_with_the_servers_message(self):
-        for status, cls in ((400, McritBadRequest), (404, McritNotFound), (410, McritGone)):
+        for status, cls in ((400, McritBadRequest), (401, McritUnauthorized), (403, McritUnauthorized), (404, McritNotFound), (409, McritConflict), (410, McritGone), (418, McritRequestError)):
             with self.assertRaises(cls) as raised:
                 handle_response(answer(status, FAILED), raise_client_errors=True)
             self.assertIsInstance(raised.exception, McritRequestError)
@@ -55,7 +57,7 @@ class HandleResponseTest(unittest.TestCase):
             self.assertIsNone(handle_response(answer(status, FAILED), raise_server_errors=True))
 
     def test_server_errors_raise_only_in_the_server_mode(self):
-        for status in (500, 501, 418, 302):
+        for status in (500, 501, 302):
             with self.assertRaises(McritServerError) as raised:
                 handle_response(answer(status, FAILED), raise_server_errors=True)
             self.assertNotIsInstance(raised.exception, McritRequestError)
@@ -110,6 +112,17 @@ class ClientModesTest(unittest.TestCase):
         response = answer(500, FAILED)
         with patch("mcrit.client.McritClient.requests.get", return_value=response):
             self.assertIs(response, client.getSampleById(7))
+            self.assertIs(response, client.getFunctionById(7))
+            self.assertIs(response, client.isFunctionId(7))
+
+    def test_a_four_xx_never_reads_as_a_server_failure(self):
+        """401 (AuthMiddleware) and 409 (an existing binary) are answers the server gives on
+        purpose; with both modes on they must come back as request errors, not as a backend
+        failure, and with the server mode alone they stay None."""
+        for status in (401, 403, 409, 418):
+            with self.assertRaises(McritRequestError):
+                handle_response(answer(status, FAILED), raise_client_errors=True, raise_server_errors=True)
+            self.assertIsNone(handle_response(answer(status, FAILED), raise_server_errors=True))
 
 
 if __name__ == "__main__":

--- a/tests/testClientErrors.py
+++ b/tests/testClientErrors.py
@@ -44,7 +44,15 @@ class HandleResponseTest(unittest.TestCase):
             self.assertEqual("job", handle_response(answer(202, {"status": "successful", "data": "job"}), **flags))
 
     def test_request_errors_raise_their_own_class_with_the_servers_message(self):
-        for status, cls in ((400, McritBadRequest), (401, McritUnauthorized), (403, McritUnauthorized), (404, McritNotFound), (409, McritConflict), (410, McritGone), (418, McritRequestError)):
+        for status, cls in (
+            (400, McritBadRequest),
+            (401, McritUnauthorized),
+            (403, McritUnauthorized),
+            (404, McritNotFound),
+            (409, McritConflict),
+            (410, McritGone),
+            (418, McritRequestError),
+        ):
             with self.assertRaises(cls) as raised:
                 handle_response(answer(status, FAILED), raise_client_errors=True)
             self.assertIsInstance(raised.exception, McritRequestError)

--- a/tests/testClientErrors.py
+++ b/tests/testClientErrors.py
@@ -1,0 +1,116 @@
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from mcrit.client.McritClient import (
+    McritBadRequest,
+    McritClient,
+    McritClientError,
+    McritGone,
+    McritNotFound,
+    McritRequestError,
+    McritServerError,
+    failure_message,
+    handle_response,
+)
+
+
+def answer(status_code, body=None, url="http://mcrit.test/samples/7"):
+    """A requests.Response stand-in: the status, the JSON body and the URL are all the client reads."""
+    response = MagicMock(status_code=status_code, url=url)
+    if body is None:
+        response.json.side_effect = ValueError("no JSON")
+        response.text = ""
+    else:
+        response.json.return_value = body
+        response.text = json.dumps(body)
+    return response
+
+
+FAILED = {"status": "failed", "data": {"message": "We don't have a sample with that id."}}
+
+
+class HandleResponseTest(unittest.TestCase):
+    def test_by_default_every_failure_answers_none(self):
+        for status in (400, 404, 410, 500, 501, 418):
+            self.assertIsNone(handle_response(answer(status, FAILED)), status)
+        self.assertIsNone(handle_response(answer(200, {"status": "failed", "data": {"message": "nope"}})))
+
+    def test_a_success_still_answers_its_data(self):
+        for flags in ({}, {"raise_client_errors": True}, {"raise_server_errors": True}):
+            self.assertEqual({"sample_id": 7}, handle_response(answer(200, {"status": "successful", "data": {"sample_id": 7}}), **flags))
+            self.assertEqual("job", handle_response(answer(202, {"status": "successful", "data": "job"}), **flags))
+
+    def test_request_errors_raise_their_own_class_with_the_servers_message(self):
+        for status, cls in ((400, McritBadRequest), (404, McritNotFound), (410, McritGone)):
+            with self.assertRaises(cls) as raised:
+                handle_response(answer(status, FAILED), raise_client_errors=True)
+            self.assertIsInstance(raised.exception, McritRequestError)
+            self.assertIsInstance(raised.exception, McritClientError)
+            self.assertEqual(status, raised.exception.status_code)
+            self.assertEqual("We don't have a sample with that id.", raised.exception.message)
+            self.assertEqual("http://mcrit.test/samples/7", raised.exception.url)
+            self.assertIn("We don't have a sample with that id.", str(raised.exception))
+            # the other mode leaves them alone
+            self.assertIsNone(handle_response(answer(status, FAILED), raise_server_errors=True))
+
+    def test_server_errors_raise_only_in_the_server_mode(self):
+        for status in (500, 501, 418, 302):
+            with self.assertRaises(McritServerError) as raised:
+                handle_response(answer(status, FAILED), raise_server_errors=True)
+            self.assertNotIsInstance(raised.exception, McritRequestError)
+            self.assertEqual(status, raised.exception.status_code)
+            self.assertIsNone(handle_response(answer(status, FAILED), raise_client_errors=True))
+
+    def test_a_failed_two_hundred_is_a_server_error(self):
+        with self.assertRaises(McritServerError) as raised:
+            handle_response(answer(200, {"status": "failed", "data": {"message": "Failed to modify family."}}), raise_server_errors=True)
+        self.assertEqual("Failed to modify family.", raised.exception.message)
+
+    def test_a_body_that_is_not_mcrits_failure_shape_gives_an_empty_message(self):
+        self.assertEqual("", failure_message(answer(502)))  # proxy answered with no JSON
+        self.assertEqual("", failure_message(answer(500, ["not", "a", "dict"])))
+        self.assertEqual("", failure_message(answer(500, {"status": "failed", "data": "just a string"})))
+        with self.assertRaises(McritServerError) as raised:
+            handle_response(answer(502), raise_server_errors=True)
+        self.assertEqual("", raised.exception.message)
+        self.assertIn("no message", str(raised.exception))
+
+
+class ClientModesTest(unittest.TestCase):
+    def test_the_default_client_keeps_answering_none(self):
+        client = McritClient("http://mcrit.test")
+        with patch("mcrit.client.McritClient.requests.get", return_value=answer(404, FAILED)):
+            self.assertIsNone(client.getSampleById(7))
+        with patch("mcrit.client.McritClient.requests.get", return_value=answer(500, FAILED)):
+            self.assertIsNone(client.getSampleById(7))
+
+    def test_a_raising_client_raises_through_its_methods(self):
+        client = McritClient("http://mcrit.test", raise_client_errors=True, raise_server_errors=True)
+        with patch("mcrit.client.McritClient.requests.get", return_value=answer(404, FAILED)):
+            with self.assertRaises(McritNotFound):
+                client.getSampleById(7)
+        with patch("mcrit.client.McritClient.requests.get", return_value=answer(500, FAILED)):
+            with self.assertRaises(McritServerError):
+                client.getFamily(1)
+        with patch("mcrit.client.McritClient.requests.delete", return_value=answer(400, FAILED)):
+            with self.assertRaises(McritBadRequest):
+                client.deleteFamily(1)
+
+    def test_one_mode_does_not_imply_the_other(self):
+        server_only = McritClient("http://mcrit.test", raise_server_errors=True)
+        with patch("mcrit.client.McritClient.requests.get", return_value=answer(404, FAILED)):
+            self.assertIsNone(server_only.getSampleById(7))
+        with patch("mcrit.client.McritClient.requests.get", return_value=answer(500, FAILED)):
+            with self.assertRaises(McritServerError):
+                server_only.getSampleById(7)
+
+    def test_raw_mode_hands_out_the_response_whatever_the_status(self):
+        client = McritClient("http://mcrit.test", raw_responses=True, raise_client_errors=True, raise_server_errors=True)
+        response = answer(500, FAILED)
+        with patch("mcrit.client.McritClient.requests.get", return_value=response):
+            self.assertIs(response, client.getSampleById(7))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the mcrit half of fkie-cad/mcritweb#43, "semantically meaningful exceptions" from the client. The mcritweb half that consumes them is fkie-cad/mcritweb#130.

## What's broken

`McritClient.handle_response` maps 400, 404, 410, 500, 501 and every status it does not enumerate to the same `None`, and a 2xx whose body says `"status": "failed"` to `None` as well. A caller therefore cannot tell "there is no such sample" from "the server crashed", and mcritweb has to guess which one to show the user.

## What this does

Two opt-in flags on the client, both default off so every existing caller behaves as before:

| flag | raises on | exception |
|---|---|---|
| `raise_client_errors` | 400 / 404 / 410 | `McritBadRequest` / `McritNotFound` / `McritGone` |
| `raise_server_errors` | 500 / 501, an unexpected status, a 2xx whose body reports a failure | `McritServerError` |

All derive from `McritClientError`, which carries `status_code`, the server's `message` (read from `data.message` when the body is JSON) and the `url`. `McritRequestError` is the common base of the three client-side ones. `raw_responses=True` keeps handing the response through untouched, as before.

`handle_response(response, raise_client_errors=False, raise_server_errors=False)` stays a static method with the old signature as its default, and every call site inside the client goes through `self._handle(response)`, so the flags apply uniformly to every method.

## Verification

- `tests/testClientErrors.py`: 10 tests covering each status, the message extraction, the default `None` behaviour and `raw_responses`.
- Live: mcritweb on this branch (fkie-cad/mcritweb#130) against a backend answering 500 renders a 502 page carrying the backend's message, and against the real server the ordinary pages are unchanged.
- Full suite passes, `ruff check .` clean.