### PR TITLE
Release on a tag through trusted publishing, with the checks that were memory before

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+# Not a workflow: GitHub reads the generated-release-notes configuration from this path and
+# nowhere else. The release itself is cut by the workflow under `.github/workflows/`.
+#
+# The generated list is appended under the hand-written CHANGELOG.md section, so it exists to
+# credit contributors and link every pull request, not to describe the release. Dependency and
+# tooling bumps are grouped so they do not sit between the real changes.
+changelog:
+  exclude:
+    authors:
+      - github-actions[bot]
+  categories:
+    - title: Changes
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependencies
+          - github_actions
+          - pre_commit
+    - title: Dependency and tooling updates
+      labels:
+        - dependencies
+        - github_actions
+        - pre_commit

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,64 @@
+name: Changelog
+
+# pull_request rather than pull_request_target: this needs the PR's changed-file list and no
+# secrets, so the read-only token a fork PR receives is enough, and no PR content is checked
+# out or executed. `labeled`/`unlabeled` are here so applying the skip label re-runs the check
+# rather than leaving a stale failure behind.
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changelog-entry:
+    name: Changelog entry
+    runs-on: ubuntu-latest
+    steps:
+      # The job runs unconditionally and decides inside the step, rather than skipping on an
+      # `if`: a skipped job reports as neither passing nor failing, and the reason a PR is
+      # exempt belongs in the log where the next reader will look for it.
+      - name: Require a changelog entry beside a user-visible change
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # contains() matches an array element exactly, so a label carrying a comma or a
+          # name this one is a prefix of cannot be mistaken for it
+          SKIP_LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+          IS_DEPENDABOT: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+        run: |
+          set -euo pipefail
+
+          if [ "${SKIP_LABELLED}" = "true" ]; then
+            echo "Labelled no-changelog; entry not required."
+            exit 0
+          fi
+          if [ "${IS_DEPENDABOT}" = "true" ]; then
+            echo "Dependency bump; the generated release notes list these under their own heading."
+            exit 0
+          fi
+
+          changed="$(gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename')"
+
+          if ! printf '%s\n' "${changed}" | grep -qE '^(mcrit/|pyproject.toml$)'; then
+            echo "No shipped files changed; entry not required."
+            exit 0
+          fi
+
+          if printf '%s\n' "${changed}" | grep -qx 'CHANGELOG.md'; then
+            echo "CHANGELOG.md touched beside the change."
+            exit 0
+          fi
+
+          echo "::error file=CHANGELOG.md::This PR changes shipped files but does not touch CHANGELOG.md. Add an entry under ## [Unreleased], or apply the no-changelog label if the change genuinely needs no entry."
+          exit 1

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,232 @@
+name: Publish release
+
+# Pushing a vX.Y.Z tag is the release. A manual run rehearses the same path against TestPyPI
+# and stops before the GitHub release, so the whole workflow can be exercised without
+# consuming a version number on PyPI.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A cancelled publish can leave PyPI holding some files of a version and not others, and the
+# version number cannot be reused afterwards.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  verify:
+    name: Verify the tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      version: ${{ steps.guard.outputs.version }}
+      prerelease: ${{ steps.guard.outputs.prerelease }}
+    steps:
+      - name: Refuse anything that is not a tag
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "${REF_TYPE}" != "tag" ]; then
+            echo "::error::Run this from a tag, not ${REF_TYPE} ${REF_NAME}."
+            exit 1
+          fi
+
+      - name: Checkout the tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Check the tag against the packaged version and the changelog
+        id: guard
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          python .github/workflows/scripts/release_guard.py \
+            --tag "${TAG}" --notes release-notes.md --github-output "${GITHUB_OUTPUT}"
+
+      - name: Check the tag is on main
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          git fetch --quiet origin main
+          if ! git merge-base --is-ancestor "${TAG}" origin/main; then
+            echo "::error::${TAG} is not an ancestor of main; releases are cut from main."
+            exit 1
+          fi
+
+      - name: Check CI passed on this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          conclusion=$(gh api \
+            "repos/${REPO}/actions/workflows/test.yml/runs?head_sha=${SHA}&status=completed" \
+            --jq '.workflow_runs[0].conclusion // ""')
+          if [ -z "${conclusion}" ]; then
+            echo "::error::No completed CI run for ${SHA}. Wait for main to go green, then re-run."
+            exit 1
+          fi
+          if [ "${conclusion}" != "success" ]; then
+            echo "::error::CI concluded '${conclusion}' for ${SHA}. Fix main before releasing."
+            exit 1
+          fi
+          echo "CI passed on ${SHA}"
+
+      - name: Keep the release notes for the later jobs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-notes
+          path: release-notes.md
+          if-no-files-found: error
+
+  build:
+    name: Build and check the distribution
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout the tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      # Isolated: the wheel is a product of the declared build requirements, not of the runner.
+      - name: Build the sdist and the wheel
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+          python -m twine check --strict dist/*
+
+      # The artifact is tested, not the tree it came from: a clean environment carrying only the
+      # declared runtime dependencies has to import the package and run its entry point. `-P`
+      # keeps the checkout in the working directory off sys.path, so the import cannot fall back
+      # to the source tree and pass for a wheel that is missing something.
+      - name: Smoke-test the built wheel
+        env:
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/python -m pip install --upgrade pip
+          /tmp/smoke/bin/python -m pip install dist/mcrit-"${VERSION}"-py3-none-any.whl
+          /tmp/smoke/bin/python -P - <<'PY'
+          import os
+          import pathlib
+
+          import mcrit
+          from mcrit.config.McritConfig import McritConfig
+
+          installed = pathlib.Path(mcrit.__file__).parent
+          assert "site-packages" in str(installed), f"imported a source tree: {installed}"
+          assert McritConfig.VERSION == os.environ["VERSION"], McritConfig.VERSION
+          assert (installed / "cache" / "logbuckets.json").exists(), "package data did not ship"
+          assert not (installed / "shinglers" / "archived").exists(), "archived shinglers shipped"
+          print(f"mcrit {McritConfig.VERSION} imported from {installed}")
+          PY
+          /tmp/smoke/bin/mcrit --help >/dev/null
+
+      - name: Keep the distribution for the later jobs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: distribution
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to ${{ github.event_name == 'workflow_dispatch' && 'TestPyPI' || 'PyPI' }}
+    needs: [verify, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: ${{ github.event_name == 'workflow_dispatch' && 'testpypi' || 'pypi' }}
+      url: ${{ github.event_name == 'workflow_dispatch' && 'https://test.pypi.org/p/mcrit' || 'https://pypi.org/p/mcrit' }}
+    permissions:
+      # mandatory for trusted publishing, and it must be the only credential in the job
+      id-token: write
+    steps:
+      - name: Fetch the distribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: distribution
+          path: dist
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          # empty resolves to PyPI: the canonical input carries no default and the action falls
+          # through to the deprecated alias, which defaults to the real index
+          repository-url: ${{ github.event_name == 'workflow_dispatch' && 'https://test.pypi.org/legacy/' || '' }}
+          # a PyPI collision means the version is already public, so only a rehearsal skips it
+          skip-existing: ${{ github.event_name == 'workflow_dispatch' }}
+          attestations: true
+          print-hash: true
+
+  release:
+    name: Create the GitHub release
+    needs: [verify, build, publish]
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Fetch the distribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: distribution
+          path: dist
+
+      - name: Fetch the release notes
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-notes
+
+      # --generate-notes appends its list under --notes-file rather than replacing it, so the
+      # changelog section leads and `.github/release.yml` groups what follows. A pre-release
+      # is marked as such and never becomes "latest".
+      - name: Create the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+          PRERELEASE: ${{ needs.verify.outputs.prerelease }}
+        run: |
+          shopt -s failglob
+          flags=(--latest)
+          if [ "${PRERELEASE}" = "true" ]; then
+            flags=(--prerelease --latest=false)
+          fi
+          gh release create "${TAG}" dist/* \
+            --repo "${REPO}" \
+            --title "${TAG}" \
+            --notes-file release-notes.md \
+            --generate-notes \
+            --verify-tag \
+            "${flags[@]}"

--- a/.github/workflows/scripts/release_guard.py
+++ b/.github/workflows/scripts/release_guard.py
@@ -1,0 +1,102 @@
+"""Checks that decide whether a tag may be released, and the notes that go with it.
+
+A script rather than inline workflow steps so the parsing has tests: the changelog format it
+reads is a convention, and a release is the one action here that cannot be undone.
+
+The same script, with a different VERSION_SOURCES table, guards every repository in the MCRIT
+ecosystem. Keep the logic identical across them and vary only the table.
+"""
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+#: Where this repository states its version. Every entry has to agree with the tag.
+#: ("label", "relative/path", regex-with-one-group) reads a literal from a text file;
+#: ("label", "pyproject.toml", None) reads `[project].version`.
+VERSION_SOURCES = [
+    ("pyproject.toml", "pyproject.toml", None),
+    ("McritConfig.VERSION", "mcrit/config/McritConfig.py", r'^    VERSION = "([0-9][0-9a-z.]*)"'),
+]
+
+#: A release version as this ecosystem tags it: `1.2.3`, or a PEP 440 pre-release such as
+#: `1.2.3rc1`, `1.2.3b2`, `1.2.3a1`. Anything else is refused rather than guessed at.
+VERSION = re.compile(r"^(?P<release>\d+\.\d+\.\d+)(?P<pre>(a|b|rc)\d+)?$")
+#: `## [1.2.3] - 2026-09-20` (or `[v1.2.3]`), the heading a release section opens with.
+SECTION = re.compile(r"^## \[v?(?P<version>[0-9][0-9a-z.]*)\] - (?P<date>\d{4}-\d{2}-\d{2})\s*$")
+#: any second-level heading, which is where a section ends
+NEXT_HEADING = re.compile(r"^## ")
+
+
+def declaredVersions(root: Path) -> dict:
+    """The version as each place that carries it states it."""
+    found = {}
+    for label, relative, pattern in VERSION_SOURCES:
+        path = root / relative
+        if pattern is None:
+            found[label] = tomllib.loads(path.read_text(encoding="utf-8"))["project"]["version"]
+            continue
+        match = re.search(pattern, path.read_text(encoding="utf-8"), re.MULTILINE)
+        if match is None:
+            raise SystemExit(f"could not read a version from {path}")
+        found[label] = match.group(1)
+    return found
+
+
+def changelogSection(changelog: str, version: str) -> str:
+    """The release notes for `version`, or a failure naming what is missing."""
+    lines = changelog.splitlines()
+    for index, line in enumerate(lines):
+        match = SECTION.match(line)
+        if match is None or match.group("version") != version:
+            continue
+        body = []
+        for following in lines[index + 1 :]:
+            if NEXT_HEADING.match(following):
+                break
+            body.append(following)
+        text = "\n".join(body).strip()
+        if not text:
+            raise SystemExit(f"CHANGELOG.md has a heading for {version} but nothing under it")
+        return text
+    raise SystemExit(f"CHANGELOG.md has no `## [{version}] - <date>` section. Rename `## [Unreleased]` to the release being cut before tagging.")
+
+
+def main(argv: list) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="the tag being released, e.g. v1.2.0")
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument("--notes", help="write the release notes to this file")
+    parser.add_argument("--github-output", help="append version= and prerelease= to this file")
+    args = parser.parse_args(argv)
+
+    if not args.tag.startswith("v"):
+        raise SystemExit(f"tag {args.tag!r} does not start with 'v'")
+    version = args.tag[1:]
+    shape = VERSION.match(version)
+    if shape is None:
+        shape_wanted = "vMAJOR.MINOR.PATCH with an optional a/b/rc pre-release suffix"
+        raise SystemExit(f"tag {args.tag!r} is not {shape_wanted}")
+
+    versions = declaredVersions(Path(args.root))
+    disagreeing = {label: value for label, value in versions.items() if value != version}
+    if disagreeing:
+        stated = ", ".join(f"{label} = {value}" for label, value in versions.items())
+        raise SystemExit(f"tag {args.tag} does not match the packaged version ({stated})")
+
+    changelog = (Path(args.root) / "CHANGELOG.md").read_text(encoding="utf-8")
+    notes = changelogSection(changelog, version)
+    if args.notes:
+        Path(args.notes).write_text(notes + "\n", encoding="utf-8")
+    if args.github_output:
+        prerelease = "true" if shape.group("pre") else "false"
+        with open(args.github_output, "a", encoding="utf-8") as output:
+            output.write(f"version={version}\nprerelease={prerelease}\n")
+    print(f"{args.tag} matches the declared version and has a changelog section")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - name: Check out repository

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ advice that had stopped being true.
 
 ## Development setup
 
-Requires **Python 3.11 or newer** (`pyproject.toml` sets `requires-python = ">=3.11"` with no upper bound). CI exercises 3.11 through 3.14.
+Requires **Python 3.12 or newer** (`pyproject.toml` sets `requires-python = ">=3.12"` with no upper bound). CI exercises 3.12 through 3.14.
 
 ```bash
 pip install -e ".[dev]"
@@ -113,8 +113,8 @@ mcrit client submit <file> -f <family_name>
 
 - Lint/format: `ruff` (line-length 180, `target-version = "py311"`, selects `E4/E7/E9/F/I/UP`). Run `ruff format .` to auto-format. Note most `UP` rules are explicitly ignored in `[tool.ruff.lint]`, so the existing `Dict`/`Optional` typing style is intentional — do not "modernize" it.
 - Type checking: `ty` (`make typecheck` / `ty check`), enforced in CI next to ruff and currently at **zero diagnostics**. There are no suppressions in the tree — fix the code or the annotation instead of adding `ty: ignore`.
-- Supported Python: 3.11+ (`requires-python = ">=3.11"`).
-- License: GPL-3.0-only. The version is bumped manually in **three** places that must agree — `pyproject.toml`, `McritConfig.VERSION` (served by the `/version` endpoint), and the newest entry in `CHANGELOG.md` — do not change unless asked.
+- Supported Python: 3.12+ (`requires-python = ">=3.12"`).
+- License: GPL-3.0-only. The version is bumped manually in **three** places that must agree — `pyproject.toml`, `McritConfig.VERSION` (served by the `/version` endpoint), and the newest entry in `CHANGELOG.md` — do not change unless asked. `tests/testReleaseGuard.py` asserts the first two agree, and the release workflow refuses a tag that does not match all three. Every PR that changes `mcrit/` adds an entry under `## [Unreleased]` or carries the `no-changelog` label. How a release is cut is in [`RELEASING.md`](RELEASING.md).
 - Never introduce or log secrets/API tokens/keys.
 
 ## Agent guardrails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ reasoning is still at hand, rather than reconstructing it from the commit log at
 
 ## [Unreleased]
 
+### Added
+
+- Pushing a `vX.Y.Z` tag now publishes the release. The workflow refuses to continue unless the tag
+  matches `pyproject.toml` and `McritConfig.VERSION`, `CHANGELOG.md` has a section for it, the commit
+  is on `main` and CI passed there; it then builds the sdist and wheel in an isolated environment,
+  installs the wheel into a clean environment to import it and run `mcrit --help`, uploads to PyPI
+  through trusted publishing with signed provenance, and creates the GitHub release from that
+  version's changelog section with the generated contributor list appended. Pre-release tags
+  (`v1.10.0rc1`) are marked as such, and a manual run rehearses the same path against TestPyPI.
+  Before, publishing was `make publish` with an API token, GitHub releases stopped at v1.3.0, and
+  nothing checked that the three version strings agreed. See `RELEASING.md`; the trusted publisher
+  and the `pypi` and `testpypi` environments are configured once by a maintainer.
+- A pull request that changes `mcrit/` or `pyproject.toml` has to add a `CHANGELOG.md` entry or
+  carry the `no-changelog` label; CI checks it.
+
+### Removed
+
+- **Python 3.11 is no longer supported**; `requires-python` is `>=3.12`. Nothing in MCRIT needed
+  3.12 - the MCRIT ecosystem now shares a 3.12 floor so one interpreter serves every component. The
+  reference `docker-mcrit` deployment already runs 3.12.
+
 ## [1.9.0] - 2026-09-08
 
 Correctness and operator-recovery release, plus a large `getUniqueBlocks` speedup. **Matching

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ First and foremost, this will ensure that you have fully compatible versions acr
 Installing MCRIT on its own will require some more steps.
 For the following, we assume Ubuntu as host operating system.
 
-MCRIT requires **Python 3.11 or newer**. Its dependencies are declared in `pyproject.toml` and are installed together with the package:
+MCRIT requires **Python 3.12 or newer**. Its dependencies are declared in `pyproject.toml` and are installed together with the package:
 
 ```bash
 # install python and MCRIT along with its dependencies

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,118 @@
+# Releasing MCRIT
+
+This repository follows the release process shared across the MCRIT ecosystem
+([smda](https://github.com/danielplohmann/smda), [purepdb](https://github.com/danielplohmann/purepdb),
+[mcrit](https://github.com/danielplohmann/mcrit), [mcritweb](https://github.com/fkie-cad/mcritweb),
+[mcrit-plugin](https://github.com/danielplohmann/mcrit-plugin),
+[docker-mcrit](https://github.com/danielplohmann/docker-mcrit)). The shape is the same everywhere;
+this file states the values that are specific to this repository.
+
+## Versioning
+
+MCRIT follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html) over the REST API, the
+configuration surface and the stored data shape; see the note at the top of `CHANGELOG.md` for what
+that does and does not cover. A release that changes the database shape ships a migration guide under
+`docs/` and says so in its `Upgrading` notes, and `docker-mcrit` is bumped to it afterwards.
+
+The version is declared in `pyproject.toml` (`[project].version`) and `mcrit/config/McritConfig.py` (`VERSION`, served by
+`/version`). The release workflow refuses a tag that does not
+match every one of them, so a bump that misses one fails before anything is published.
+
+## Changelog
+
+`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). It is the one
+authoritative record of what a release contains: the GitHub release notes are generated from it, and
+nothing is written twice.
+
+- Every pull request that changes something a user can observe adds its own bullet under
+  `## [Unreleased]`, in the subsection it belongs to (`Added`, `Changed`, `Deprecated`, `Removed`,
+  `Fixed`, `Security`), while the change is fresh. The `Changelog` check fails a PR that touches
+  shipped files without touching `CHANGELOG.md`; apply the `no-changelog` label when a change
+  genuinely needs no entry (a typo, a CI-only change), and say why in the PR.
+- An entry says what changed and what it costs the reader: what to do when upgrading, what may
+  behave differently, which issue or PR it closes.
+- Dependency bumps need no entry. GitHub lists them under their own heading in the release notes,
+  from the `dependencies` / `github_actions` labels (`.github/release.yml`).
+
+## Cutting a release
+
+1. Check that `main` is green and that everything meant for the release has merged.
+2. In one commit on a branch, then merged through a PR:
+   - set the new version in `pyproject.toml` (`[project].version`) and `mcrit/config/McritConfig.py` (`VERSION`, served by
+`/version`);
+   - in `CHANGELOG.md`, rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`, drop the empty
+     subsections, open a fresh empty `## [Unreleased]` above it, and update the compare links at
+     the foot of the file.
+3. Wait for CI to pass on the merge commit. Then tag that commit and push the tag:
+
+   ```bash
+   git tag -a vX.Y.Z -m "MCRIT X.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+Pushing the tag is the release. `.github/workflows/publish-release.yml` then:
+
+1. **Verify** — refuses to continue unless the tag matches both version strings, `CHANGELOG.md` has a
+   `## [X.Y.Z] - <date>` section (which becomes the release notes), the tagged commit is on `main`,
+   and CI passed on that commit.
+2. **Build** — builds the sdist and wheel in an isolated environment, checks their metadata with
+   `twine check --strict`, and installs the wheel into a clean virtual environment carrying only the
+   declared runtime dependencies to import it, check the version it serves, check the package data
+   shipped, and run the `mcrit` entry point.
+3. **Publish** — uploads to PyPI through [trusted publishing](https://docs.pypi.org/trusted-publishers/)
+   with signed provenance attestations. No API token is stored anywhere.
+4. **Release** — creates the GitHub release for the tag with the changelog section as its body,
+   GitHub's generated contributor and PR list appended under it, and the sdist and wheel attached.
+
+Each gate fails with a message naming what to fix. Nothing has to be remembered at the console.
+
+## Pre-releases
+
+A release candidate is tagged `vX.Y.Zrc1` (also `a1`, `b1`), with the same version string in
+`pyproject.toml` (`[project].version`) and `mcrit/config/McritConfig.py` (`VERSION`, served by
+`/version`) and a `## [X.Y.Zrc1] - YYYY-MM-DD` changelog section. The workflow marks the
+GitHub release as a pre-release and does not make it "latest". PyPI
+does not install a pre-release unless it is asked for explicitly (`pip install --pre`), and
+`docker-mcrit` pins exact versions, so a candidate never reaches a deployment by accident.
+
+## Rehearsing
+
+Run *Publish release* manually from the Actions tab, choosing a tag as the ref. A manual run goes
+through the same gates and build, publishes to [TestPyPI](https://test.pypi.org/p/mcrit) instead of
+PyPI (an already-present version is skipped rather than failed), and stops before creating the
+GitHub release. Rehearse the first release after any change to the workflow.
+
+## When a release fails
+
+- **A gate failed before anything was published** (tag/version mismatch, missing changelog section,
+  tag not on `main`, CI not green): fix the cause on `main`, delete the
+  tag locally and on the remote (`git push --delete origin vX.Y.Z`), and tag again once the fix has
+  merged. Nothing needs cleaning up.
+- **Publishing to PyPI failed part-way**: a version number on PyPI is permanent even when yanked,
+  so do not try to reuse it. Fix the cause, bump the patch version, and release again. Yank the
+  incomplete version on PyPI if any of its files were accepted.
+- **The GitHub release step failed after publishing**: re-run only the failed job from the Actions
+  UI; the built artifacts are kept as workflow artifacts and the step is idempotent.
+
+## Maintainer configuration
+
+Done once, by a repository owner; the workflow cannot create these for itself.
+
+- **PyPI trusted publisher** for the `mcrit` project: owner `danielplohmann`, repository `mcrit`,
+  workflow `publish-release.yml`, environment `pypi`. Add the same publisher on TestPyPI with
+  environment `testpypi` to enable rehearsals.
+- **GitHub environments** `pypi` and `testpypi` (Settings → Environments). Restricting `pypi` to
+  the `v*` tag pattern and requiring a reviewer is recommended: it makes the publish step a
+  deliberate click even if a tag is pushed by mistake.
+- **Label** `no-changelog`, used by the changelog check.
+- Optionally, **immutable releases** (Settings → General → Releases), so a published release's
+  assets and tag can no longer be changed.
+
+## Release order across the ecosystem
+
+MCRIT depends on `smda` (`>=4.2.13`) and is depended on by `mcritweb` (`>=1.5.3`), by
+`mcrit-plugin` (which vendors a minimal client rather than importing the package), and by
+`docker-mcrit`, which pins an exact MCRIT and MCRITweb version in its `.env`. When a change here
+needs a newer smda, release smda first and raise the floor in `pyproject.toml`; when a change
+here is needed by mcritweb, release MCRIT first, then mcritweb with its floor raised, then bump
+`docker-mcrit`.

--- a/mcrit/config/McritConfig.py
+++ b/mcrit/config/McritConfig.py
@@ -8,7 +8,7 @@ from .StorageConfig import StorageConfig
 
 
 class McritConfig:
-    # NOTE to self: always change this in pyproject.toml and the README changelog as well!
+    # served by /version; has to equal [project].version in pyproject.toml, which the release workflow checks
     VERSION = "1.9.0"
     # basic pathing info
     CONFIG_FILE_PATH = str(os.path.abspath(__file__))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "mcrit"
 version = "1.9.0"
 description = "MCRIT is a framework created for simplified application of the MinHash algorithm to code similarity."
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = "GPL-3.0-only"
 license-files = ["LICENSE"]
 authors = [
@@ -20,7 +20,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
@@ -71,6 +70,7 @@ dev = [
 Homepage = "https://github.com/danielplohmann/mcrit"
 Repository = "https://github.com/danielplohmann/mcrit"
 Issues = "https://github.com/danielplohmann/mcrit/issues"
+Changelog = "https://github.com/danielplohmann/mcrit/blob/main/CHANGELOG.md"
 
 [project.scripts]
 mcrit = "mcrit.__main__:main"
@@ -90,7 +90,7 @@ exclude = ["tests*", "data*", "docs*", "examples*", "plugins*"]
 mcrit = ["cache/*.json"]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 line-length = 180
 
 [tool.ruff.lint]

--- a/tests/testReleaseGuard.py
+++ b/tests/testReleaseGuard.py
@@ -1,0 +1,121 @@
+"""The release gate (`.github/workflows/scripts/release_guard.py`) runs once per release, minutes
+before the artefact becomes permanent, so here is the only place its checks can be exercised
+before they matter. It also holds the one test tying `McritConfig.VERSION` to `pyproject.toml`."""
+
+import importlib.util
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from mcrit.config.McritConfig import McritConfig
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / ".github" / "workflows" / "scripts" / "release_guard.py"
+
+CHANGELOG = """# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- something not yet released.
+
+## [1.10.0] - 2026-09-20
+
+### Changed
+
+- the thing this release did.
+
+## [1.10.0rc1] - 2026-09-15
+
+### Added
+
+- the candidate.
+
+## [1.9.0] - 2026-09-08
+
+### Fixed
+
+- an older release.
+"""
+
+
+@pytest.fixture(scope="module")
+def guard():
+    if not SCRIPT.exists():
+        pytest.skip("running outside a source tree")
+    spec = importlib.util.spec_from_file_location("release_guard", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _tree(tmp_path: Path, version: str, changelog: str = CHANGELOG) -> Path:
+    (tmp_path / "pyproject.toml").write_text(f'[project]\nname = "mcrit"\nversion = "{version}"\n')
+    (tmp_path / "mcrit" / "config").mkdir(parents=True)
+    (tmp_path / "mcrit" / "config" / "McritConfig.py").write_text(f'class McritConfig:\n    VERSION = "{version}"\n')
+    (tmp_path / "CHANGELOG.md").write_text(changelog)
+    return tmp_path
+
+
+def test_config_version_equals_the_packaged_version():
+    pyproject = ROOT / "pyproject.toml"
+    if not pyproject.exists():
+        pytest.skip("running outside a source tree")
+    assert McritConfig.VERSION == tomllib.loads(pyproject.read_text())["project"]["version"]
+
+
+def test_the_section_for_a_version_is_returned_and_stops_at_the_next(guard):
+    notes = guard.changelogSection(CHANGELOG, "1.10.0")
+    assert "the thing this release did" in notes
+    assert "the candidate" not in notes
+    assert "not yet released" not in notes
+
+
+def test_a_missing_or_empty_or_undated_section_fails(guard):
+    with pytest.raises(SystemExit, match="Unreleased"):
+        guard.changelogSection(CHANGELOG, "1.11.0")
+    with pytest.raises(SystemExit, match="nothing under it"):
+        guard.changelogSection("# Changelog\n\n## [9.0.0] - 2026-01-01\n\n## [8.0.0] - 2025-01-01\n\n- x\n", "9.0.0")
+    with pytest.raises(SystemExit):
+        guard.changelogSection("# Changelog\n\n## [9.0.0]\n\n- something.\n", "9.0.0")
+
+
+def test_the_declared_versions_in_this_tree_agree(guard):
+    versions = guard.declaredVersions(ROOT)
+    assert set(versions) == {"pyproject.toml", "McritConfig.VERSION"}
+    assert len(set(versions.values())) == 1
+
+
+def test_a_matching_tag_passes_and_writes_notes_and_outputs(guard, tmp_path):
+    root = _tree(tmp_path, "1.10.0")
+    notes, output = root / "notes.md", root / "output.txt"
+    argv = ["--tag", "v1.10.0", "--root", str(root), "--notes", str(notes), "--github-output", str(output)]
+    assert guard.main(argv) == 0
+    assert "the thing this release did" in notes.read_text()
+    assert output.read_text() == "version=1.10.0\nprerelease=false\n"
+
+
+def test_a_pre_release_tag_is_flagged(guard, tmp_path):
+    root = _tree(tmp_path, "1.10.0rc1")
+    output = root / "output.txt"
+    assert guard.main(["--tag", "v1.10.0rc1", "--root", str(root), "--github-output", str(output)]) == 0
+    assert "prerelease=true" in output.read_text()
+
+
+@pytest.mark.parametrize("tag", ["1.10.0", "v1.10", "v1.10.0-rc1", "v1.10.0.dev1", "vlatest"])
+def test_a_malformed_tag_fails(guard, tmp_path, tag):
+    root = _tree(tmp_path, "1.10.0")
+    with pytest.raises(SystemExit):
+        guard.main(["--tag", tag, "--root", str(root)])
+
+
+def test_a_tag_disagreeing_with_any_declared_version_fails(guard, tmp_path):
+    root = _tree(tmp_path, "1.9.0")
+    with pytest.raises(SystemExit, match=r"1\.9\.0"):
+        guard.main(["--tag", "v1.10.0", "--root", str(root)])
+    (root / "pyproject.toml").write_text('[project]\nname = "mcrit"\nversion = "1.10.0"\n')
+    with pytest.raises(SystemExit, match=r"McritConfig\.VERSION = 1\.9\.0"):
+        guard.main(["--tag", "v1.10.0", "--root", str(root)])


### PR DESCRIPTION
Releasing MCRIT is `make publish` with an API token. GitHub releases stopped at v1.3.0, and nothing checks that the three places the version is written — `pyproject.toml`, `McritConfig.VERSION` (served by `/version`) and the newest `CHANGELOG.md` heading — agree before a version number is consumed on PyPI.

This is one of six pull requests giving the MCRIT ecosystem one release process — the same guard, the same tag-triggered workflow, the same changelog check, and a `RELEASING.md` in each repository stating only the values that differ. A maintainer learns it once.

## Architecture

**The hand-written `CHANGELOG.md` is the single stream of change information.** #191 adopted Keep a Changelog; this makes it load-bearing. Every PR that touches `mcrit/` or `pyproject.toml` adds its own bullet under `## [Unreleased]`, or carries the `no-changelog` label; a new `Changelog` check enforces that (read-only token, no PR content executed, Dependabot exempt). At release time the version's section *is* the release notes, and GitHub's generated list of merged PRs and contributors is appended under it. `.github/release.yml` groups the dependency bumps.

Release Please, semantic-release, towncrier and scriv were considered. They either derive notes from commit subjects — which this repository does not write in a machine-readable form, and which yield a list rather than the measured entries the changelog header asks for — or add a second place to write release information. Making the existing file authoritative and gating on it is the cheapest reliable system.

**Versioning** stays Semantic Versioning over the REST API, configuration surface and stored data shape, as the changelog header states. `pyproject.toml` and `McritConfig.VERSION` both stay: the config value is what `/version` serves from a checkout, and reading installed metadata there would break `pip install -e .`-less deployments. A new test asserts the two agree; the workflow refuses a tag that does not match both.

## What pushing `vX.Y.Z` does now

`.github/workflows/publish-release.yml`:

| job | what it does |
|---|---|
| verify | refuses unless the tag matches both version strings, `CHANGELOG.md` has a `## [X.Y.Z] - <date>` section (written out as the notes), the commit is an ancestor of `main`, and the `CI` workflow concluded `success` on that commit |
| build | `python -m build` in isolation, `twine check --strict`, then installs the wheel into a clean venv with only the declared runtime dependencies and imports it with `python -P` so `./mcrit` cannot stand in for it — checks `McritConfig.VERSION`, that `cache/logbuckets.json` shipped, that `shinglers/archived` did not, and runs `mcrit --help` |
| publish | `pypa/gh-action-pypi-publish` through trusted publishing, `id-token: write` as the only credential, attestations on. Environment `pypi`; a manual run goes to `testpypi` and skips an existing version |
| release | `gh release create` with the changelog section as body, `--generate-notes` appended, sdist and wheel attached. Pre-release tags (`v1.10.0rc1`) are marked `--prerelease` and not `--latest` |

A manual run from a tag rehearses the whole path against TestPyPI and stops before the GitHub release. The guard script has tests (`tests/testReleaseGuard.py`).

## Other changes

- **Python floor 3.12** (`requires-python`, classifiers, unit matrix, `ruff` target). The ecosystem shares one floor; the reference `docker-mcrit` deployment already runs 3.12 and nothing in MCRIT needed it. Recorded under `Removed`.
- `pyproject.toml` gains a `Changelog` URL; it was already PEP 621 with a PEP 639 license expression, so nothing else moved.
- `RELEASING.md` documents cutting, rehearsing, pre-releases, recovery, the one-time maintainer configuration, and the release order across the ecosystem (smda → MCRIT → MCRITweb → docker-mcrit). `AGENTS.md` points at it.
- `McritConfig.VERSION` keeps a one-line note that the release workflow checks it against `pyproject.toml`, replacing the note-to-self about the README.

## Security

- Actions were already SHA-pinned with `persist-credentials: false` and per-job permissions; the new workflows follow the same pattern, `contents: read` at the top and raised per job only where a job writes.
- No token stored anywhere — trusted publishing replaces `make publish`'s API token, and each file carries PEP 740 provenance.
- `zizmor --persona=regular` reports no findings; `actionlint` clean.

## Tests

- Unit suite (`-m "not mongo and not sleep"`): 196 passed, 3 failed — the three failures in `testMinHashRepair.py` fail identically on `main` in this environment and are unrelated (they depend on the locally installed smda version). `ruff check`, `ruff format --check` and `ty check` clean.
- `python -m build` + `twine check --strict` pass; the wheel installs into a clean Python 3.13 venv, imports from `site-packages`, ships the cache data and not the archived shinglers, and `mcrit --help` runs. Metadata reads `Requires-Python: >=3.12`, `License-Expression: GPL-3.0-only`.
- `release_guard.py --tag v1.9.0` against the real tree extracts the 1.9.0 section from `CHANGELOG.md`.

## What a maintainer has to configure once

1. A **trusted publisher** on pypi.org for `mcrit`: owner `danielplohmann`, repository `mcrit`, workflow `publish-release.yml`, environment `pypi`; the same on test.pypi.org with environment `testpypi` for rehearsals.
2. GitHub **environments** `pypi` and `testpypi`. A required reviewer on `pypi` turns the publish into an approval step.
3. The **`no-changelog` label**.

Until 1 is done, pushing a tag fails at the publish job; nothing is created on GitHub and the tag can be deleted and re-pushed.

## Compatibility

`make publish` remains the manual fallback. `docker-mcrit` installs `mcrit==<tag>` from PyPI and clones the tag, and both continue to work; the 3.12 floor matches its image. MCRITweb's `mcrit>=1.5.3` floor is untouched.

## Related pull requests across the ecosystem

The same process, one PR per repository. None depends on another to merge; release order once merged is smda → purepdb → picblocks → MCRIT → MCRITweb → docker-mcrit.

- smda: danielplohmann/smda#343
- purepdb: danielplohmann/purepdb#59
- picblocks: danielplohmann/picblocks#5
- MCRIT: danielplohmann/mcrit#193
- MCRITweb: fkie-cad/mcritweb#176
- mcrit-plugin: danielplohmann/mcrit-plugin#15
- docker-mcrit: danielplohmann/docker-mcrit#12



