### PR TITLE
Say that an upgraded corpus reports every sample as stale, and what to do instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,12 +131,26 @@ available, none of them automatic and none required for correct serving:
 |---|---|
 | `rebuild_picblockhash_index` | enables the fast `getUniqueBlocks`; until it runs, the previous full scan is used |
 | `recompute_family_stats` | corrects counters that have already drifted |
-| `repair_minhashes` | rehashes only the samples an older escaper hashed |
+| `repair_minhashes` | rehashes only the samples an older escaper hashed - **read the note below first** |
 | `purgeEmptyBandDocuments()` | clears the band tombstones older deletions left |
 | `db.functions.dropIndex("_picblockhashes.offset_1")` | reclaims the index above on an existing instance |
 
 The new endpoints mean MCRITweb needs a matching release to *use* them; MCRITweb works unchanged
 against this version either way.
+
+**A corpus that upgrades into this version reports every one of its samples as having stale
+minhashes, and that is usually wrong.** Staleness is decided by a per-sample `minhash_smda_version`
+that did not exist before 1.9.0, and a sample without one counts as stale - so `/status` shows
+`num_samples_with_stale_minhashes` equal to the whole corpus on the first look, whatever the true
+state. Running `repair_minhashes` in response rehashes everything, which on a multi-million-function
+corpus is hours of work and a long stretch of degraded matching for no gain.
+
+Check first whether the minhashes actually are stale - `escaper_fingerprint` in `/status` against
+what produced them, or a sample rehashed by hand and compared. If they are current, record that
+instead of recomputing it: `setMinHashVersionForSamples(<running smda version>)` sets the field for
+every sample in one update (storage-level; there is no route for it, since it asserts something only
+an operator can know). If they genuinely are stale, `repair_minhashes` is the cheap way to fix them
+and the reason it exists.
 
 ## Older releases
 


### PR DESCRIPTION
Documentation only. Adds one note to the 1.9.0 `Upgrading` block; the released artifacts are unaffected.

### What the entry was missing

It describes `repair_minhashes` but not the state an existing instance is in the moment it upgrades. Staleness is decided by a per-sample `minhash_smda_version` that **did not exist before 1.9.0**, and `_staleMinHashVersionQuery` counts a sample without one as stale:

```python
{"$or": [{"minhash_smda_version": {"$exists": False}},
         {"minhash_smda_version": {"$in": stale_values}}]}
```

So the first `/status` after upgrading reports `num_samples_with_stale_minhashes` equal to the entire corpus, whatever its true state.

That is deliberate and correct — the field cannot be inferred retroactively, and #180 said as much. But the entry as written invites an operator to answer it by running the repair.

### Why that matters more than it sounds

Measured on the instance this release was verified against: **8,693 samples, 0 carrying the field, actual drift 0.000%** — every signature was recomputed and verified under the running smda before 1.9.0 existed. Running `repair_minhashes` there would rehash 11.67M functions for no gain: hours of work, band-index churn, and a long stretch of degraded matching.

The note therefore says to **check first**, and if the minhashes are current to *record* that rather than recompute it — `setMinHashVersionForSamples(<running smda version>)`, one update over the corpus — while keeping `repair_minhashes` as the right tool when they genuinely are stale, which is what it was built for.

`repair_minhashes` in the actions table now points at the note.

### On editing an entry for a released version

The tag is cut and on PyPI, so this changes the repo's changelog without changing what v1.9.0 shipped. That seemed right for an operational caveat that upgraders will act on within minutes of reading it — but it is a judgement, and if you would rather it sat under `[Unreleased]` or in a migration doc instead, say so and I will move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwSfzAD1ZwEoWY3eWvbYvX
