### PR TITLE
Read wrap_at when rendering a YARA rule, instead of the wrap_string function (#186)

### DIFF
--- a/mcrit/storage/UniqueBlocksResult.py
+++ b/mcrit/storage/UniqueBlocksResult.py
@@ -34,11 +34,12 @@ class UniqueBlocksResult:
     def __init__(self) -> None:
         pass
 
-    def generateYaraRule(self, min_ins=None, max_ins=None, min_bytes=None, max_bytes=None, required_per_sample=10, condition_required=7, wrap_at=0):
+    def generateYaraRule(self, min_ins=None, max_ins=None, min_bytes=None, max_bytes=None, required_per_sample=10, condition_required=7, wrap_at=80):
         cover = self.generateBlockCover(min_ins=min_ins, max_ins=max_ins, min_bytes=min_bytes, max_bytes=max_bytes, required_per_sample=required_per_sample)
         return self.renderRule(cover, condition_required, wrap_at=wrap_at)
 
-    def renderRule(self, block_cover, condition_required, wrap_at=0):
+    def renderRule(self, block_cover, condition_required, wrap_at=80):
+        """Render the YARA rule. wrap_at is the column to wrap the hex at; 0 keeps it on one line."""
         yara_blocks = block_cover["block_hashes"]
         block_hash_string = ",".join([pic_hash for pic_hash in yara_blocks])
         rule_identifier = hashlib.sha256(block_hash_string.encode()).hexdigest()[:16]
@@ -60,9 +61,9 @@ class UniqueBlocksResult:
             for ins in result["instructions"]:
                 yarafied += f"         * {ins[1]:{maxlen_ins}} | {ins[2]} {ins[3]}\n"
             yarafied += "         */\n"
-            if wrap_string:
+            if wrap_at:
                 yarafied += f"        $blockhash_{pichash} = {{\n"
-                yarafied += "            " + wrap_string(result["escaped_sequence"], max_column_length=80, padding=12) + "\n"
+                yarafied += "            " + wrap_string(result["escaped_sequence"], max_column_length=wrap_at, padding=12) + "\n"
                 yarafied += "        }\n"
             else:
                 yarafied += f"        $blockhash_{pichash} = {{ " + result["escaped_sequence"] + " }\n"

--- a/tests/testMinHashIndex.py
+++ b/tests/testMinHashIndex.py
@@ -11,6 +11,7 @@ from mcrit.index.MinHashIndex import MinHashIndex
 from mcrit.index.SearchQueryParser import SearchQueryParser
 from mcrit.libs.utility import generate_unique_pairs
 from mcrit.minhash.EscaperFingerprint import getEscaperFingerprint
+from mcrit.storage.UniqueBlocksResult import UniqueBlocksResult
 
 from .context import config
 
@@ -115,6 +116,35 @@ class UniqueBlocksCoverTestSuite(unittest.TestCase):
         self.assertEqual(1, statistics["num_samples_covered"])
         self.assertEqual(10, statistics["yara_covers"])
         self.assertEqual(len(result["yara_rule"]), statistics["yara_covers"])
+
+    def testWrapAtControlsTheRuleWidth(self):
+        # #186: renderRule tested the wrap_string *function* for truthiness instead of the
+        # wrap_at parameter, so the parameter did nothing and the hex was always wrapped at a
+        # hardcoded 80 columns - the single-line branch was unreachable.
+        index = MinHashIndex(config)
+        worker = index.queue._worker
+        report = SmdaReport.fromFile(EXAMPLE_REPORT)
+        assert report is not None
+        sample_entry = index._storage.addSmdaReport(report)
+        assert sample_entry is not None
+
+        # through the wire shape the real caller sees: MCRITweb feeds fromDict a result that has
+        # been through JSON, so the block-hash keys are strings by then
+        result = json.loads(json.dumps(worker.getUniqueBlocks([sample_entry.sample_id])))
+        blocks = UniqueBlocksResult.fromDict(result)
+
+        unwrapped = blocks.generateYaraRule(wrap_at=0)
+        narrow = blocks.generateYaraRule(wrap_at=40)
+        default = blocks.generateYaraRule()
+
+        # 0 keeps each pattern on one line; a width wraps it
+        self.assertNotIn("= {\n", unwrapped)
+        self.assertIn("= {\n", narrow)
+        # the width is honoured rather than ignored, so a narrower wrap yields more lines
+        self.assertGreater(len(narrow.splitlines()), len(unwrapped.splitlines()))
+        self.assertGreater(len(narrow.splitlines()), len(default.splitlines()))
+        # the default reproduces the width that used to be hardcoded
+        self.assertEqual(default, blocks.generateYaraRule(wrap_at=80))
 
     def testCoversRequiredShapesTheRule(self):
         index = MinHashIndex(config)


### PR DESCRIPTION
Closes #186.

`renderRule` tested `if wrap_string:` — the module-level *function*, always truthy — where it meant `if wrap_at:`. The parameter was never read, so rules were always wrapped, always at a hardcoded 80 columns, and the single-line branch below the condition was unreachable. MCRITweb has been calling `generateYaraRule(wrap_at=40)` and silently getting 80.

`wrap_at` is now both the switch and the width, which is what its name says: `0` keeps the hex on one line, `N` wraps at `N` columns.

### The one judgement call: the default moves 0 → 80

Taking the parameter at face value would make the default single-line, which changes the output of **every** caller that passes nothing. 80 is what those callers have actually been getting all along, so defaulting to it means this fix changes output only for callers that ask it to:

| caller | before | after |
|---|---|---|
| `generateYaraRule()` | wrapped at 80 | wrapped at 80 — **unchanged** |
| `generateYaraRule(wrap_at=40)` (MCRITweb) | wrapped at 80 | wrapped at 40 |
| `generateYaraRule(wrap_at=0)` | wrapped at 80 | single line — reachable for the first time |

If you would rather the signature read literally — default `0`, meaning no wrapping — that is a one-character change and I am happy to make it; it just means default rule output changes for everyone.

### Test

`testWrapAtControlsTheRuleWidth` pins all three: `0` produces no `= {\n`, a width does, a narrower width yields more lines, and the default equals `wrap_at=80` explicitly.

The test feeds `fromDict` a **JSON-round-tripped** result, because that is the shape the real caller has: MCRITweb receives the result over the wire, so its block-hash keys are strings by then. Worth knowing — `renderRule` joins those keys and raises `TypeError: sequence item 0: expected str instance, int found` on the in-process worker result, whose keys are still ints. That is pre-existing and untouched here, but it means `UniqueBlocksResult.generateYaraRule` only works on a result that has been through JSON. Say the word and I will file it.

### Verification

```
282 passed, 36 subtests passed
All checks passed!            # ruff check
141 files already formatted   # ruff format --check
All checks passed!            # ty check (pinned 0.0.74)
```

Also relevant to the `ty` pin: this bug is what `ty` 0.0.79's `redundant-condition` rule was reporting, and it was the *only* diagnostic on the tree. **With this fixed, `ty check` exits 0 under 0.0.79 as well** — verified — so the pin is no longer holding back a red tree, only a deliberate-bump policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwSfzAD1ZwEoWY3eWvbYvX
