### PR TITLE
Adopt Keep a Changelog, keeping the entries' depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,142 @@
 # Changelog
 
-Newest first. Entries carry the release date, the version, and what changed.
+All notable changes to this project are documented in this file.
 
- * 2026-09-08 v1.9.0:  Correctness and operator-recovery release, plus a large `getUniqueBlocks` speedup. **Matching results are unchanged at default configuration** - a reference matching digest over an 11.6M-function corpus reproduced byte-for-byte against v1.8.1 (8,125,782 bytes of match payload, 5,523 sample matches) - and the database shape is unchanged, so no migration is required. Two of the fixes below *can* change reported numbers, which is why that statement is qualified: the percentage denominator is now sized by what the request can actually match, which differs from before only when a request passes a `pichash_size` other than the configured `MINHASH_FN_MIN_INS` (#156); and a function unique to one family is now weighted by its best match rather than whichever came last (#157). **BREAKING (consumers of the Python objects, not the wire format):** `MatchedFunctionEntry.match_is_minhash`, `match_is_pichash` and `match_is_library` are now `bool` properties over the stored flag integer rather than the masked integer itself, which is what makes `getMatchTuple()` hand the flags back unchanged - it previously multiplied already-masked bits by their flag again, so a pichash-only match round-tripped as `IS_LIBRARY` and a library match lost its flag entirely, on a served route (#155). Truthiness is unaffected, so `if entry.match_is_pichash` behaves as before; code comparing them to `2` or `4` must change. `MatchingResult.toDict()` also emitted `matches.functions` as a dict where `fromDict` reads a list, so `fromDict(toDict())` raised `TypeError`; the wire format now round-trips, and `MatchedFunctionEntry` uses `__slots__` (217 -> 145 bytes retained per matched pair, measured on a 240k-pair report) (#44). Serving a stored result no longer parses the GridFS JSON only to re-serialise it: both result routes hand out the stored bytes inside the response envelope, which was **0.66 s of a 1.03 s report open** on an 8 MB report (#152); `compact=true` still parses, since it edits the result. A sample search for an unknown sha256 answers with no match instead of HTTP 500 (#158). **Reliability of the queue and the denormalised bookkeeping**, all of which had silent failure modes: a worker killed without unwinding (the OOM killer's way) used to strand its job forever, because `next()` only hands out unlocked jobs and nothing cleared the lock - and `get_cached_job_id()` then served that dead job's id to every identical resubmission, which waited on work that could never run; workers now carry a heartbeat, a registered worker whose heartbeat is older than the queue timeout is treated as dead and its jobs are reclaimed with one attempt fewer, and the cached-job lookup only serves a job that is finished, waiting, or in flight on a live worker (#150). The per-family counters that `/status` sums are now kept consistent with the collections they summarise - increments against a missing family are logged rather than silently discarded, imports create the family document their sample references, `modifySample` uses atomic `$inc` instead of read-modify-write, `deleteSample` decrements by what it actually removed, and family deletion is judged by whether any sample still references the family rather than by a counter that may have drifted; `recomputeFamilyStats()` puts an already-drifted instance right and reports every correction (#151). `deleteSample` no longer leaves an emptied band posting list behind, and no longer *creates* band documents through an `upsert` on the pull path (#149). **An escaper change no longer costs a full reindex**: each sample records which SMDA version escaped its minhashes, `/status` reports the compatibility threshold and how many samples are stale, and `repair_minhashes` rehashes only those samples, one at a time, with the index serving throughout - where `recalculateMinHashes` drops every band collection and rehashes the whole corpus (#142). `getUnhashedFunctions` now selects in the database and skips functions that can never be hashed; its work set was "minhash is empty", which on a real corpus included 4.16M functions below `MINHASH_FN_MIN_INS` whose disassembly it re-fetched on every invocation, which is what made the repair above impractical to run at all. **`getUniqueBlocks` is answered from an inverted index** rather than by reading every function that carries picblockhashes - 9,088,495 documents and 51,364,030 block entries streamed into Python on the reference corpus, about 92 s per call regardless of how many samples were asked about. A `picblockhashes` collection keyed by block hash makes that **92 s -> 0.11 s for one sample and 107 s -> 2.9 s for five**, reading one document per candidate hash; it is maintained on the write paths and costs 0.47 GB plus its `_id` index over 12.1M distinct hashes. It is read only when a completeness flag vouches for it, so an existing database keeps using the old scan - retained, not deleted - until `rebuild_picblockhash_index` has run once: upgrading changes performance, never results. The unused `_picblockhashes.offset` index is no longer created; no query could use it (the only reference is a `$project`), and it held 0.678 GB - 27% of the `functions` index footprint - plus a multikey write per block per function. Adds `STORAGE_BAND_STRATEGY = "explicit"`, which states each band's signature offsets directly - via `STORAGE_BAND_PROJECTION` or a name from `STORAGE_BAND_PRESET` - instead of deriving them from a seed (`random`) or a stride (`linear`). It subsumes both, and allows what neither can express: bands of differing size, overlapping bands, and bands confined to one shingler's segment of the signature. That last one is the point. `generate_segmented_sequence` puts the metric shingler's fields at offsets 0-15 and the block shingler's at 16-63, and a band matches only if *all* its fields match, so a band spanning both segments fails when either segment moves - and the two move independently: recompilation shifts function metrics while block structure survives, and an escaper change (SMDA 4.4.5) moved block fields on ~20% of a real corpus while metrics stayed put. Existing behaviour is unchanged - `random` remains the default - and the `legacy-random-20x4` and `legacy-linear-16x4` presets reproduce the two derived strategies exactly, so an instance can move to `explicit` without reindexing (asserted in the new tests, and verified on an 11.6M-function corpus where a reference matching digest reproduced byte-for-byte against an index built under the seed-derived projection). Under `explicit`, `STORAGE_NUM_BANDS` derives from the projection, which every consumer already tolerates since they only ever iterate `range(STORAGE_NUM_BANDS)` and treat a band as an opaque numbered bucket. Validation reports coverage rather than requiring it - overlapping and partial projections are legitimate LSH, and the long-shipped `random` default covers only 45 of 64 fields - but a projection that silently ignores a third of the signature now says so at startup, as does one where no band avoids the metric segment (the `linear` stride puts exactly one metric field in every band, so a recompilation that shifts metrics can lose all bands at once). `getBandProjectionFingerprint` identifies the projection an index was built under: band keys are derived data exactly like minhashes, so changing the projection without rebuilding leaves an index that still resolves, still returns candidates, and is quietly wrong. NOTE that band offset *order within a band* is significant - a band hash concatenates the field values in projection order - so neither the presets nor the fingerprint normalise it; sorting a projection's offsets yields one that covers the same fields and retrieves almost nothing against an index built under the unsorted form. Two defects fixed alongside: `rebuildMinhashBandIndex` dropped only `band_0..STORAGE_NUM_BANDS-1`, so lowering the band count stranded the surplus collections holding entries under the previous projection, invisible to matching and consuming disk until someone raised the count again; and `STORAGE_BAND_STRATEGY` carried no type annotation, so it was not a dataclass field and could not be set through `StorageConfig(...)` like every neighbouring setting. **NOTE, five one-time operator actions** are available after upgrading, none of them automatic and none required for correct serving: `rebuild_picblockhash_index` (enables the fast `getUniqueBlocks`), `recompute_family_stats` (corrects counters already drifted), `repair_minhashes` (rehashes samples an older escaper hashed), `purgeEmptyBandDocuments()` (clears band tombstones older deletions left), and `db.functions.dropIndex("_picblockhashes.offset_1")` (reclaims the index above on an existing instance). NOTE also that the new endpoints mean MCRITweb needs a matching release to use any of them; MCRITweb itself works unchanged against this version.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) over **the REST API, the
+configuration surface and the stored data shape**. Python object internals - the classes in
+`mcrit.storage` and friends - may change in a minor release; where that is expected to break a
+consumer, the entry says so.
+
+Entries carry the measurement, the caveat and the failure mode, not just the change: a line that
+says what moved without saying what it cost, what it cannot see, or how it would be noticed is
+worth less than the space it takes. Add yours to `[Unreleased]` when the change merges, while the
+reasoning is still at hand, rather than reconstructing it from the commit log at release time.
+
+## [Unreleased]
+
+## [1.9.0] - 2026-09-08
+
+Correctness and operator-recovery release, plus a large `getUniqueBlocks` speedup. **Matching
+results are unchanged at default configuration** - a reference digest over an 11.6M-function corpus
+reproduced byte-for-byte against v1.8.1 (8,125,782 bytes of match payload, 5,523 sample matches) -
+and the database shape is unchanged, so no migration is required. Two fixes below *can* change
+reported numbers; see `Changed`.
+
+### Added
+
+- `explicit` band projection strategy, stating each band's signature offsets directly via
+  `STORAGE_BAND_PROJECTION` or a name from `STORAGE_BAND_PRESET`, instead of deriving them from a
+  seed (`random`) or a stride (`linear`). It allows what neither can express: bands of differing
+  size, overlapping bands, and bands confined to one shingler's segment of the signature. That last
+  is the point - `generate_segmented_sequence` puts metric fields at offsets 0-15 and block fields
+  at 16-63, a band matches only if *all* its fields match, and the two segments move independently:
+  recompilation shifts metrics while block structure survives, and the SMDA 4.4.5 escaper change
+  moved block fields on ~20% of a real corpus while metrics stayed put. `random` remains the
+  default, and `legacy-random-20x4` / `legacy-linear-16x4` reproduce the derived strategies exactly,
+  so an instance can adopt `explicit` without reindexing - asserted in tests and verified on an
+  11.6M-function corpus where a reference digest reproduced byte-for-byte against an index built
+  under the seed-derived projection ([#147]).
+- `getBandProjectionFingerprint`, identifying the projection an index was built under. Band keys are
+  derived data exactly like minhashes, so changing the projection without rebuilding leaves an index
+  that still resolves, still returns candidates, and is quietly wrong. NOTE that offset *order
+  within a band* is significant - a band hash concatenates field values in projection order - so
+  neither the presets nor the fingerprint normalise it ([#147]).
+- Inverted `picblockhashes` collection answering `getUniqueBlocks`: **92 s -> 0.11 s for one sample
+  and 107 s -> 2.9 s for five** on the reference corpus, reading one document per candidate hash
+  instead of every function carrying block hashes (9,088,495 documents, 51,364,030 block entries,
+  and a cost independent of how many samples were requested). It is read only when a completeness
+  flag vouches for it, so an existing database keeps using the old scan - retained, not deleted -
+  until `rebuild_picblockhash_index` has run once: upgrading changes performance, never results
+  ([#154]).
+- `POST /repair_minhashes`, rehashing only the samples an older SMDA escaper hashed, one sample at a
+  time and with the index serving throughout, where `recalculateMinHashes` drops every band
+  collection and rehashes the whole corpus. Each sample records which SMDA version escaped its
+  minhashes, and `/status` reports `minhash_compatibility_threshold` and
+  `num_samples_with_stale_minhashes` ([#142]).
+- `POST /recompute_family_stats`, setting every family's counters from the collections, recreating
+  family documents that samples reference but no document describes, and reporting every correction
+  ([#151]).
+- `GET /rebuild_picblockhash_index` ([#154]) and `purgeEmptyBandDocuments()` ([#149]), both for an
+  operator to run once after upgrading.
+
+### Changed
+
+- **BREAKING for Python consumers:** `MatchedFunctionEntry.match_is_minhash`, `match_is_pichash` and
+  `match_is_library` are now `bool` properties over the stored flag integer rather than the masked
+  integer itself. Truthiness is unaffected - `if entry.match_is_pichash` behaves as before - but
+  code comparing them to `2` or `4` must change. The wire format is unchanged ([#155]).
+- The percentage denominator is sized by what the request can actually match. This differs from
+  before **only** when a request passes a `pichash_size` other than the configured
+  `MINHASH_FN_MIN_INS`; where the two agree, reported percentages are unchanged ([#156]).
+- A function unique to one family is weighted by its best match rather than whichever match came
+  last ([#157]).
+- Stored results are served as the bytes they were stored with rather than parsed and immediately
+  re-serialised, which was **0.66 s of a 1.03 s report open** on an 8 MB report. `compact=true`
+  keeps the parsing path, since it edits the result ([#152]).
+- `getUnhashedFunctions` selects in the database and skips functions that can never be hashed. Its
+  work set was "minhash is empty", which on a real corpus included 4.16M functions below
+  `MINHASH_FN_MIN_INS` whose disassembly it re-fetched on every invocation - which is what made a
+  minhash repair impractical to run at all.
+- `MatchedFunctionEntry` uses `__slots__`: 217 -> 145 bytes retained per matched pair, measured on a
+  240k-pair report ([#44]).
+- `rebuildMinhashBandIndex` drops every `band_*` collection present, not only
+  `band_0..STORAGE_NUM_BANDS-1`; lowering the band count previously stranded the surplus
+  collections, invisible to matching and consuming disk ([#147]).
+
+### Removed
+
+- The `_picblockhashes.offset` index is no longer created. No query can use it - the only reference
+  to that field is a `$project`, which an index cannot serve - and it held 0.678 GB, **27% of the
+  `functions` collection's index footprint**, plus a multikey write per block per function on every
+  insert. Existing instances keep their copy until it is dropped explicitly; see `Upgrading`.
+
+### Fixed
+
+- `getMatchTuple()` corrupted the match flags on a served route, multiplying already-masked bits by
+  their flag a second time: a pichash-only match round-tripped as `IS_LIBRARY` (2 -> 4) and a
+  library match lost its flag entirely (4 -> 16) ([#155]).
+- `MatchingResult.toDict()` emitted `matches.functions` as a dict keyed by function id where
+  `fromDict` reads a list, so `fromDict(toDict())` raised `TypeError` ([#44]).
+- A worker killed without unwinding - the OOM killer's way - stranded its job forever: `next()` only
+  hands out unlocked jobs and nothing cleared the lock, and `get_cached_job_id()` then served that
+  dead job's id to every identical resubmission, which waited on work that could never run. Workers
+  now carry a heartbeat, a registered worker whose heartbeat is older than the queue timeout is
+  treated as dead and its unfinished jobs are reclaimed with one attempt fewer, and the cached-job
+  lookup only serves a job that is finished, waiting, or in flight on a live worker ([#150]).
+- The per-family counters `/status` sums drifted from the collections they summarise: increments
+  against a missing family were silently discarded, imports did not create the family document their
+  sample references, `modifySample` used read-modify-write where concurrent relabels lose an update,
+  `deleteSample` decremented by the sample's stored statistics rather than by what it removed, and
+  family deletion was judged by a counter that may have drifted rather than by whether any sample
+  still references the family ([#151]).
+- `deleteSample` left an emptied band posting list behind, and its `upsert` on the pull path could
+  *create* band documents - so a delete could grow the index ([#149]).
+- A sample search for an unknown sha256 answers with no match instead of HTTP 500 ([#158]).
+- `STORAGE_BAND_STRATEGY` carried no type annotation, so it was not a dataclass field and could not
+  be set through `StorageConfig(...)` like every neighbouring setting ([#147]).
+
+### Upgrading
+
+No database-shape change, so **no migration is required**. Five one-time operator actions are
+available, none of them automatic and none required for correct serving:
+
+| action | effect |
+|---|---|
+| `rebuild_picblockhash_index` | enables the fast `getUniqueBlocks`; until it runs, the previous full scan is used |
+| `recompute_family_stats` | corrects counters that have already drifted |
+| `repair_minhashes` | rehashes only the samples an older escaper hashed |
+| `purgeEmptyBandDocuments()` | clears the band tombstones older deletions left |
+| `db.functions.dropIndex("_picblockhashes.offset_1")` | reclaims the index above on an existing instance |
+
+The new endpoints mean MCRITweb needs a matching release to *use* them; MCRITweb works unchanged
+against this version either way.
+
+## Older releases
+
+Entries below predate this format and are kept verbatim, newest first. Each carries the release
+date, the version, and what changed.
+
  * 2026-08-25 v1.8.1:  Declares `packaging` as a dependency, which `MongoDbStorage` has imported all along without it ever being listed - not in `pyproject.toml` and not in the `requirements.txt` it replaced. It was satisfied by accident, because that file also listed `pytest`, which depends on packaging; 1.8.0 correctly moved the test tooling to the `dev` extra and took packaging with it, so **`mcrit server` and `mcrit worker` cannot start on a clean 1.8.0 install** - `ModuleNotFoundError: No module named 'packaging'` from `MongoDbStorage.py`. Anyone on 1.8.0 should upgrade; an environment that happens to carry packaging (a dev checkout, or anything with pytest installed) is unaffected either way. The CI build job now installs the built wheel into a venv with nothing else in it and imports the server, the storage factory and the CLI from outside the checkout, so an undeclared runtime dependency or a wheel missing code fails the build - every other job installs the `dev` extra and can therefore never see it.
  * 2026-08-25 v1.8.0:  Packaging, tooling and latent-bug release; matching results, configuration and database shape are unchanged from v1.7.1, and no re-index or migration is required. BREAKING (build only): `requirements.txt` and `requirements-dev.txt` are gone - dependencies live in `pyproject.toml`, so install with `pip install -e .` and `pip install -e ".[dev]"` for the development tooling (docker-mcrit is updated to match). `setup.py`, `pytest.ini`, `.coveragerc`, `ruff.toml` and `.pylintrc` collapse into that one file as well, which also stops `pytest`, `pytest-cov` and `coverage` from being installed as *runtime* dependencies of the wheel (#101, THX to @r0ny123!). CI pins every action to a commit SHA, drops its token permissions to the minimum per job, adds timeouts and Dependabot, tests 3.11 through 3.14, and gates on the `ty` type checker next to `ruff`. Adopting `ty` is what makes this more than a tooling release: it surfaced eleven latent bugs, all fixed here (#102, THX to @r0ny123!). Five `MemoryStorage` methods raised on every call - `modifyFamily(is_library=...)`, `deleteFamily(keep_samples=True)`, `getUniqueBlocks`, `getMatchesForPicBlockHash` and the query-sample accessors, which did not accept `is_query` and so broke `Worker`'s query-sample cleanup on that backend; `addStorageContent` wrote a 2-tuple into the pichash index where every other site writes `(family_id, sample_id, function_id)`, silently corrupting it on import. `mcrit server` could not start where gunicorn is absent (i.e. on Windows, where the dependency marker excludes it), `MongoDbStorage.deleteSample` reported a successful query-sample deletion as a failure, `getCandidatesForMinHash` returned `None` where the memory backend returns an empty set, and `LocalQueue._file_to_grid` raised on `str` input. The `AUTH_TOKEN` can now be supplied via the `MCRIT_AUTH_TOKEN` environment variable instead of being edited into the installed config, the API token is compared in constant time, and a server that serves an unprotected API says so in its log (#96, THX to @r0ny123!). Malformed search queries - an unbalanced parenthesis, a dangling operator - are answered with HTTP 400 and the parser's message instead of a 500 and a traceback (#146). `getUniqueBlocks` reports `yara_covers` for real rather than always `0`, and its block entries now carry the same fields on both storage backends, which is what the block cover needs to run on the memory backend at all (#144).
  * 2026-08-24 v1.7.1:  Bugfix release; matching results, configuration and database shape are unchanged from v1.7.0. Search conditions on `pichash` no longer crash the Mongo search transpiler: every condition used to be passed through an `_encodePichash(None, ...)` call that could never work, so a condition on `pichash` raised instead of querying. Conditions now behave per operator - `:`, `=` and `!=` hex-encode the value, `?` and `!?` match a regex against the stored hex representation, and the four range operators are rejected with an explicit error, because the stored form is a variable-length hex string on which comparisons are not meaningful (#100, THX to @r0ny123!; #145 tracks the zero-padded encoding that would make them work). Consequently, sorting function search results by `pichash` is unsupported on the MongoDB backend and now says so: it never worked, since the search cursor pages by comparing the sort field, and the sort named `pichash` where the document stores `_pichash` - so a first page that looked fine was mis-sorted and the second page crashed. Search endpoints answer an unsupported field, operator or sort field with `{"status": "failed"}` and HTTP 400 instead of a 500 and a traceback, and the `sort_by` whitelists raise instead of asserting. Cross-compare reports no longer emit phantom entries for samples outside the requested set, which could leave `matching_percent` with rows of inconsistent width and break the downstream clustering (#98, resolving a TODO from 2022, also THX to @r0ny123!). Minhash storage is now query-function aware: `addMinHash`/`addMinHashes` route negative function ids to `query_functions`, skip banding for them (they are query input only, never index material), and warn instead of silently dropping minhashes whose function does not exist (#97, THX to @r0ny123!) - no production path feeds query functions into either method today, as `MatcherQuery` hashes them in memory, so this hardens a latent case rather than fixing an observed one. Regex literals across the server resources use raw strings and ruff now enforces W605 to keep it that way (#103), plus tests for the serialization helpers (#99), the search transpiler, the search responders and the query-function minhash routing.
@@ -129,3 +263,18 @@ Newest first. Entries carry the release date, the version, and what changed.
  * 2022-02-09  v0.9.0: Added PicBlocks to MCRIT.
  * 2022-01-19  v0.8.0: Migrated the client and the examples into the primary MCRIT repository.
  * 2021-12-16  v0.7.0: Initial private release.
+
+[Unreleased]: https://github.com/danielplohmann/mcrit/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/danielplohmann/mcrit/compare/v1.8.1...v1.9.0
+[#44]: https://github.com/danielplohmann/mcrit/issues/44
+[#142]: https://github.com/danielplohmann/mcrit/issues/142
+[#147]: https://github.com/danielplohmann/mcrit/pull/147
+[#149]: https://github.com/danielplohmann/mcrit/issues/149
+[#150]: https://github.com/danielplohmann/mcrit/issues/150
+[#151]: https://github.com/danielplohmann/mcrit/issues/151
+[#152]: https://github.com/danielplohmann/mcrit/issues/152
+[#154]: https://github.com/danielplohmann/mcrit/pull/154
+[#155]: https://github.com/danielplohmann/mcrit/issues/155
+[#156]: https://github.com/danielplohmann/mcrit/issues/156
+[#157]: https://github.com/danielplohmann/mcrit/issues/157
+[#158]: https://github.com/danielplohmann/mcrit/issues/158

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,12 @@ reported numbers; see `Changed`.
 - `deleteSample` left an emptied band posting list behind, and its `upsert` on the pull path could
   *create* band documents - so a delete could grow the index ([#149]).
 - A sample search for an unknown sha256 answers with no match instead of HTTP 500 ([#158]).
+- `renderRule` tested the `wrap_string` *function* for truthiness where it meant the `wrap_at`
+  parameter, so `wrap_at` was never read: YARA rules were always wrapped, always at a hardcoded 80
+  columns, and the single-line branch was unreachable. MCRITweb had been asking for `wrap_at=40` and
+  silently getting 80. `wrap_at` is now both the switch and the width - `0` keeps the hex on one
+  line, `N` wraps at `N` - and its default moves from `0` to `80`, the width callers were already
+  getting, so output changes only for callers that ask ([#186]).
 - `STORAGE_BAND_STRATEGY` carried no type annotation, so it was not a dataclass field and could not
   be set through `StorageConfig(...)` like every neighbouring setting ([#147]).
 
@@ -278,3 +284,4 @@ date, the version, and what changed.
 [#156]: https://github.com/danielplohmann/mcrit/issues/156
 [#157]: https://github.com/danielplohmann/mcrit/issues/157
 [#158]: https://github.com/danielplohmann/mcrit/issues/158
+[#186]: https://github.com/danielplohmann/mcrit/issues/186


### PR DESCRIPTION
Adopts [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), as r0ny123 suggested — with two additions the spec does not cover and this project needs. **One file changes.**

### What the spec gives us

The six standard sections (`Added` / `Changed` / `Deprecated` / `Removed` / `Fixed` / `Security`, omitted when empty), an `Unreleased` section, ISO dates, and comparison links at the bottom.

**The `Unreleased` section is the real win, not the formatting.** The 1.9.0 entry in this PR was reconstructed from 14 merge commits after the fact — which is exactly the "commit log diff" anti-pattern the spec warns about, done by hand. An `Unreleased` section means each change is written down when it merges, while the author still remembers the caveat.

### Two departures from the spec, both deliberate

**A release summary paragraph under the version heading.** *"Matching results are unchanged at default configuration"* is the single most load-bearing sentence in an mcrit release note, and the bullet structure gives a reader nowhere to meet it first.

**An `### Upgrading` block.** 1.9.0 alone introduces five one-time operator actions, arriving across six PRs. The spec has no section for them, and a reader should not have to assemble that list out of the bullets.

### What is *not* converted, and why

**The 125 historical entries stay verbatim**, under an `## Older releases` heading. Translating them is a large rewrite that risks losing nuance in entries whose whole value is their nuance — the v1.7.0 entry alone carries the byte-for-byte verification, the "no migration window needed because readers fall back", the "in-place does not reclaim the space", and the "older versions then fail *quietly*, so run `unsplit` before downgrading". Every version still has an entry, which is what the spec actually asks for.

Verified mechanically rather than eyeballed — exactly one entry left the old list, the one now converted:

```
old: 126 version entries   new: 125
missing from new:  * 2026-09-08 v1.9.0:      <- converted to the new format
added to new:      (none)
```

All twelve link references were checked against the API for the right target type (`issues/` vs `pull/`); #147 and #154 are PRs, the other ten are issues.

### The semver claim is scoped, not asserted flat

The header says the project adheres to semver over **the REST API, the configuration surface and the stored data shape**, and that Python object internals may change in a minor release.

This matters on day one: 1.9.0 changes `MatchedFunctionEntry.match_is_*` from masked integers to bool properties under a minor bump. A bare "adheres to Semantic Versioning" would be false the moment it was written. Worth a maintainer's opinion on whether that is the scope you want to commit to — it is the one judgement in here that is a policy choice rather than a formatting one.

### The convention, stated in the header

> Entries carry the measurement, the caveat and the failure mode, not just the change: a line that says what moved without saying what it cost, what it cannot see, or how it would be noticed is worth less than the space it takes.

The format is a better container than what was there; it will not preserve the depth by itself. That depends on writing the bullets that way, so the expectation is written down where the next person will see it.

### Not done here

- No tooling. The format is machine-parseable enough that the release workflow could assert the top section matches the tag being cut — worth doing, but separately.
- `Deprecated` and `Security` are absent from 1.9.0 because they are empty; the spec expects omission.
- No `CONTRIBUTING.md` — the convention lives in the changelog header, where someone about to write an entry will actually read it. Happy to move it if you would rather it lived elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwSfzAD1ZwEoWY3eWvbYvX
