### PR TITLE
Bump ty to 0.0.79, and record the policy the pin actually follows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,12 @@ dev = [
     "ruff",
     "twine",
     # ty is pinned: it gates CI and is pre-1.0, so a new release can add diagnostics and redden an
-    # unchanged tree. Dependabot proposes the bump, which is where a new diagnostic gets reviewed.
-    "ty==0.0.74",
+    # unchanged tree. Dependabot is deliberately left to propose the bump - that PR is the canary,
+    # and a red one is a bug report, not a nuisance: 0.0.79's redundant-condition rule is what
+    # found #186, a parameter that had been silently ignored for as long as it existed. Take the
+    # bump in its own change once the tree is clean under the new version, and never merge a red
+    # one - during a deep PR queue it reddens every open branch for reasons unrelated to them.
+    "ty==0.0.79",
 ]
 
 [project.urls]


### PR DESCRIPTION
Supersedes #159 (Dependabot's 0.0.78). One file.

### Why 0.0.79 rather than 0.0.78

The tree is clean under 0.0.79 — verified on `main` at 7dedbb1 — so there is no reason to stop short of current. It was **not** clean until an hour ago: 0.0.79's `redundant-condition` rule reported one diagnostic, and that diagnostic was #186, fixed in #189. With that merged, `ty check` exits 0.

### Why no Dependabot `ignore`

I proposed one earlier, modelled on danielplohmann/smda#302. **I now think that would be the wrong lesson for this repo, and today is the evidence.**

The existing comment says Dependabot's PR "is where a new diagnostic gets reviewed". That policy just paid for itself: #159 is what prompted anyone to run a newer `ty` at all, which surfaced a real user-facing bug that had been shipping silently — a parameter ignored for as long as it existed. An `ignore` stanza would have suppressed exactly the signal that caught it.

So the bumps stay. The comment now records the part that *was* missing:

```toml
# ty is pinned: it gates CI and is pre-1.0, so a new release can add diagnostics and redden an
# unchanged tree. Dependabot is deliberately left to propose the bump - that PR is the canary,
# and a red one is a bug report, not a nuisance: 0.0.79's redundant-condition rule is what
# found #186, a parameter that had been silently ignored for as long as it existed. Take the
# bump in its own change once the tree is clean under the new version, and never merge a red
# one - during a deep PR queue it reddens every open branch for reasons unrelated to them.
"ty==0.0.79",
```

The failure mode worth avoiding was never the bump — it is merging a *red* one while a queue is deep, which reddens every open branch for reasons unrelated to them.

### Verification

Against `ty==0.0.79`:

```
282 passed, 36 subtests passed
All checks passed!            # ruff check
141 files already formatted   # ruff format --check
All checks passed!            # ty check
```

Dev tooling only, so no changelog entry — not notable to users under Keep a Changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwSfzAD1ZwEoWY3eWvbYvX